### PR TITLE
feat: ChatGPT-style chat-centric UI redesign with navigation drawer

### DIFF
--- a/app/src/main/java/com/opencode/android/data/connection/SecureSettingsRepository.kt
+++ b/app/src/main/java/com/opencode/android/data/connection/SecureSettingsRepository.kt
@@ -111,6 +111,11 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore {
                 .apply()
         }
 
+    /** True once the user has completed (or explicitly skipped) first-run onboarding. */
+    var onboardingCompleted: Boolean
+        get() = preferences.getBoolean(KEY_ONBOARDING_COMPLETED, false)
+        set(value) = preferences.edit().putBoolean(KEY_ONBOARDING_COMPLETED, value).apply()
+
     companion object {
         private const val PREFS_NAME = "opencode_android_secure_settings"
         private const val KEY_CONNECTIONS = "connections"
@@ -125,5 +130,6 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore {
         private const val KEY_ASSISTANT_RUNTIME_ID = "assistant_runtime_id"
         private const val KEY_ASSISTANT_WORKSPACE_PATH = "assistant_workspace_path"
         private const val KEY_SAF_WORKSPACE_URIS = "saf_workspace_uris"
+        private const val KEY_ONBOARDING_COMPLETED = "onboarding_completed"
     }
 }

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
@@ -1,0 +1,585 @@
+package com.opencode.android.feature.chat
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.core.api.OpenCodeAgent
+import com.opencode.android.core.api.OpenCodeProvider
+import com.opencode.android.runtime.PermissionResponse
+import com.opencode.android.runtime.RuntimeTarget
+import com.opencode.android.runtime.WorkspaceRef
+import com.opencode.android.ui.components.StatusChip
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+
+/**
+ * ChatGPT-like chat home screen: hamburger + centered title top bar, empty-state
+ * suggestions or the message timeline, and a rounded composer with model/agent/
+ * workspace chips. Message rendering (bubbles, tool/reasoning cards, permission
+ * cards) is reused from OpenCodeChatScreen.kt via the now package-visible
+ * MessageBubble / AssistantTimeline / PermissionCard composables.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatHomeScreen(
+    state: ChatUiState,
+    providers: List<OpenCodeProvider>,
+    agents: List<OpenCodeAgent>,
+    workspaces: List<WorkspaceRef>,
+    selectedProviderId: String?,
+    selectedModelId: String?,
+    selectedAgentId: String?,
+    runtimeTargets: List<RuntimeTarget>,
+    selectedRuntimeId: String?,
+    onSelectRuntime: (String) -> Unit,
+    onSelectModel: (String, String) -> Unit,
+    onSelectAgent: (String) -> Unit,
+    onSelectWorkspace: (String?) -> Unit,
+    onSendMessage: (String) -> Unit,
+    onPermission: (String, PermissionResponse, Boolean) -> Unit,
+    onAbort: () -> Unit,
+    onMic: () -> Unit,
+    onNewChat: () -> Unit,
+    onOpenHistory: () -> Unit,
+    onOpenDrawer: () -> Unit
+) {
+    var input by remember { mutableStateOf("") }
+    val listState = rememberLazyListState()
+    var overflowExpanded by remember { mutableStateOf(false) }
+    var titleMenuExpanded by remember { mutableStateOf(false) }
+    var showModelPicker by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState()
+
+    LaunchedEffect(state.messages.size, state.permissions.size) {
+        val totalItems = state.messages.size + state.permissions.size
+        if (totalItems > 0) listState.animateScrollToItem(totalItems - 1)
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        CenterAlignedTopAppBar(
+            title = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.clickable { titleMenuExpanded = true }
+                ) {
+                    Text(
+                        text = stringResource(R.string.chat_home_title),
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                    DropdownMenu(expanded = titleMenuExpanded, onDismissRequest = { titleMenuExpanded = false }) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.new_chat)) },
+                            onClick = { titleMenuExpanded = false; onNewChat() }
+                        )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.session_history)) },
+                            onClick = { titleMenuExpanded = false; onOpenHistory() }
+                        )
+                    }
+                }
+            },
+            navigationIcon = {
+                IconButton(onClick = onOpenDrawer) {
+                    Icon(Icons.Default.Menu, contentDescription = stringResource(R.string.menu_description))
+                }
+            },
+            actions = {
+                IconButton(onClick = onNewChat) {
+                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.new_chat))
+                }
+                Box {
+                    IconButton(onClick = { overflowExpanded = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.chat_options_description))
+                    }
+                    DropdownMenu(expanded = overflowExpanded, onDismissRequest = { overflowExpanded = false }) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.new_chat)) },
+                            onClick = { overflowExpanded = false; onNewChat() }
+                        )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.session_history)) },
+                            onClick = { overflowExpanded = false; onOpenHistory() }
+                        )
+                    }
+                }
+            },
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = MaterialTheme.colorScheme.background
+            )
+        )
+
+        Box(modifier = Modifier.weight(1f)) {
+            val showEmptyState = state.messages.isEmpty() && state.permissions.isEmpty() &&
+                !state.isLoadingHistory && state.error == null
+            if (showEmptyState) {
+                EmptyChatState(onSuggestionClick = { text -> input = text })
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(state.messages, key = { it.id }) { message ->
+                        if (message.isUser) MessageBubble(message) else AssistantTimeline(message)
+                    }
+                    items(state.permissions, key = { "permission-${it.id}" }) { permission ->
+                        PermissionCard(permission, onPermission)
+                    }
+                    if (state.isThinking) {
+                        item { StatusChip(text = stringResource(R.string.thinking), active = true) }
+                    }
+                    state.error?.let { error ->
+                        item {
+                            Card(
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.12f)
+                                )
+                            ) {
+                                Text(
+                                    text = error,
+                                    modifier = Modifier.padding(14.dp),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        ChatComposer(
+            input = input,
+            onInputChange = { input = it },
+            isRunning = state.isRunning,
+            onSend = {
+                if (input.isNotBlank()) {
+                    onSendMessage(input)
+                    input = ""
+                }
+            },
+            onAbort = onAbort,
+            onMic = onMic,
+            modelLabel = selectedModelId ?: stringResource(R.string.opencode_default_value),
+            onModelChipClick = { showModelPicker = true },
+            agents = agents,
+            selectedAgentId = selectedAgentId,
+            onSelectAgent = onSelectAgent,
+            workspaces = workspaces,
+            selectedWorkspacePath = state.selectedWorkspacePath,
+            workspaceSelectable = state.sessionId == null,
+            onSelectWorkspace = onSelectWorkspace
+        )
+    }
+
+    if (showModelPicker) {
+        ModelAndRuntimePickerSheet(
+            sheetState = sheetState,
+            runtimeTargets = runtimeTargets,
+            selectedRuntimeId = selectedRuntimeId,
+            onSelectRuntime = onSelectRuntime,
+            providers = providers,
+            selectedProviderId = selectedProviderId,
+            selectedModelId = selectedModelId,
+            onSelectModel = onSelectModel,
+            onDismiss = { showModelPicker = false }
+        )
+    }
+}
+
+@Composable
+private fun EmptyChatState(onSuggestionClick: (String) -> Unit) {
+    val suggestion1 = stringResource(R.string.suggestion_implement_title)
+    val suggestion2 = stringResource(R.string.suggestion_debug_title)
+    val suggestion3 = stringResource(R.string.suggestion_organize_title)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Terminal,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .padding(18.dp)
+                    .size(36.dp)
+            )
+        }
+        Spacer(Modifier.height(20.dp))
+        Text(
+            text = stringResource(R.string.chat_build_headline),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.chat_build_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(28.dp))
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            SuggestionCard(
+                icon = Icons.Default.Build,
+                title = suggestion1,
+                subtitle = stringResource(R.string.suggestion_implement_subtitle),
+                onClick = { onSuggestionClick(suggestion1) }
+            )
+            SuggestionCard(
+                icon = Icons.Default.BugReport,
+                title = suggestion2,
+                subtitle = stringResource(R.string.suggestion_debug_subtitle),
+                onClick = { onSuggestionClick(suggestion2) }
+            )
+            SuggestionCard(
+                icon = Icons.Default.Folder,
+                title = suggestion3,
+                subtitle = stringResource(R.string.suggestion_organize_subtitle),
+                onClick = { onSuggestionClick(suggestion3) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SuggestionCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Surface(
+                shape = RoundedCornerShape(10.dp),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(title, fontWeight = FontWeight.Medium, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Icon(
+                Icons.Default.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChatComposer(
+    input: String,
+    onInputChange: (String) -> Unit,
+    isRunning: Boolean,
+    onSend: () -> Unit,
+    onAbort: () -> Unit,
+    onMic: () -> Unit,
+    modelLabel: String,
+    onModelChipClick: () -> Unit,
+    agents: List<OpenCodeAgent>,
+    selectedAgentId: String?,
+    onSelectAgent: (String) -> Unit,
+    workspaces: List<WorkspaceRef>,
+    selectedWorkspacePath: String?,
+    workspaceSelectable: Boolean,
+    onSelectWorkspace: (String?) -> Unit
+) {
+    var attachExpanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+        ) {
+            Column(modifier = Modifier.padding(6.dp)) {
+                TextField(
+                    value = input,
+                    onValueChange = onInputChange,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text(stringResource(R.string.chat_message_placeholder)) },
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        disabledContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent
+                    ),
+                    maxLines = 6
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box {
+                        IconButton(onClick = { attachExpanded = true }) {
+                            Icon(Icons.Default.Add, contentDescription = stringResource(R.string.attach_button_description))
+                        }
+                        DropdownMenu(expanded = attachExpanded, onDismissRequest = { attachExpanded = false }) {
+                            // TODO: implement real attachments (files, images, camera capture)
+                            // once the backend supports multipart prompt attachments.
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.attach_menu_stub)) },
+                                onClick = { attachExpanded = false },
+                                enabled = false
+                            )
+                        }
+                    }
+                    Spacer(Modifier.weight(1f))
+                    IconButton(onClick = onMic) {
+                        Icon(Icons.Default.Mic, contentDescription = stringResource(R.string.voice))
+                    }
+                    Spacer(Modifier.width(4.dp))
+                    if (isRunning) {
+                        FilledIconButton(onClick = onAbort) {
+                            Icon(Icons.Default.Stop, contentDescription = stringResource(R.string.stop_run))
+                        }
+                    } else {
+                        FilledIconButton(onClick = onSend, enabled = input.isNotBlank()) {
+                            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = stringResource(R.string.send_description))
+                        }
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            ChipButton(label = modelLabel, onClick = onModelChipClick)
+            AgentChip(agents = agents, selectedAgentId = selectedAgentId, onSelect = onSelectAgent)
+            WorkspaceChip(
+                workspaces = workspaces,
+                selectedPath = selectedWorkspacePath,
+                enabled = workspaceSelectable,
+                onSelect = onSelectWorkspace
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChipButton(label: String, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier.clickable(onClick = onClick),
+        shape = RoundedCornerShape(100.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
+            Icon(Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun AgentChip(
+    agents: List<OpenCodeAgent>,
+    selectedAgentId: String?,
+    onSelect: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        ChipButton(label = selectedAgentId ?: "build", onClick = { expanded = true })
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            agents.forEach { agent ->
+                DropdownMenuItem(
+                    text = { Text(agent.name) },
+                    onClick = { onSelect(agent.name); expanded = false }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkspaceChip(
+    workspaces: List<WorkspaceRef>,
+    selectedPath: String?,
+    enabled: Boolean,
+    onSelect: (String?) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selected = workspaces.firstOrNull { it.path == selectedPath }
+    Box {
+        Surface(
+            modifier = Modifier.clickable(enabled = enabled) { expanded = true },
+            shape = RoundedCornerShape(100.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Icon(Icons.Default.Folder, contentDescription = null, modifier = Modifier.size(16.dp))
+                Text(
+                    text = selected?.name ?: stringResource(R.string.default_folder),
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1
+                )
+                Icon(Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(16.dp))
+            }
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.default_folder)) },
+                onClick = { onSelect(null); expanded = false }
+            )
+            workspaces.forEach { workspace ->
+                DropdownMenuItem(
+                    text = { Text(workspace.name) },
+                    onClick = { onSelect(workspace.path); expanded = false }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChatHomeScreenEmptyPreview() {
+    OpenCodeAndroidTheme {
+        ChatHomeScreen(
+            state = ChatUiState(backendName = "OpenCode · 1.0.0", isConnected = true),
+            providers = emptyList(),
+            agents = emptyList(),
+            workspaces = emptyList(),
+            selectedProviderId = null,
+            selectedModelId = null,
+            selectedAgentId = null,
+            runtimeTargets = emptyList(),
+            selectedRuntimeId = null,
+            onSelectRuntime = {},
+            onSelectModel = { _, _ -> },
+            onSelectAgent = {},
+            onSelectWorkspace = {},
+            onSendMessage = {},
+            onPermission = { _, _, _ -> },
+            onAbort = {},
+            onMic = {},
+            onNewChat = {},
+            onOpenHistory = {},
+            onOpenDrawer = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/chat/ModelAndRuntimePickerSheet.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ModelAndRuntimePickerSheet.kt
@@ -1,0 +1,207 @@
+package com.opencode.android.feature.chat
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Android
+import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.core.api.OpenCodeModel
+import com.opencode.android.core.api.OpenCodeProvider
+import com.opencode.android.runtime.RuntimeTarget
+import com.opencode.android.runtime.RuntimeType
+
+/**
+ * Bottom sheet opened from the chat screen's model chip. Lets the user pick both
+ * the execution target (this Android device or a registered remote runtime) and
+ * the model to use from the currently selected provider's catalog.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModelAndRuntimePickerSheet(
+    sheetState: SheetState,
+    runtimeTargets: List<RuntimeTarget>,
+    selectedRuntimeId: String?,
+    onSelectRuntime: (String) -> Unit,
+    providers: List<OpenCodeProvider>,
+    selectedProviderId: String?,
+    selectedModelId: String?,
+    onSelectModel: (String, String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            item {
+                Column {
+                    Text(
+                        text = stringResource(R.string.picker_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = stringResource(R.string.picker_caption),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            item {
+                SheetSectionHeader(stringResource(R.string.section_runtime))
+            }
+            items(runtimeTargets, key = { "runtime-${it.id}" }) { target ->
+                RuntimeRow(
+                    target = target,
+                    selected = target.id == selectedRuntimeId,
+                    onClick = { onSelectRuntime(target.id) }
+                )
+            }
+
+            item {
+                Column {
+                    Spacer(Modifier.height(8.dp))
+                    HorizontalDivider()
+                    SheetSectionHeader(stringResource(R.string.section_model))
+                }
+            }
+
+            if (providers.isEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(R.string.picker_no_providers),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 12.dp)
+                    )
+                }
+            } else {
+                providers.forEach { provider ->
+                    val models = provider.models.values
+                        .filter { it.status == null || it.status == "active" }
+                        .sortedBy { it.name.lowercase() }
+                    if (models.isNotEmpty()) {
+                        item {
+                            Text(
+                                text = provider.name,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                            )
+                        }
+                        items(models, key = { "model-${provider.id}-${it.id}" }) { model ->
+                            ModelRow(
+                                model = model,
+                                selected = provider.id == selectedProviderId && model.id == selectedModelId,
+                                onClick = { onSelectModel(provider.id, model.id) }
+                            )
+                        }
+                    }
+                }
+            }
+
+            item {
+                Spacer(Modifier.height(24.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SheetSectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(top = 12.dp, bottom = 4.dp)
+    )
+}
+
+@Composable
+private fun RuntimeRow(
+    target: RuntimeTarget,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(
+            imageVector = if (target.type == RuntimeType.LOCAL) Icons.Default.Android else Icons.Default.Computer,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = if (target.type == RuntimeType.LOCAL) {
+                stringResource(R.string.this_android)
+            } else {
+                target.displayName
+            },
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        RadioButton(selected = selected, onClick = onClick)
+    }
+}
+
+@Composable
+private fun ModelRow(
+    model: OpenCodeModel,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(model.name, style = MaterialTheme.typography.bodyMedium, maxLines = 1)
+            Text(
+                model.id,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1
+            )
+        }
+        RadioButton(selected = selected, onClick = onClick)
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
@@ -538,8 +538,9 @@ private fun AgentSelector(
     }
 }
 
+// Not private: reused by ChatHomeScreen.kt (same package) for the redesigned chat screen.
 @Composable
-private fun MessageBubble(message: ChatMessage) {
+fun MessageBubble(message: ChatMessage) {
     Box(
         modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.CenterEnd
@@ -557,8 +558,9 @@ private fun MessageBubble(message: ChatMessage) {
     }
 }
 
+// Not private: reused by ChatHomeScreen.kt (same package) for the redesigned chat screen.
 @Composable
-private fun AssistantTimeline(message: ChatMessage) {
+fun AssistantTimeline(message: ChatMessage) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -823,8 +825,9 @@ private fun PatchCard(part: ChatPart.Patch) {
     }
 }
 
+// Not private: reused by ChatHomeScreen.kt (same package) for the redesigned chat screen.
 @Composable
-private fun PermissionCard(
+fun PermissionCard(
     permission: PermissionRequest,
     onPermission: (String, PermissionResponse, Boolean) -> Unit
 ) {

--- a/app/src/main/java/com/opencode/android/feature/onboarding/AndroidSetupScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/onboarding/AndroidSetupScreen.kt
@@ -1,0 +1,382 @@
+package com.opencode.android.feature.onboarding
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.runtime.LocalRuntimeStatus
+import com.opencode.android.ui.components.SectionCard
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private data class SetupProvider(val id: String, val labelRes: Int)
+
+private val SETUP_PROVIDERS = listOf(
+    SetupProvider("openai", R.string.provider_openai),
+    SetupProvider("google", R.string.provider_google),
+    SetupProvider("anthropic", R.string.provider_anthropic),
+    SetupProvider("ollama", R.string.provider_ollama),
+    SetupProvider("other", R.string.provider_other)
+)
+
+private enum class LocalTestState { UNTESTED, TESTING, SUCCESS, FAILURE }
+
+/**
+ * Guided setup for running OpenCode directly on this Android device: download the
+ * managed runtime, choose an AI provider, store its API key, then run a connection
+ * test. Step 1 is wired to [onStartRuntimeSetup] (WorkspaceViewModel.setupLocalRuntime)
+ * and reflects [runtimeStatus] (LocalRuntimeManager.state). Step 3 saves the key via
+ * [onSaveApiKey] (SettingsViewModel draft + saveApiKey). Step 4's connection test is a
+ * TODO placeholder — see comment below — since there is no dedicated "verify provider
+ * credentials" backend call yet.
+ */
+@Composable
+fun AndroidSetupScreen(
+    runtimeStatus: LocalRuntimeStatus,
+    onStartRuntimeSetup: () -> Unit,
+    onSaveApiKey: (providerId: String, apiKey: String) -> Unit,
+    onBack: () -> Unit,
+    onFinish: () -> Unit
+) {
+    var selectedProviderId by remember { mutableStateOf(SETUP_PROVIDERS.first().id) }
+    var apiKey by remember { mutableStateOf("") }
+    var apiKeyVisible by remember { mutableStateOf(false) }
+    var testState by remember { mutableStateOf(LocalTestState.UNTESTED) }
+    val scope = rememberCoroutineScope()
+
+    val runtimeReady = runtimeStatus is LocalRuntimeStatus.Ready || runtimeStatus is LocalRuntimeStatus.Stopped
+    val currentStep = when {
+        !runtimeReady -> 1
+        apiKey.isBlank() -> 3
+        testState == LocalTestState.UNTESTED -> 4
+        else -> 4
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.android_setup_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.nav_back))
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            StepIndicator(currentStep = currentStep)
+
+            SectionCard {
+                Text(
+                    "1. " + stringResource(R.string.setup_step_download),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.height(10.dp))
+                when (val status = runtimeStatus) {
+                    LocalRuntimeStatus.NotInstalled -> {
+                        Button(onClick = onStartRuntimeSetup, modifier = Modifier.fillMaxWidth()) {
+                            Text(stringResource(R.string.setup_this_device_button))
+                        }
+                    }
+                    is LocalRuntimeStatus.Installing -> {
+                        Text(status.step, style = MaterialTheme.typography.bodySmall)
+                        Spacer(Modifier.height(8.dp))
+                        if (status.progress != null) {
+                            LinearProgressIndicator(
+                                progress = { status.progress.coerceIn(0f, 1f) },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        } else {
+                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        }
+                    }
+                    is LocalRuntimeStatus.Starting -> {
+                        Text(stringResource(R.string.starting_opencode_version, status.version))
+                        Spacer(Modifier.height(8.dp))
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    }
+                    is LocalRuntimeStatus.Ready -> {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.ready_running, status.version))
+                        }
+                    }
+                    is LocalRuntimeStatus.Stopped -> {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.installed_stopped, status.version))
+                        }
+                    }
+                    is LocalRuntimeStatus.Broken -> {
+                        Text(status.reason, color = MaterialTheme.colorScheme.error)
+                        Spacer(Modifier.height(8.dp))
+                        Button(onClick = onStartRuntimeSetup, modifier = Modifier.fillMaxWidth()) {
+                            Text(stringResource(R.string.repair_and_resetup_button))
+                        }
+                    }
+                    is LocalRuntimeStatus.UnsupportedAbi -> {
+                        Text(stringResource(R.string.unsupported_abi, status.abi), color = MaterialTheme.colorScheme.error)
+                    }
+                    is LocalRuntimeStatus.Updating -> {
+                        Text(status.step, style = MaterialTheme.typography.bodySmall)
+                        Spacer(Modifier.height(8.dp))
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    }
+                }
+            }
+
+            SectionCard {
+                Text(
+                    "2. " + stringResource(R.string.setup_step_provider),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.height(10.dp))
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(3),
+                    modifier = Modifier.height(160.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    items(SETUP_PROVIDERS, key = { it.id }) { provider ->
+                        ProviderTile(
+                            label = stringResource(provider.labelRes),
+                            selected = provider.id == selectedProviderId,
+                            onClick = { selectedProviderId = provider.id }
+                        )
+                    }
+                }
+            }
+
+            SectionCard {
+                Text(
+                    "3. " + stringResource(R.string.setup_step_apikey),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.height(10.dp))
+                OutlinedTextField(
+                    value = apiKey,
+                    onValueChange = {
+                        apiKey = it
+                        testState = LocalTestState.UNTESTED
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.api_key_hint)) },
+                    leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                    trailingIcon = {
+                        IconButton(onClick = { apiKeyVisible = !apiKeyVisible }) {
+                            Icon(
+                                if (apiKeyVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    visualTransformation = if (apiKeyVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    stringResource(R.string.apikey_caption),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(10.dp))
+                Button(
+                    onClick = { onSaveApiKey(selectedProviderId, apiKey) },
+                    enabled = apiKey.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.save_api_key))
+                }
+            }
+
+            SectionCard {
+                Text(
+                    "4. " + stringResource(R.string.setup_step_test),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.height(10.dp))
+                TestStatusRow(testState)
+                Spacer(Modifier.height(10.dp))
+                Button(
+                    onClick = {
+                        // TODO: replace with a real provider connectivity check (e.g. a
+                        // lightweight models-list call through the local runtime) once
+                        // that endpoint is exposed. For now this simulates a check based
+                        // on whether an API key has been entered.
+                        scope.launch {
+                            testState = LocalTestState.TESTING
+                            delay(700)
+                            testState = if (apiKey.isNotBlank()) LocalTestState.SUCCESS else LocalTestState.FAILURE
+                        }
+                    },
+                    enabled = testState != LocalTestState.TESTING,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.run_connection_test_button))
+                }
+            }
+
+            Button(
+                onClick = onFinish,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(100.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Text(stringResource(R.string.setup_complete_button), fontWeight = FontWeight.SemiBold)
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun StepIndicator(currentStep: Int) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        (1..4).forEach { step ->
+            val active = step <= currentStep
+            Surface(
+                shape = RoundedCornerShape(100.dp),
+                color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+                contentColor = if (active) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+            ) {
+                Text(
+                    text = step.toString(),
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProviderTile(label: String, selected: Boolean, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(72.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        border = BorderStroke(
+            width = if (selected) 2.dp else 1.dp,
+            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+        )
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(label, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Medium)
+        }
+    }
+}
+
+@Composable
+private fun TestStatusRow(state: LocalTestState) {
+    val (icon, label, color) = when (state) {
+        LocalTestState.UNTESTED -> Triple(Icons.Default.NetworkCheck, stringResource(R.string.test_status_untested), MaterialTheme.colorScheme.onSurfaceVariant)
+        LocalTestState.TESTING -> Triple(null, stringResource(R.string.test_status_testing), MaterialTheme.colorScheme.onSurfaceVariant)
+        LocalTestState.SUCCESS -> Triple(Icons.Default.CheckCircle, stringResource(R.string.test_status_success), MaterialTheme.colorScheme.primary)
+        LocalTestState.FAILURE -> Triple(Icons.Default.Error, stringResource(R.string.test_status_failure), MaterialTheme.colorScheme.error)
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (state == LocalTestState.TESTING) {
+            CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
+        } else if (icon != null) {
+            Icon(icon, contentDescription = null, tint = color)
+        }
+        Spacer(Modifier.width(8.dp))
+        Text(label, color = color)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AndroidSetupScreenPreview() {
+    OpenCodeAndroidTheme {
+        AndroidSetupScreen(
+            runtimeStatus = LocalRuntimeStatus.NotInstalled,
+            onStartRuntimeSetup = {},
+            onSaveApiKey = { _, _ -> },
+            onBack = {},
+            onFinish = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/onboarding/OnboardingChoiceScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/onboarding/OnboardingChoiceScreen.kt
@@ -1,0 +1,219 @@
+package com.opencode.android.feature.onboarding
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Android
+import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+
+private enum class OnboardingOption { ANDROID, REMOTE }
+
+/**
+ * First-run onboarding: choose whether to run OpenCode locally on this Android
+ * device, or connect to an existing PC/Mac OpenCode server. Either path (or an
+ * explicit skip) marks onboarding as complete.
+ */
+@Composable
+fun OnboardingChoiceScreen(
+    onSelectAndroid: () -> Unit,
+    onSelectRemote: () -> Unit,
+    onAddRemoteLater: () -> Unit
+) {
+    var selected by remember { mutableStateOf(OnboardingOption.ANDROID) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(32.dp))
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Terminal,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .padding(20.dp)
+                    .size(40.dp)
+            )
+        }
+        Spacer(Modifier.height(20.dp))
+        Text(
+            text = stringResource(R.string.onboarding_welcome_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = stringResource(R.string.onboarding_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(28.dp))
+
+        OnboardingCard(
+            icon = Icons.Default.Android,
+            title = stringResource(R.string.onboarding_android_title),
+            description = stringResource(R.string.onboarding_android_desc),
+            badge = stringResource(R.string.onboarding_recommended_badge),
+            selected = selected == OnboardingOption.ANDROID,
+            onClick = { selected = OnboardingOption.ANDROID }
+        )
+        Spacer(Modifier.height(12.dp))
+        OnboardingCard(
+            icon = Icons.Default.Computer,
+            title = stringResource(R.string.onboarding_remote_title),
+            description = stringResource(R.string.onboarding_remote_desc),
+            badge = null,
+            selected = selected == OnboardingOption.REMOTE,
+            onClick = { selected = OnboardingOption.REMOTE }
+        )
+
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.onboarding_switch_note),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(Modifier.height(24.dp))
+        Button(
+            onClick = { if (selected == OnboardingOption.ANDROID) onSelectAndroid() else onSelectRemote() },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            shape = RoundedCornerShape(100.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            )
+        ) {
+            Text(
+                text = if (selected == OnboardingOption.ANDROID) {
+                    stringResource(R.string.onboarding_primary_button_android)
+                } else {
+                    stringResource(R.string.onboarding_primary_button_remote)
+                },
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        TextButton(onClick = onAddRemoteLater) {
+            Text(stringResource(R.string.onboarding_skip_link))
+        }
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun OnboardingCard(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    description: String,
+    badge: String?,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(
+            width = if (selected) 2.dp else 1.dp,
+            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+        )
+    ) {
+        Column(modifier = Modifier.padding(18.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+                ) {
+                    Icon(
+                        icon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(10.dp)
+                    )
+                }
+                Box(modifier = Modifier.weight(1f))
+                if (badge != null) {
+                    Surface(
+                        shape = RoundedCornerShape(100.dp),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
+                    ) {
+                        Text(
+                            text = badge,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OnboardingChoiceScreenPreview() {
+    OpenCodeAndroidTheme {
+        OnboardingChoiceScreen(onSelectAndroid = {}, onSelectRemote = {}, onAddRemoteLater = {})
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/schedule/ScheduleScreen.kt
@@ -1,0 +1,332 @@
+package com.opencode.android.feature.schedule
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CloudSync
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.ui.components.SectionCard
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+
+private enum class ScheduleFilter { ALL, ENABLED, DISABLED }
+
+/**
+ * Schedule / task-automation screen. Backed by the in-memory [ScheduleViewModel]
+ * placeholder — see that file for TODOs on wiring real persistence and execution.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScheduleScreen(
+    items: List<ScheduleItem>,
+    onToggle: (String) -> Unit,
+    onAdd: (String, String, ScheduleRepeat) -> Unit,
+    onOpenDrawer: () -> Unit
+) {
+    var filter by remember { mutableStateOf(ScheduleFilter.ALL) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var overflowExpanded by remember { mutableStateOf(false) }
+
+    val filtered = when (filter) {
+        ScheduleFilter.ALL -> items
+        ScheduleFilter.ENABLED -> items.filter { it.enabled }
+        ScheduleFilter.DISABLED -> items.filter { !it.enabled }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.schedule_title), fontWeight = FontWeight.SemiBold) },
+                navigationIcon = {
+                    IconButton(onClick = onOpenDrawer) {
+                        Icon(Icons.Default.Menu, contentDescription = stringResource(R.string.menu_description))
+                    }
+                },
+                actions = {
+                    IconButton(onClick = {}) {
+                        Icon(Icons.Default.FilterList, contentDescription = stringResource(R.string.filter_description))
+                    }
+                    Box {
+                        IconButton(onClick = { overflowExpanded = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.chat_options_description))
+                        }
+                        DropdownMenu(expanded = overflowExpanded, onDismissRequest = { overflowExpanded = false }) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.new_schedule_button)) },
+                                onClick = { overflowExpanded = false; showCreateDialog = true }
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background
+                )
+            )
+
+            Text(
+                text = stringResource(R.string.schedule_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 20.dp)
+            )
+            Spacer(Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.padding(horizontal = 20.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                FilterChip(
+                    selected = filter == ScheduleFilter.ALL,
+                    onClick = { filter = ScheduleFilter.ALL },
+                    label = { Text(stringResource(R.string.filter_all)) }
+                )
+                FilterChip(
+                    selected = filter == ScheduleFilter.ENABLED,
+                    onClick = { filter = ScheduleFilter.ENABLED },
+                    label = { Text(stringResource(R.string.filter_enabled)) }
+                )
+                FilterChip(
+                    selected = filter == ScheduleFilter.DISABLED,
+                    onClick = { filter = ScheduleFilter.DISABLED },
+                    label = { Text(stringResource(R.string.filter_disabled)) }
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(filtered, key = { it.id }) { scheduleItem ->
+                    ScheduleCard(scheduleItem, onToggle)
+                }
+                item { Spacer(Modifier.height(80.dp)) }
+            }
+        }
+
+        Button(
+            onClick = { showCreateDialog = true },
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 24.dp),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(100.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            )
+        ) {
+            Icon(Icons.Default.Add, contentDescription = null)
+            Spacer(Modifier.width(6.dp))
+            Text(stringResource(R.string.new_schedule_button))
+        }
+    }
+
+    if (showCreateDialog) {
+        CreateScheduleDialog(
+            onDismiss = { showCreateDialog = false },
+            onCreate = { name, time, repeat ->
+                onAdd(name, time, repeat)
+                showCreateDialog = false
+            }
+        )
+    }
+}
+
+@Composable
+private fun ScheduleCard(item: ScheduleItem, onToggle: (String) -> Unit) {
+    SectionCard {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Surface(
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+            ) {
+                Icon(
+                    Icons.Default.CloudSync,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(item.name, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(2.dp))
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Icon(
+                        Icons.Default.Schedule,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.height(14.dp)
+                    )
+                    Text(
+                        text = buildString {
+                            if (item.dayOfWeek != null) append(item.dayOfWeek)
+                            append(item.time)
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Icon(
+                        Icons.Default.Repeat,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.height(14.dp)
+                    )
+                    Text(
+                        text = if (item.repeat == ScheduleRepeat.DAILY) {
+                            stringResource(R.string.schedule_repeat_daily)
+                        } else {
+                            stringResource(R.string.schedule_repeat_weekly)
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Switch(checked = item.enabled, onCheckedChange = { onToggle(item.id) })
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CreateScheduleDialog(
+    onDismiss: () -> Unit,
+    onCreate: (String, String, ScheduleRepeat) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var time by remember { mutableStateOf("") }
+    var repeat by remember { mutableStateOf(ScheduleRepeat.DAILY) }
+    var repeatMenuExpanded by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.schedule_create_dialog_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.schedule_name_hint)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = time,
+                    onValueChange = { time = it },
+                    label = { Text(stringResource(R.string.schedule_time_hint)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                ExposedDropdownMenuBox(
+                    expanded = repeatMenuExpanded,
+                    onExpandedChange = { repeatMenuExpanded = it }
+                ) {
+                    OutlinedTextField(
+                        value = if (repeat == ScheduleRepeat.DAILY) {
+                            stringResource(R.string.schedule_repeat_daily)
+                        } else {
+                            stringResource(R.string.schedule_repeat_weekly)
+                        },
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text(stringResource(R.string.schedule_repeat_label)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = repeatMenuExpanded) },
+                        modifier = Modifier
+                            .menuAnchor()
+                            .fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = repeatMenuExpanded,
+                        onDismissRequest = { repeatMenuExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.schedule_repeat_daily)) },
+                            onClick = { repeat = ScheduleRepeat.DAILY; repeatMenuExpanded = false }
+                        )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.schedule_repeat_weekly)) },
+                            onClick = { repeat = ScheduleRepeat.WEEKLY; repeatMenuExpanded = false }
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onCreate(name, time, repeat) },
+                enabled = name.isNotBlank() && time.isNotBlank()
+            ) {
+                Text(stringResource(R.string.save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ScheduleScreenPreview() {
+    OpenCodeAndroidTheme {
+        ScheduleScreen(
+            items = listOf(
+                ScheduleItem(name = "デイリー同期", time = "09:00", repeat = ScheduleRepeat.DAILY, enabled = true),
+                ScheduleItem(name = "レポート生成", time = "08:00", repeat = ScheduleRepeat.WEEKLY, dayOfWeek = "月曜", enabled = false)
+            ),
+            onToggle = {},
+            onAdd = { _, _, _ -> },
+            onOpenDrawer = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/opencode/android/feature/schedule/ScheduleViewModel.kt
@@ -1,0 +1,49 @@
+package com.opencode.android.feature.schedule
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.util.UUID
+
+enum class ScheduleRepeat { DAILY, WEEKLY }
+
+data class ScheduleItem(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val time: String,
+    val repeat: ScheduleRepeat,
+    val dayOfWeek: String? = null,
+    val enabled: Boolean
+)
+
+/**
+ * PLACEHOLDER VIEWMODEL: holds an in-memory list of "scheduled tasks" so the new
+ * Schedule screen has something real to render and toggle. This is not backed by
+ * any persistence or actual task runner yet.
+ *
+ * TODO: replace with a real scheduling backend (e.g. WorkManager-driven automation
+ * that talks to the OpenCode runtime) once that feature is designed. Until then,
+ * items reset to the seed data below every time the app process restarts.
+ */
+class ScheduleViewModel : ViewModel() {
+    private val mutableState = MutableStateFlow(
+        listOf(
+            ScheduleItem(name = "デイリー同期", time = "09:00", repeat = ScheduleRepeat.DAILY, enabled = true),
+            ScheduleItem(name = "コード整形", time = "12:00", repeat = ScheduleRepeat.DAILY, enabled = true),
+            ScheduleItem(name = "レポート生成", time = "08:00", repeat = ScheduleRepeat.WEEKLY, dayOfWeek = "月曜", enabled = false),
+            ScheduleItem(name = "バックアップ", time = "23:00", repeat = ScheduleRepeat.DAILY, enabled = true)
+        )
+    )
+    val state: StateFlow<List<ScheduleItem>> = mutableState.asStateFlow()
+
+    fun toggle(id: String) {
+        mutableState.update { list -> list.map { if (it.id == id) it.copy(enabled = !it.enabled) else it } }
+    }
+
+    fun add(name: String, time: String, repeat: ScheduleRepeat) {
+        if (name.isBlank() || time.isBlank()) return
+        mutableState.update { it + ScheduleItem(name = name.trim(), time = time.trim(), repeat = repeat, enabled = true) }
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/settings/ProviderSettingsScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/settings/ProviderSettingsScreen.kt
@@ -1,0 +1,144 @@
+package com.opencode.android.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.ui.components.LabelValueRow
+import com.opencode.android.ui.components.SectionCard
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+
+/**
+ * Provider / API-key management detail screen. Mirrors the provider credential
+ * section that used to live inline in the old SettingsScreen.kt, wired to the same
+ * SettingsViewModel draft + save/clear API key actions.
+ */
+@Composable
+fun ProviderSettingsScreen(
+    credentialStatuses: Map<String, Boolean>,
+    draftProviderId: String,
+    draftApiKey: String,
+    credentialMessage: String?,
+    onDraftProviderId: (String) -> Unit,
+    onDraftApiKey: (String) -> Unit,
+    onSaveApiKey: () -> Unit,
+    onClearApiKey: (String) -> Unit,
+    onBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.provider_settings_row)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.nav_back))
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SectionCard {
+                Text(
+                    text = stringResource(R.string.provider_credentials_help),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                credentialStatuses.forEach { (providerId, saved) ->
+                    LabelValueRow(
+                        label = providerId,
+                        value = if (saved) stringResource(R.string.key_saved) else stringResource(R.string.key_missing)
+                    )
+                    if (saved) {
+                        Spacer(Modifier.height(8.dp))
+                        OutlinedButton(
+                            onClick = { onClearApiKey(providerId) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(stringResource(R.string.clear_api_key))
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                }
+                OutlinedTextField(
+                    value = draftProviderId,
+                    onValueChange = onDraftProviderId,
+                    label = { Text(stringResource(R.string.provider_id_hint)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    leadingIcon = { Icon(Icons.Default.Key, contentDescription = null) }
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = draftApiKey,
+                    onValueChange = onDraftApiKey,
+                    label = { Text(stringResource(R.string.api_key_hint)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+                )
+                Spacer(Modifier.height(8.dp))
+                Button(onClick = onSaveApiKey, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.save_api_key))
+                }
+                credentialMessage?.let {
+                    Spacer(Modifier.height(8.dp))
+                    Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProviderSettingsScreenPreview() {
+    OpenCodeAndroidTheme {
+        ProviderSettingsScreen(
+            credentialStatuses = mapOf("openai" to true, "anthropic" to false),
+            draftProviderId = "",
+            draftApiKey = "",
+            credentialMessage = null,
+            onDraftProviderId = {},
+            onDraftApiKey = {},
+            onSaveApiKey = {},
+            onClearApiKey = {},
+            onBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/settings/SettingsScreenV2.kt
+++ b/app/src/main/java/com/opencode/android/feature/settings/SettingsScreenV2.kt
@@ -1,0 +1,316 @@
+package com.opencode.android.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.PrivacyTip
+import androidx.compose.material.icons.filled.RecordVoiceOver
+import androidx.compose.material.icons.filled.Router
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.ui.components.SectionCard
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+
+/**
+ * Redesigned settings landing screen: grouped rounded cards under アシスタント設定 /
+ * システム設定 / アプリ設定. Real sub-flows (voice, provider credentials) navigate to
+ * dedicated screens; wake word / privacy / app info are lightweight stub dialogs.
+ */
+@Composable
+fun SettingsScreenV2(
+    assistantConfigured: Boolean,
+    notificationsEnabled: Boolean,
+    onToggleNotifications: (Boolean) -> Unit,
+    appVersion: String,
+    onOpenDrawer: () -> Unit,
+    onOpenAssistantSettings: () -> Unit,
+    onOpenVoiceSettings: () -> Unit,
+    onOpenProviderSettings: () -> Unit,
+    onOpenLocalRuntime: () -> Unit,
+    onOpenRemoteConnection: () -> Unit,
+    onOpenWorkspaces: () -> Unit,
+    onOpenDiagnostics: () -> Unit
+) {
+    var showWakeWordDialog by remember { mutableStateOf(false) }
+    var showPrivacyDialog by remember { mutableStateOf(false) }
+    var showAboutDialog by remember { mutableStateOf(false) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        CenterAlignedTopAppBar(
+            title = { Text(stringResource(R.string.nav_settings), fontWeight = FontWeight.SemiBold) },
+            navigationIcon = {
+                IconButton(onClick = onOpenDrawer) {
+                    Icon(Icons.Default.Menu, contentDescription = stringResource(R.string.menu_description))
+                }
+            },
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = MaterialTheme.colorScheme.background
+            )
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item {
+                Text(
+                    stringResource(R.string.section_assistant_settings),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            item {
+                SectionCard {
+                    SettingsRow(
+                        icon = Icons.Default.Home,
+                        title = stringResource(R.string.settings_home_assistant_row),
+                        trailing = {
+                            StatusPill(
+                                text = if (assistantConfigured) stringResource(R.string.assistant_enabled_pill) else stringResource(R.string.assistant_disabled_pill),
+                                active = assistantConfigured
+                            )
+                        },
+                        onClick = onOpenAssistantSettings
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.Mic,
+                        title = stringResource(R.string.wake_word_row_title),
+                        trailingText = stringResource(R.string.wake_word_value),
+                        onClick = { showWakeWordDialog = true }
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.RecordVoiceOver,
+                        title = stringResource(R.string.voice_settings_row),
+                        onClick = onOpenVoiceSettings
+                    )
+                }
+            }
+
+            item {
+                Text(
+                    stringResource(R.string.section_system_settings),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            item {
+                SectionCard {
+                    SettingsRow(
+                        icon = Icons.Default.Key,
+                        title = stringResource(R.string.provider_settings_row),
+                        onClick = onOpenProviderSettings
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.Terminal,
+                        title = stringResource(R.string.settings_local_runtime_row),
+                        onClick = onOpenLocalRuntime
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.Router,
+                        title = stringResource(R.string.remote_connection_row),
+                        onClick = onOpenRemoteConnection
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.Folder,
+                        title = stringResource(R.string.settings_workspace_row),
+                        onClick = onOpenWorkspaces
+                    )
+                }
+            }
+
+            item {
+                Text(
+                    stringResource(R.string.section_app_settings),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            item {
+                SectionCard {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
+                        Icon(Icons.Default.Notifications, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                        Text(
+                            stringResource(R.string.notifications_row),
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Switch(checked = notificationsEnabled, onCheckedChange = onToggleNotifications)
+                    }
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.PrivacyTip,
+                        title = stringResource(R.string.privacy_row),
+                        onClick = { showPrivacyDialog = true }
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.History,
+                        title = stringResource(R.string.diagnostics_row),
+                        onClick = onOpenDiagnostics
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Default.Info,
+                        title = stringResource(R.string.app_info_row),
+                        onClick = { showAboutDialog = true }
+                    )
+                }
+            }
+        }
+    }
+
+    if (showWakeWordDialog) {
+        StubDialog(
+            title = stringResource(R.string.wake_word_row_title),
+            body = stringResource(R.string.wake_word_stub_body),
+            onDismiss = { showWakeWordDialog = false }
+        )
+    }
+    if (showPrivacyDialog) {
+        StubDialog(
+            title = stringResource(R.string.privacy_row),
+            body = stringResource(R.string.privacy_stub_body),
+            onDismiss = { showPrivacyDialog = false }
+        )
+    }
+    if (showAboutDialog) {
+        StubDialog(
+            title = stringResource(R.string.app_info_row),
+            body = "${stringResource(R.string.app_name)} $appVersion\n${stringResource(R.string.unofficial_client)}",
+            onDismiss = { showAboutDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun SettingsRow(
+    icon: ImageVector,
+    title: String,
+    trailingText: String? = null,
+    trailing: (@Composable () -> Unit)? = null,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        Text(title, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+        trailingText?.let {
+            Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        trailing?.invoke()
+        Icon(
+            Icons.Default.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun SettingsDivider() {
+    androidx.compose.material3.HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f))
+}
+
+@Composable
+private fun StatusPill(text: String, active: Boolean) {
+    val color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        color = color.copy(alpha = 0.14f),
+        contentColor = color,
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(100.dp)
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun StubDialog(title: String, body: String, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(body) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.close_description)) }
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsScreenV2Preview() {
+    OpenCodeAndroidTheme {
+        SettingsScreenV2(
+            assistantConfigured = true,
+            notificationsEnabled = true,
+            onToggleNotifications = {},
+            appVersion = "0.1.0",
+            onOpenDrawer = {},
+            onOpenAssistantSettings = {},
+            onOpenVoiceSettings = {},
+            onOpenProviderSettings = {},
+            onOpenLocalRuntime = {},
+            onOpenRemoteConnection = {},
+            onOpenWorkspaces = {},
+            onOpenDiagnostics = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/settings/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/settings/VoiceSettingsScreen.kt
@@ -1,0 +1,120 @@
+package com.opencode.android.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.RecordVoiceOver
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.ui.components.SectionCard
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+
+/** Voice settings detail screen: hosts the existing TTS / continuous-conversation toggles. */
+@Composable
+fun VoiceSettingsScreen(
+    ttsEnabled: Boolean,
+    continuousConversation: Boolean,
+    onTtsChange: (Boolean) -> Unit,
+    onContinuousChange: (Boolean) -> Unit,
+    onBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.voice_settings_row)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.nav_back))
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SectionCard {
+                VoiceToggleRow(
+                    icon = Icons.Default.RecordVoiceOver,
+                    title = stringResource(R.string.voice_response),
+                    description = stringResource(R.string.auto_start_mic),
+                    checked = ttsEnabled,
+                    onCheckedChange = onTtsChange
+                )
+            }
+            SectionCard {
+                VoiceToggleRow(
+                    icon = Icons.Default.Mic,
+                    title = stringResource(R.string.continuous_conversation),
+                    description = stringResource(R.string.auto_start_mic),
+                    checked = continuousConversation,
+                    onCheckedChange = onContinuousChange
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VoiceToggleRow(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, fontWeight = FontWeight.Medium)
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun VoiceSettingsScreenPreview() {
+    OpenCodeAndroidTheme {
+        VoiceSettingsScreen(
+            ttsEnabled = true,
+            continuousConversation = false,
+            onTtsChange = {},
+            onContinuousChange = {},
+            onBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/feature/workspace/RemoteConnectionScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/workspace/RemoteConnectionScreen.kt
@@ -1,0 +1,385 @@
+package com.opencode.android.feature.workspace
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.WifiFind
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
+import com.opencode.android.R
+import com.opencode.android.core.api.OpenCodeHealth
+import com.opencode.android.core.security.ConnectionQrPayload
+import com.opencode.android.ui.components.SectionCard
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Dedicated "connect to PC/Mac" screen used both from first-run onboarding and from
+ * the drawer's "リモート接続" entry. Reuses [ConnectionFormState] plus
+ * WorkspaceViewModel.testConnection/saveConnection and the QR/LAN discovery helpers
+ * already used by ConnectionDialog.kt.
+ */
+@Composable
+fun RemoteConnectionScreen(
+    onTestConnection: suspend (ConnectionFormState) -> Result<OpenCodeHealth>,
+    onSaveConnection: (ConnectionFormState) -> Unit,
+    onBack: () -> Unit,
+    onConnected: () -> Unit
+) {
+    var form by remember { mutableStateOf(ConnectionFormState()) }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var discoveryDialogOpen by remember { mutableStateOf(false) }
+    var isDiscovering by remember { mutableStateOf(false) }
+    var discoveredServers by remember { mutableStateOf<List<DiscoveredServer>>(emptyList()) }
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val qrScanLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
+        val text = result.contents ?: return@rememberLauncherForActivityResult
+        ConnectionQrPayload.parse(text)?.let { payload ->
+            form = ConnectionFormState(
+                name = payload.name.orEmpty(),
+                baseUrl = payload.url.orEmpty(),
+                username = payload.username?.takeIf { it.isNotBlank() } ?: "opencode",
+                password = payload.password.orEmpty(),
+                allowInsecureLan = payload.insecure
+            )
+        }
+    }
+
+    fun startLanDiscovery() {
+        discoveryDialogOpen = true
+        discoveredServers = emptyList()
+        isDiscovering = true
+        scope.launch {
+            val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
+            withTimeoutOrNull(10_000) {
+                LanDiscovery(nsdManager).discover().collect { server ->
+                    discoveredServers = (discoveredServers + server).distinctBy { it.host to it.port }
+                }
+            }
+            isDiscovering = false
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.remote_connection_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.nav_back))
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SectionCard {
+                StepRow(1, Icons.Default.PlayArrow, stringResource(R.string.remote_step1_title), stringResource(R.string.remote_step1_desc))
+                Spacer(Modifier.height(12.dp))
+                StepRow(2, Icons.Default.Link, stringResource(R.string.remote_step2_title), stringResource(R.string.remote_step2_desc))
+                Spacer(Modifier.height(12.dp))
+                StepRow(3, Icons.Default.CheckCircle, stringResource(R.string.remote_step3_title), stringResource(R.string.remote_step3_desc))
+            }
+
+            SectionCard {
+                OutlinedTextField(
+                    value = form.name,
+                    onValueChange = { form = form.copy(name = it, testSucceeded = false, testMessage = null) },
+                    label = { Text(stringResource(R.string.connection_name)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                Spacer(Modifier.height(10.dp))
+                OutlinedTextField(
+                    value = form.baseUrl,
+                    onValueChange = { form = form.copy(baseUrl = it, testSucceeded = false, testMessage = null) },
+                    label = { Text(stringResource(R.string.server_url)) },
+                    leadingIcon = { Icon(Icons.Default.Link, contentDescription = null) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    isError = form.baseUrl.isNotBlank() && form.normalizedUrl == null
+                )
+                Spacer(Modifier.height(10.dp))
+                OutlinedTextField(
+                    value = form.username,
+                    onValueChange = { form = form.copy(username = it) },
+                    label = { Text(stringResource(R.string.username)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                Spacer(Modifier.height(10.dp))
+                OutlinedTextField(
+                    value = form.password,
+                    onValueChange = { form = form.copy(password = it, testSucceeded = false, testMessage = null) },
+                    label = { Text(stringResource(R.string.password)) },
+                    leadingIcon = { Icon(Icons.Default.Key, contentDescription = null) },
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                OutlinedButton(
+                    onClick = {
+                        qrScanLauncher.launch(ScanOptions().setBeepEnabled(false).setOrientationLocked(false))
+                    },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Icon(Icons.Default.QrCodeScanner, contentDescription = null)
+                    Spacer(Modifier.width(6.dp))
+                    Text(stringResource(R.string.add_via_qr))
+                }
+                OutlinedButton(
+                    onClick = { startLanDiscovery() },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Icon(Icons.Default.WifiFind, contentDescription = null)
+                    Spacer(Modifier.width(6.dp))
+                    Text(stringResource(R.string.discover_on_lan))
+                }
+            }
+
+            SectionCard {
+                Row(verticalAlignment = Alignment.Top, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Icon(Icons.Default.Info, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    Text(
+                        stringResource(R.string.remote_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            if (form.testMessage != null) {
+                Text(
+                    text = form.testMessage.orEmpty(),
+                    color = if (form.testSucceeded) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+
+            Button(
+                onClick = {
+                    scope.launch {
+                        form = form.copy(isTesting = true, testMessage = null)
+                        onTestConnection(form).fold(
+                            onSuccess = { health ->
+                                form = form.copy(
+                                    isTesting = false,
+                                    testSucceeded = health.healthy,
+                                    testMessage = "OpenCode ${health.version}"
+                                )
+                            },
+                            onFailure = { error ->
+                                form = form.copy(
+                                    isTesting = false,
+                                    testSucceeded = false,
+                                    testMessage = error.message ?: "Connection failed"
+                                )
+                            }
+                        )
+                    }
+                },
+                enabled = form.canSave && !form.isTesting,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+            ) {
+                if (form.isTesting) {
+                    CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(Icons.Default.NetworkCheck, contentDescription = null)
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.remote_test_connection_button), fontWeight = FontWeight.SemiBold)
+            }
+
+            if (form.testSucceeded) {
+                Button(
+                    onClick = {
+                        onSaveConnection(form)
+                        onConnected()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(52.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                ) {
+                    Text(stringResource(R.string.remote_save_connection_button), fontWeight = FontWeight.SemiBold)
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+
+    if (discoveryDialogOpen) {
+        AlertDialog(
+            onDismissRequest = { discoveryDialogOpen = false },
+            title = { Text(stringResource(R.string.discovered_servers_title)) },
+            text = {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (isDiscovering) {
+                        Text(
+                            stringResource(R.string.discovering_servers),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    }
+                    if (discoveredServers.isEmpty()) {
+                        if (!isDiscovering) {
+                            Text(
+                                stringResource(R.string.no_servers_found),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        discoveredServers.forEach { server ->
+                            SectionCard(
+                                modifier = Modifier.clickable {
+                                    form = ConnectionFormState(
+                                        name = server.name,
+                                        baseUrl = server.baseUrl,
+                                        allowInsecureLan = true
+                                    )
+                                    discoveryDialogOpen = false
+                                }
+                            ) {
+                                Text(server.name, fontWeight = FontWeight.Medium)
+                                Text(
+                                    server.baseUrl,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { discoveryDialogOpen = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun StepRow(number: Int, icon: ImageVector, title: String, description: String) {
+    Row(verticalAlignment = Alignment.Top, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        Column {
+            Text(
+                text = "$number. $title",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RemoteConnectionScreenPreview() {
+    OpenCodeAndroidTheme {
+        RemoteConnectionScreen(
+            onTestConnection = { Result.success(OpenCodeHealth(true, "1.0.0")) },
+            onSaveConnection = {},
+            onBack = {},
+            onConnected = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/ui/AppDrawerContent.kt
+++ b/app/src/main/java/com/opencode/android/ui/AppDrawerContent.kt
@@ -1,0 +1,300 @@
+package com.opencode.android.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.filled.Router
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+import com.opencode.android.ui.theme.OpenCodeAndroidTheme
+
+/** A recent chat entry rendered in the drawer's "最近のチャット" section. */
+data class DrawerRecentSession(
+    val id: String,
+    val title: String,
+    val relativeTime: String
+)
+
+/**
+ * ChatGPT-style left navigation drawer content: brand header, new-chat action,
+ * recent chats, a static "pinned" section (placeholder), a features list, and a
+ * footer account card.
+ */
+@Composable
+fun AppDrawerContent(
+    recentSessions: List<DrawerRecentSession>,
+    onNewChat: () -> Unit,
+    onOpenSession: (String, String) -> Unit,
+    onNavigate: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .width(300.dp)
+            .padding(vertical = 8.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(10.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Terminal,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(8.dp)
+                    )
+                }
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+                // TODO: wire up search-in-chats once a search index exists.
+                IconButton(onClick = {}) {
+                    Icon(Icons.Default.Search, contentDescription = stringResource(R.string.drawer_search_description))
+                }
+            }
+
+            DrawerActionRow(
+                icon = Icons.AutoMirrored.Filled.Chat,
+                label = stringResource(R.string.new_chat),
+                emphasized = true,
+                onClick = onNewChat
+            )
+
+            Spacer(Modifier.height(8.dp))
+            DrawerSectionHeader(stringResource(R.string.drawer_recent_chats))
+            if (recentSessions.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.no_sessions),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)
+                )
+            } else {
+                recentSessions.forEach { session ->
+                    DrawerChatRow(
+                        title = session.title.ifBlank { session.id },
+                        subtitle = session.relativeTime,
+                        onClick = { onOpenSession(session.id, session.title) }
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+            DrawerSectionHeader(stringResource(R.string.drawer_pinned))
+            // Static placeholder pinned items — TODO: back with real pinning once supported.
+            DrawerChatRow(
+                title = stringResource(R.string.drawer_pinned_sample_1),
+                subtitle = null,
+                onClick = {}
+            )
+            DrawerChatRow(
+                title = stringResource(R.string.drawer_pinned_sample_2),
+                subtitle = null,
+                onClick = {}
+            )
+
+            Spacer(Modifier.height(8.dp))
+            DrawerSectionHeader(stringResource(R.string.drawer_features))
+            DrawerFeatureRow(Icons.Default.Schedule, stringResource(R.string.schedule_title)) { onNavigate("schedule") }
+            DrawerFeatureRow(Icons.Default.Computer, stringResource(R.string.settings_local_runtime_row)) { onNavigate("local-runtime-management") }
+            DrawerFeatureRow(Icons.Default.Router, stringResource(R.string.remote_connection_row)) { onNavigate("remote-connection") }
+            DrawerFeatureRow(Icons.Default.Folder, stringResource(R.string.settings_workspace_row)) { onNavigate("workspaces") }
+            DrawerFeatureRow(Icons.Default.Settings, stringResource(R.string.nav_settings)) { onNavigate("settings") }
+            DrawerFeatureRow(Icons.Default.History, stringResource(R.string.diagnostics_row)) { onNavigate("activity") }
+            Spacer(Modifier.height(8.dp))
+        }
+
+        HorizontalDivider()
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.AccountCircle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.height(32.dp)
+            )
+            Spacer(Modifier.width(10.dp))
+            Column {
+                // Static placeholder identity — TODO: replace with real account info once auth exists.
+                Text(
+                    text = stringResource(R.string.drawer_user_email_placeholder),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = stringResource(R.string.drawer_plan_label),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DrawerSectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)
+    )
+}
+
+@Composable
+private fun DrawerActionRow(
+    icon: ImageVector,
+    label: String,
+    emphasized: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = if (emphasized) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (emphasized) FontWeight.SemiBold else FontWeight.Normal
+        )
+    }
+}
+
+@Composable
+private fun DrawerChatRow(
+    title: String,
+    subtitle: String?,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(
+            Icons.Default.PushPin,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.height(16.dp)
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyMedium, maxLines = 1)
+            subtitle?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DrawerFeatureRow(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(label, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+        Icon(
+            Icons.Default.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AppDrawerContentPreview() {
+    OpenCodeAndroidTheme {
+        AppDrawerContent(
+            recentSessions = listOf(
+                DrawerRecentSession("1", "認証バグの調査", "3時間前"),
+                DrawerRecentSession("2", "READMEの更新", "昨日")
+            ),
+            onNewChat = {},
+            onOpenSession = { _, _ -> },
+            onNavigate = {}
+        )
+    }
+}

--- a/app/src/main/java/com/opencode/android/ui/OpenCodeApp.kt
+++ b/app/src/main/java/com/opencode/android/ui/OpenCodeApp.kt
@@ -4,18 +4,10 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Chat
-import androidx.compose.material.icons.filled.Dashboard
-import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -25,13 +17,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -45,15 +34,20 @@ import com.opencode.android.feature.activity.SessionDetailScreen
 import com.opencode.android.feature.activity.SessionDetailViewModel
 import com.opencode.android.feature.assistant.SpeechRecognizerManager
 import com.opencode.android.feature.assistant.SpeechResult
+import com.opencode.android.feature.chat.ChatHomeScreen
 import com.opencode.android.feature.chat.ChatViewModel
-import com.opencode.android.feature.chat.OpenCodeChatScreen
 import com.opencode.android.feature.chat.buildHandoffPrompt
-import com.opencode.android.feature.home.HomeScreen
-import com.opencode.android.feature.home.HomeViewModel
-import com.opencode.android.feature.settings.SettingsScreen
+import com.opencode.android.feature.onboarding.AndroidSetupScreen
+import com.opencode.android.feature.onboarding.OnboardingChoiceScreen
+import com.opencode.android.feature.schedule.ScheduleScreen
+import com.opencode.android.feature.schedule.ScheduleViewModel
+import com.opencode.android.feature.settings.ProviderSettingsScreen
+import com.opencode.android.feature.settings.SettingsScreenV2
 import com.opencode.android.feature.settings.SettingsViewModel
+import com.opencode.android.feature.settings.VoiceSettingsScreen
 import com.opencode.android.feature.workspace.LocalRuntimeManagementScreen
 import com.opencode.android.feature.workspace.LocalRuntimeManagementViewModel
+import com.opencode.android.feature.workspace.RemoteConnectionScreen
 import com.opencode.android.feature.workspace.WorkspaceExplorerScreen
 import com.opencode.android.feature.workspace.WorkspaceExplorerViewModel
 import com.opencode.android.feature.workspace.WorkspaceViewModel
@@ -64,21 +58,22 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-private enum class Destination(
-    val route: String,
-    val labelRes: Int,
-    val icon: ImageVector
-) {
-    HOME("home", R.string.nav_home, Icons.Default.Dashboard),
-    CHAT("chat", R.string.nav_chat, Icons.AutoMirrored.Filled.Chat),
-    WORKSPACES("workspaces", R.string.nav_workspaces, Icons.Default.Folder),
-    ACTIVITY("activity", R.string.nav_activity, Icons.Default.History),
-    SETTINGS("settings", R.string.nav_settings, Icons.Default.Settings)
-}
-
+private const val ROUTE_ONBOARDING = "onboarding"
+private const val ROUTE_ANDROID_SETUP = "android-setup"
+private const val ROUTE_REMOTE_CONNECTION = "remote-connection"
+private const val ROUTE_CHAT = "chat"
+private const val ROUTE_SCHEDULE = "schedule"
+private const val ROUTE_SETTINGS = "settings"
+private const val ROUTE_SETTINGS_VOICE = "settings-voice"
+private const val ROUTE_SETTINGS_PROVIDERS = "settings-providers"
+private const val ROUTE_WORKSPACES = "workspaces"
+private const val ROUTE_ACTIVITY = "activity"
 private const val WORKSPACE_DETAIL_ROUTE = "workspace-detail"
 private const val SESSION_DETAIL_ROUTE = "session-detail"
 private const val LOCAL_RUNTIME_MANAGEMENT_ROUTE = "local-runtime-management"
+
+/** Routes whose top bar exposes the hamburger menu / drawer swipe gesture. */
+private val DRAWER_ROOT_ROUTES = setOf(ROUTE_CHAT, ROUTE_SETTINGS, ROUTE_SCHEDULE)
 
 private fun speechLocaleTag(context: android.content.Context): String {
     val locale = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
@@ -88,6 +83,20 @@ private fun speechLocaleTag(context: android.content.Context): String {
         context.resources.configuration.locale
     }
     return locale?.toLanguageTag()?.takeIf { it.isNotBlank() } ?: "en-US"
+}
+
+/** Relative-time label ("3時間前" / "3 hours ago") for the drawer's recent-chats list. */
+private fun relativeTimeLabel(context: android.content.Context, epochMillis: Long): String {
+    val diffMillis = (System.currentTimeMillis() - epochMillis).coerceAtLeast(0L)
+    val minutes = diffMillis / 60_000L
+    val hours = minutes / 60L
+    val days = hours / 24L
+    return when {
+        minutes < 1L -> context.getString(R.string.drawer_time_just_now)
+        hours < 1L -> context.getString(R.string.drawer_time_minutes_ago, minutes)
+        days < 1L -> context.getString(R.string.drawer_time_hours_ago, hours)
+        else -> context.getString(R.string.drawer_time_days_ago, days)
+    }
 }
 
 @Composable
@@ -102,15 +111,11 @@ fun OpenCodeApp(
     var pendingHandoffPrompt by remember { mutableStateOf<Pair<String, String>?>(null) }
     var selectedWorkspace by remember { mutableStateOf<WorkspaceRef?>(null) }
     var selectedSession by remember { mutableStateOf<OpenCodeSession?>(null) }
+    var notificationsEnabled by remember { mutableStateOf(true) }
 
     val selectedRuntime by app.runtimeRegistry.selected.collectAsState()
     val runtimeTargets by app.runtimeRegistry.targets.collectAsState()
     val preferences by app.preferences.state.collectAsState()
-    val homeViewModel: HomeViewModel = viewModel(
-        key = "home",
-        factory = ViewModelFactory { HomeViewModel(app.catalogRepository, app.preferences) }
-    )
-    val homeState by homeViewModel.state.collectAsState()
 
     val workspaceViewModel: WorkspaceViewModel = viewModel(
         key = "workspaces",
@@ -294,56 +299,103 @@ fun OpenCodeApp(
         app.runtimeRegistry.select(targetRuntimeId)
     }
 
-    val showBottomBar = Destination.entries.any { destination ->
-        destination.route == backStackEntry?.destination?.route
+    // First-run gate: onboarding is the start destination until completed or skipped.
+    val startDestination = remember { if (app.settings.onboardingCompleted) ROUTE_CHAT else ROUTE_ONBOARDING }
+    val completeOnboardingAndGoToChat: () -> Unit = {
+        app.settings.onboardingCompleted = true
+        navController.navigate(ROUTE_CHAT) {
+            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+            launchSingleTop = true
+        }
     }
 
-    Scaffold(
-        bottomBar = {
-            if (showBottomBar) NavigationBar {
-                Destination.entries.forEach { destination ->
-                    val selected = backStackEntry?.destination?.hierarchy
-                        ?.any { it.route == destination.route } == true
-                    NavigationBarItem(
-                        selected = selected,
-                        onClick = {
-                            navController.navigate(destination.route) {
-                                popUpTo(Destination.HOME.route) { saveState = true }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                        icon = { Icon(destination.icon, contentDescription = stringResource(destination.labelRes)) },
-                        label = { Text(stringResource(destination.labelRes)) }
-                    )
-                }
-            }
+    val appVersion = remember {
+        runCatching {
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName
+        }.getOrNull().orEmpty()
+    }
+
+    val recentSessions = remember(activityState.sessions) {
+        activityState.sessions.take(8).map { session ->
+            DrawerRecentSession(
+                id = session.id,
+                title = session.title.ifBlank { session.slug ?: session.id },
+                relativeTime = relativeTimeLabel(context, session.time.updated ?: session.time.created)
+            )
         }
-    ) { paddingValues ->
-        NavHost(
-            navController = navController,
-            startDestination = Destination.HOME.route,
-            modifier = Modifier.padding(paddingValues)
-        ) {
-            composable(Destination.HOME.route) {
-                HomeScreen(
-                    state = homeState,
+    }
+
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val drawerScope = rememberCoroutineScope()
+    val currentRoute = backStackEntry?.destination?.route
+
+    fun closeDrawer() {
+        drawerScope.launch { drawerState.close() }
+    }
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        gesturesEnabled = currentRoute in DRAWER_ROOT_ROUTES,
+        drawerContent = {
+            ModalDrawerSheet {
+                AppDrawerContent(
+                    recentSessions = recentSessions,
                     onNewChat = {
+                        closeDrawer()
                         pendingSession = null
                         chatViewModel.newSession()
-                        navController.navigate(Destination.CHAT.route)
+                        navController.navigate(ROUTE_CHAT) { launchSingleTop = true }
                     },
-                    onOpenWorkspaces = { navController.navigate(Destination.WORKSPACES.route) },
-                    onOpenActivity = { navController.navigate(Destination.ACTIVITY.route) },
                     onOpenSession = { id, title ->
+                        closeDrawer()
                         pendingSession = id to title
-                        navController.navigate(Destination.CHAT.route)
+                        navController.navigate(ROUTE_CHAT) { launchSingleTop = true }
                     },
-                    onRefresh = homeViewModel::refresh
+                    onNavigate = { route ->
+                        closeDrawer()
+                        navController.navigate(route) { launchSingleTop = true }
+                    }
+                )
+            }
+        }
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = startDestination
+        ) {
+            composable(ROUTE_ONBOARDING) {
+                OnboardingChoiceScreen(
+                    onSelectAndroid = { navController.navigate(ROUTE_ANDROID_SETUP) },
+                    onSelectRemote = { navController.navigate(ROUTE_REMOTE_CONNECTION) },
+                    onAddRemoteLater = { navController.navigate(ROUTE_REMOTE_CONNECTION) }
                 )
             }
 
-            composable(Destination.CHAT.route) {
+            composable(ROUTE_ANDROID_SETUP) {
+                val localRuntimeStatus by app.localRuntimeManager.state.collectAsState()
+                AndroidSetupScreen(
+                    runtimeStatus = localRuntimeStatus,
+                    onStartRuntimeSetup = workspaceViewModel::setupLocalRuntime,
+                    onSaveApiKey = { providerId, apiKey ->
+                        settingsViewModel.updateDraftProviderId(providerId)
+                        settingsViewModel.updateDraftApiKey(apiKey)
+                        settingsViewModel.saveApiKey()
+                    },
+                    onBack = { navController.popBackStack() },
+                    onFinish = completeOnboardingAndGoToChat
+                )
+            }
+
+            composable(ROUTE_REMOTE_CONNECTION) {
+                RemoteConnectionScreen(
+                    onTestConnection = workspaceViewModel::testConnection,
+                    onSaveConnection = workspaceViewModel::saveConnection,
+                    onBack = { navController.popBackStack() },
+                    onConnected = completeOnboardingAndGoToChat
+                )
+            }
+
+            composable(ROUTE_CHAT) {
                 LaunchedEffect(pendingSession) {
                     pendingSession?.let { (id, title) ->
                         chatViewModel.openSession(id, title)
@@ -357,7 +409,7 @@ fun OpenCodeApp(
                         pendingHandoffPrompt = null
                     }
                 }
-                OpenCodeChatScreen(
+                ChatHomeScreen(
                     state = chatState,
                     providers = settingsState.providers,
                     agents = settingsState.agents,
@@ -365,7 +417,17 @@ fun OpenCodeApp(
                     selectedProviderId = settingsState.providerId,
                     selectedModelId = settingsState.modelId,
                     selectedAgentId = settingsState.agentId,
-                    otherRuntimes = runtimeTargets.filter { it.id != selectedRuntime?.id },
+                    runtimeTargets = runtimeTargets,
+                    selectedRuntimeId = selectedRuntime?.id,
+                    onSelectRuntime = { id ->
+                        if (id != selectedRuntime?.id) {
+                            if (chatState.messages.isNotEmpty()) {
+                                onHandoff(id)
+                            } else {
+                                app.runtimeRegistry.select(id)
+                            }
+                        }
+                    },
                     onSelectModel = settingsViewModel::selectModel,
                     onSelectAgent = settingsViewModel::selectAgent,
                     onSelectWorkspace = chatViewModel::selectWorkspace,
@@ -373,11 +435,82 @@ fun OpenCodeApp(
                     onPermission = chatViewModel::respondToPermission,
                     onAbort = chatViewModel::abort,
                     onMic = requestVoiceInput,
-                    onHandoff = onHandoff
+                    onNewChat = {
+                        pendingSession = null
+                        chatViewModel.newSession()
+                    },
+                    onOpenHistory = {
+                        navController.navigate(ROUTE_ACTIVITY) { launchSingleTop = true }
+                    },
+                    onOpenDrawer = { drawerScope.launch { drawerState.open() } }
                 )
             }
 
-            composable(Destination.WORKSPACES.route) {
+            composable(ROUTE_SCHEDULE) {
+                val scheduleViewModel: ScheduleViewModel = viewModel(
+                    key = "schedule",
+                    factory = ViewModelFactory { ScheduleViewModel() }
+                )
+                val scheduleItems by scheduleViewModel.state.collectAsState()
+                ScheduleScreen(
+                    items = scheduleItems,
+                    onToggle = scheduleViewModel::toggle,
+                    onAdd = scheduleViewModel::add,
+                    onOpenDrawer = { drawerScope.launch { drawerState.open() } }
+                )
+            }
+
+            composable(ROUTE_SETTINGS) {
+                SettingsScreenV2(
+                    assistantConfigured = settingsState.assistantRuntimeId != null,
+                    notificationsEnabled = notificationsEnabled,
+                    onToggleNotifications = { enabled ->
+                        // Local UI toggle only — Android has no API to programmatically revoke
+                        // notification access, so turning this off is visual until the user
+                        // also disables notifications from system settings. TODO: reflect the
+                        // real system permission state instead of local-only UI state.
+                        notificationsEnabled = enabled
+                        if (enabled && android.os.Build.VERSION.SDK_INT >= 33) {
+                            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                        }
+                    },
+                    appVersion = appVersion,
+                    onOpenDrawer = { drawerScope.launch { drawerState.open() } },
+                    onOpenAssistantSettings = onOpenAssistantSettings,
+                    onOpenVoiceSettings = { navController.navigate(ROUTE_SETTINGS_VOICE) },
+                    onOpenProviderSettings = { navController.navigate(ROUTE_SETTINGS_PROVIDERS) },
+                    onOpenLocalRuntime = { navController.navigate(LOCAL_RUNTIME_MANAGEMENT_ROUTE) },
+                    onOpenRemoteConnection = { navController.navigate(ROUTE_REMOTE_CONNECTION) },
+                    onOpenWorkspaces = { navController.navigate(ROUTE_WORKSPACES) },
+                    onOpenDiagnostics = { navController.navigate(ROUTE_ACTIVITY) }
+                )
+            }
+
+            composable(ROUTE_SETTINGS_VOICE) {
+                VoiceSettingsScreen(
+                    ttsEnabled = settingsState.ttsEnabled,
+                    continuousConversation = settingsState.continuousConversation,
+                    onTtsChange = settingsViewModel::setTtsEnabled,
+                    onContinuousChange = settingsViewModel::setContinuousConversation,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+
+            composable(ROUTE_SETTINGS_PROVIDERS) {
+                ProviderSettingsScreen(
+                    credentialStatuses = settingsState.credentialStatuses,
+                    draftProviderId = settingsState.draftProviderId,
+                    draftApiKey = settingsState.draftApiKey,
+                    credentialMessage = settingsState.credentialMessage,
+                    onDraftProviderId = settingsViewModel::updateDraftProviderId,
+                    onDraftApiKey = settingsViewModel::updateDraftApiKey,
+                    onSaveApiKey = settingsViewModel::saveApiKey,
+                    onClearApiKey = settingsViewModel::clearApiKey,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+
+            composable(ROUTE_WORKSPACES) {
                 WorkspacesScreen(
                     state = workspaceState,
                     onSelectRuntime = workspaceViewModel::selectRuntime,
@@ -472,7 +605,7 @@ fun OpenCodeApp(
                 }
             }
 
-            composable(Destination.ACTIVITY.route) {
+            composable(ROUTE_ACTIVITY) {
                 ActivityScreen(
                     state = activityState,
                     onRefresh = activityViewModel::refresh,
@@ -482,7 +615,7 @@ fun OpenCodeApp(
                     },
                     onOpenSession = { id, title ->
                         pendingSession = id to title
-                        navController.navigate(Destination.CHAT.route)
+                        navController.navigate(ROUTE_CHAT) { launchSingleTop = true }
                     },
                     onPermission = activityViewModel::respondToPermission,
                     onRenameSession = activityViewModel::renameSession,
@@ -509,31 +642,10 @@ fun OpenCodeApp(
                         onRefresh = detailViewModel::refresh,
                         onContinueChat = {
                             pendingSession = session.id to session.title
-                            navController.navigate(Destination.CHAT.route)
+                            navController.navigate(ROUTE_CHAT) { launchSingleTop = true }
                         }
                     )
                 }
-            }
-
-            composable(Destination.SETTINGS.route) {
-                SettingsScreen(
-                    state = settingsState,
-                    onOpenAssistantSettings = onOpenAssistantSettings,
-                    onTtsChange = settingsViewModel::setTtsEnabled,
-                    onContinuousChange = settingsViewModel::setContinuousConversation,
-                    onDraftProviderId = settingsViewModel::updateDraftProviderId,
-                    onDraftApiKey = settingsViewModel::updateDraftApiKey,
-                    onSaveApiKey = settingsViewModel::saveApiKey,
-                    onClearApiKey = settingsViewModel::clearApiKey,
-                    onAssistantRuntime = settingsViewModel::setAssistantRuntimeId,
-                    onAssistantWorkspace = settingsViewModel::setAssistantWorkspacePath,
-                    onImportWorkspace = { workspaceImportLauncher.launch(null) },
-                    onRequestNotifications = {
-                        if (android.os.Build.VERSION.SDK_INT >= 33) {
-                            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                        }
-                    }
-                )
             }
         }
     }

--- a/app/src/main/java/com/opencode/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/opencode/android/ui/theme/Color.kt
@@ -2,14 +2,16 @@ package com.opencode.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val OpenCodeBackground = Color(0xFF0B1017)
-val OpenCodeSurface = Color(0xFF121A24)
-val OpenCodeSurfaceVariant = Color(0xFF1A2633)
-val OpenCodePrimary = Color(0xFF6EA8FE)
-val OpenCodeSecondary = Color(0xFF55C6C1)
-val OpenCodeSuccess = Color(0xFF62C58F)
-val OpenCodeWarning = Color(0xFFF2B766)
-val OpenCodeError = Color(0xFFFF7A86)
-val OpenCodeTextPrimary = Color(0xFFF2F5F9)
-val OpenCodeTextSecondary = Color(0xFFA9B6C5)
-val OpenCodeOutline = Color(0xFF304153)
+// OpenCode-styled dark theme: near-black background, dark gray surfaces,
+// thin gray outlines, and a restrained soft-blue accent.
+val OpenCodeBackground = Color(0xFF0A0C10)
+val OpenCodeSurface = Color(0xFF14171C)
+val OpenCodeSurfaceVariant = Color(0xFF1C2027)
+val OpenCodePrimary = Color(0xFF8AB4F8)
+val OpenCodeSecondary = Color(0xFF6FA8A3)
+val OpenCodeSuccess = Color(0xFF6FCF97)
+val OpenCodeWarning = Color(0xFFE3B341)
+val OpenCodeError = Color(0xFFF07178)
+val OpenCodeTextPrimary = Color(0xFFECEDEE)
+val OpenCodeTextSecondary = Color(0xFF9AA1AC)
+val OpenCodeOutline = Color(0xFF2A2F37)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -324,4 +324,122 @@
     <string name="install_step_installing_dev_tools">Gitと開発ツールを導入しています</string>
     <string name="install_step_activating_runtime">ランタイムを有効化しています</string>
     <string name="install_step_done">ローカルOpenCodeを導入しました</string>
+
+    <!-- Redesign: drawer -->
+    <string name="menu_description">メニュー</string>
+    <string name="drawer_search_description">検索</string>
+    <string name="drawer_recent_chats">最近のチャット</string>
+    <string name="drawer_pinned">ピン留め</string>
+    <string name="drawer_pinned_sample_1">重要な会話</string>
+    <string name="drawer_pinned_sample_2">プロジェクトのメモ</string>
+    <string name="drawer_features">機能</string>
+    <string name="drawer_plan_label">無料プラン</string>
+    <string name="drawer_user_email_placeholder">user@example.com</string>
+    <string name="drawer_time_just_now">たった今</string>
+    <string name="drawer_time_minutes_ago">%1$d分前</string>
+    <string name="drawer_time_hours_ago">%1$d時間前</string>
+    <string name="drawer_time_days_ago">%1$d日前</string>
+
+    <!-- Redesign: chat home -->
+    <string name="chat_home_title">チャット</string>
+    <string name="chat_build_headline">OpenCodeで開発を進める</string>
+    <string name="chat_build_subtitle">コードの実装、修正、レビューまで、何でも聞いてください。</string>
+    <string name="chat_message_placeholder">OpenCodeにメッセージを送る…</string>
+    <string name="suggestion_implement_title">関数の実装を手伝って</string>
+    <string name="suggestion_implement_subtitle">コードを書いて実装する</string>
+    <string name="suggestion_debug_title">バグの原因を調べて</string>
+    <string name="suggestion_debug_subtitle">問題を診断して修正する</string>
+    <string name="suggestion_organize_title">プロジェクトの構成を整理して</string>
+    <string name="suggestion_organize_subtitle">ファイルやフォルダを整理する</string>
+    <string name="attach_button_description">添付</string>
+    <string name="attach_menu_stub">ファイルを添付（準備中）</string>
+    <string name="session_history">セッション履歴</string>
+
+    <!-- Redesign: model & runtime picker -->
+    <string name="picker_title">モデルと実行先を選択</string>
+    <string name="picker_caption">使用するモデルと実行先を選びます。</string>
+    <string name="section_runtime">実行先</string>
+    <string name="section_model">モデル</string>
+    <string name="this_android">このAndroid</string>
+    <string name="picker_no_providers">接続済みのプロバイダがありません</string>
+
+    <!-- Redesign: onboarding -->
+    <string name="onboarding_welcome_title">OpenCodeへようこそ</string>
+    <string name="onboarding_subtitle">コードを書く・修正する・理解する。はじめるには、いずれか1つの実行パスを選ぶだけです。</string>
+    <string name="onboarding_recommended_badge">おすすめ</string>
+    <string name="onboarding_android_title">このAndroidで始める</string>
+    <string name="onboarding_android_desc">端末内でOpenCodeを直接実行します。</string>
+    <string name="onboarding_remote_title">PC・Macに接続する</string>
+    <string name="onboarding_remote_desc">既存のOpenCodeサーバーに接続します。</string>
+    <string name="onboarding_switch_note">どちらを選んでも、あとからもう一方を追加して切り替えることができます。</string>
+    <string name="onboarding_primary_button_android">Androidでセットアップを開始</string>
+    <string name="onboarding_primary_button_remote">PC・Macへ接続する</string>
+    <string name="onboarding_skip_link">後でリモート接続を追加</string>
+
+    <!-- Redesign: Android local setup -->
+    <string name="android_setup_title">このAndroidをセットアップ</string>
+    <string name="setup_step_download">ランタイムをダウンロード</string>
+    <string name="setup_step_provider">プロバイダを選択</string>
+    <string name="setup_step_apikey">APIキーを設定</string>
+    <string name="setup_step_test">接続テスト</string>
+    <string name="apikey_caption">APIキーはこの端末に安全に保存されます</string>
+    <string name="test_status_untested">未テスト</string>
+    <string name="test_status_testing">テスト中…</string>
+    <string name="test_status_success">接続に成功しました</string>
+    <string name="test_status_failure">接続に失敗しました</string>
+    <string name="run_connection_test_button">接続テストを実行</string>
+    <string name="setup_complete_button">完了</string>
+    <string name="provider_openai">OpenAI</string>
+    <string name="provider_google">Google</string>
+    <string name="provider_anthropic">Anthropic</string>
+    <string name="provider_ollama">Ollama</string>
+    <string name="provider_other">その他</string>
+
+    <!-- Redesign: remote connection -->
+    <string name="remote_connection_title">PC・Macに接続</string>
+    <string name="remote_step1_title">PCでOpenCodeを起動</string>
+    <string name="remote_step1_desc">PCでopencode serveを起動します。</string>
+    <string name="remote_step2_title">URLを入力またはQRで読み取り</string>
+    <string name="remote_step2_desc">サーバーのアドレスを入力するか、QRコードを読み取ります。</string>
+    <string name="remote_step3_title">接続を確認</string>
+    <string name="remote_step3_desc">保存する前に接続を確認します。</string>
+    <string name="remote_hint">PCのOpenCodeで「接続を許可」が有効になっていることを確認してください。</string>
+    <string name="remote_test_connection_button">接続をテスト</string>
+    <string name="remote_save_connection_button">この接続を保存</string>
+
+    <!-- Redesign: schedule -->
+    <string name="schedule_title">スケジュール</string>
+    <string name="schedule_subtitle">タスクの自動実行を管理します。</string>
+    <string name="filter_description">フィルター</string>
+    <string name="filter_all">すべて</string>
+    <string name="filter_enabled">有効</string>
+    <string name="filter_disabled">停止中</string>
+    <string name="new_schedule_button">+ 新規スケジュール</string>
+    <string name="schedule_create_dialog_title">新規スケジュール</string>
+    <string name="schedule_name_hint">名前</string>
+    <string name="schedule_time_hint">時刻 (例: 09:00)</string>
+    <string name="schedule_repeat_label">繰り返し</string>
+    <string name="schedule_repeat_daily">毎日</string>
+    <string name="schedule_repeat_weekly">毎週</string>
+
+    <!-- Redesign: settings V2 -->
+    <string name="section_assistant_settings">アシスタント設定</string>
+    <string name="section_system_settings">システム設定</string>
+    <string name="section_app_settings">アプリ設定</string>
+    <string name="settings_home_assistant_row">ホームアシスタント</string>
+    <string name="assistant_enabled_pill">有効</string>
+    <string name="assistant_disabled_pill">無効</string>
+    <string name="wake_word_row_title">ウェイクワード</string>
+    <string name="wake_word_value">OpenCode</string>
+    <string name="wake_word_stub_body">この機能は準備中です。</string>
+    <string name="voice_settings_row">音声設定</string>
+    <string name="provider_settings_row">プロバイダ設定</string>
+    <string name="settings_local_runtime_row">ローカルランタイム</string>
+    <string name="remote_connection_row">リモート接続</string>
+    <string name="settings_workspace_row">ワークスペース</string>
+    <string name="notifications_row">通知</string>
+    <string name="privacy_row">プライバシーとデータ</string>
+    <string name="privacy_stub_body">この機能は準備中です。</string>
+    <string name="diagnostics_row">診断・ログ</string>
+    <string name="app_info_row">アプリ情報</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,4 +324,122 @@
     <string name="install_step_installing_dev_tools">Installing Git and development tools</string>
     <string name="install_step_activating_runtime">Activating the runtime</string>
     <string name="install_step_done">Local OpenCode installed</string>
+
+    <!-- Redesign: drawer -->
+    <string name="menu_description">Menu</string>
+    <string name="drawer_search_description">Search</string>
+    <string name="drawer_recent_chats">Recent chats</string>
+    <string name="drawer_pinned">Pinned</string>
+    <string name="drawer_pinned_sample_1">Important conversation</string>
+    <string name="drawer_pinned_sample_2">Project notes</string>
+    <string name="drawer_features">Features</string>
+    <string name="drawer_plan_label">Free plan</string>
+    <string name="drawer_user_email_placeholder">user@example.com</string>
+    <string name="drawer_time_just_now">Just now</string>
+    <string name="drawer_time_minutes_ago">%1$d minutes ago</string>
+    <string name="drawer_time_hours_ago">%1$d hours ago</string>
+    <string name="drawer_time_days_ago">%1$d days ago</string>
+
+    <!-- Redesign: chat home -->
+    <string name="chat_home_title">Chat</string>
+    <string name="chat_build_headline">Build with OpenCode</string>
+    <string name="chat_build_subtitle">Ask anything — implement, fix, and review code together.</string>
+    <string name="chat_message_placeholder">Message OpenCode…</string>
+    <string name="suggestion_implement_title">Help me implement a function</string>
+    <string name="suggestion_implement_subtitle">Write and implement code</string>
+    <string name="suggestion_debug_title">Find the cause of a bug</string>
+    <string name="suggestion_debug_subtitle">Diagnose and fix issues</string>
+    <string name="suggestion_organize_title">Organize the project structure</string>
+    <string name="suggestion_organize_subtitle">Clean up files and folders</string>
+    <string name="attach_button_description">Attach</string>
+    <string name="attach_menu_stub">Attach file (coming soon)</string>
+    <string name="session_history">Session history</string>
+
+    <!-- Redesign: model & runtime picker -->
+    <string name="picker_title">Select model &amp; runtime</string>
+    <string name="picker_caption">Choose where to run and which model to use.</string>
+    <string name="section_runtime">Runtime</string>
+    <string name="section_model">Model</string>
+    <string name="this_android">This Android</string>
+    <string name="picker_no_providers">No connected providers yet</string>
+
+    <!-- Redesign: onboarding -->
+    <string name="onboarding_welcome_title">Welcome to OpenCode</string>
+    <string name="onboarding_subtitle">Write, fix, and understand code. To get started, just choose one execution path.</string>
+    <string name="onboarding_recommended_badge">Recommended</string>
+    <string name="onboarding_android_title">Start with this Android</string>
+    <string name="onboarding_android_desc">Run OpenCode directly on this device.</string>
+    <string name="onboarding_remote_title">Connect to a PC or Mac</string>
+    <string name="onboarding_remote_desc">Connect to an existing OpenCode server.</string>
+    <string name="onboarding_switch_note">Either way, you can add the other option later and switch anytime.</string>
+    <string name="onboarding_primary_button_android">Start setup on Android</string>
+    <string name="onboarding_primary_button_remote">Connect to a PC or Mac</string>
+    <string name="onboarding_skip_link">Add a remote connection later</string>
+
+    <!-- Redesign: Android local setup -->
+    <string name="android_setup_title">Set up this Android</string>
+    <string name="setup_step_download">Download runtime</string>
+    <string name="setup_step_provider">Choose a provider</string>
+    <string name="setup_step_apikey">Set API key</string>
+    <string name="setup_step_test">Test connection</string>
+    <string name="apikey_caption">Your API key is stored securely on this device</string>
+    <string name="test_status_untested">Not tested</string>
+    <string name="test_status_testing">Testing…</string>
+    <string name="test_status_success">Connection succeeded</string>
+    <string name="test_status_failure">Connection failed</string>
+    <string name="run_connection_test_button">Run connection test</string>
+    <string name="setup_complete_button">Done</string>
+    <string name="provider_openai">OpenAI</string>
+    <string name="provider_google">Google</string>
+    <string name="provider_anthropic">Anthropic</string>
+    <string name="provider_ollama">Ollama</string>
+    <string name="provider_other">Other</string>
+
+    <!-- Redesign: remote connection -->
+    <string name="remote_connection_title">Connect to PC/Mac</string>
+    <string name="remote_step1_title">Start OpenCode on your PC</string>
+    <string name="remote_step1_desc">Launch opencode serve on your computer.</string>
+    <string name="remote_step2_title">Enter URL or scan QR</string>
+    <string name="remote_step2_desc">Type in the server address, or scan its QR code.</string>
+    <string name="remote_step3_title">Verify connection</string>
+    <string name="remote_step3_desc">Run a quick health check before saving.</string>
+    <string name="remote_hint">Make sure \"Allow connections\" is enabled in OpenCode on your PC.</string>
+    <string name="remote_test_connection_button">Test connection</string>
+    <string name="remote_save_connection_button">Save this connection</string>
+
+    <!-- Redesign: schedule -->
+    <string name="schedule_title">Schedule</string>
+    <string name="schedule_subtitle">Manage automated task runs.</string>
+    <string name="filter_description">Filter</string>
+    <string name="filter_all">All</string>
+    <string name="filter_enabled">Enabled</string>
+    <string name="filter_disabled">Disabled</string>
+    <string name="new_schedule_button">+ New schedule</string>
+    <string name="schedule_create_dialog_title">New schedule</string>
+    <string name="schedule_name_hint">Name</string>
+    <string name="schedule_time_hint">Time (e.g. 09:00)</string>
+    <string name="schedule_repeat_label">Repeat</string>
+    <string name="schedule_repeat_daily">Daily</string>
+    <string name="schedule_repeat_weekly">Weekly</string>
+
+    <!-- Redesign: settings V2 -->
+    <string name="section_assistant_settings">Assistant settings</string>
+    <string name="section_system_settings">System settings</string>
+    <string name="section_app_settings">App settings</string>
+    <string name="settings_home_assistant_row">Home assistant</string>
+    <string name="assistant_enabled_pill">Enabled</string>
+    <string name="assistant_disabled_pill">Disabled</string>
+    <string name="wake_word_row_title">Wake word</string>
+    <string name="wake_word_value">OpenCode</string>
+    <string name="wake_word_stub_body">This feature is coming soon.</string>
+    <string name="voice_settings_row">Voice settings</string>
+    <string name="provider_settings_row">Provider settings</string>
+    <string name="settings_local_runtime_row">Local runtime</string>
+    <string name="remote_connection_row">Remote connection</string>
+    <string name="settings_workspace_row">Workspace</string>
+    <string name="notifications_row">Notifications</string>
+    <string name="privacy_row">Privacy &amp; data</string>
+    <string name="privacy_stub_body">This feature is coming soon.</string>
+    <string name="diagnostics_row">Diagnostics &amp; logs</string>
+    <string name="app_info_row">App info</string>
 </resources>


### PR DESCRIPTION
## 概要

下部5タブ構成を廃止し、ChatGPT アプリに近い「チャット中心 + 左ドロワー」構成へ全面再設計しました。ダークテーマは OpenCode らしいほぼ黒背景 + 濃グレーカード + 控えめブルーアクセントに統一しています。既存の ViewModel / runtime / data 層はそのまま流用し、UI 層のみを再構築しています。

## 主な変更

### ナビゲーション (`ui/OpenCodeApp.kt` 全面書き換え)
- `ModalNavigationDrawer` + `NavHost` 構成。起動時ルート = チャット
- 初回起動時のみオンボーディングを表示 (`SecureSettingsRepository.onboardingCompleted` で判定)
- ルート: `chat` / `onboarding` / `android-setup` / `remote-connection` / `schedule` / `settings` (+ `settings-voice`, `settings-providers`) / `workspaces` / `activity` + 既存の詳細ルート3つ
- 音声入力・通知権限・ワークスペースインポート・ランタイムハンドオフ等の既存ロジックは全て維持

### 新規画面
- **ChatHomeScreen**: 空状態(ロゴ + 提案カード3枚) + 丸型入力バー。下部チップは「モデル / エージェント / ワークスペース」のみ。実行先チップは常時表示しない
- **ModelAndRuntimePickerSheet**: モデルチップから開くボトムシート。「実行先 (このAndroid / リモート端末)」と「モデル」を1つの UI で選択。セッション中の実行先切り替えは既存ハンドオフ機構に接続
- **AppDrawerContent**: 新しいチャット / 最近のチャット / ピン留め / 機能リンク / アカウントフッター
- **OnboardingChoiceScreen**: 「このAndroidで始める(おすすめ)」主導線 + 「PC・Macに接続する」サブ導線。どちらか一方で開始可能
- **AndroidSetupScreen**: ランタイムDL → プロバイダ選択 → APIキー → 接続テスト の4ステップ。ローカルランタイムマネージャと APIキー保存に接続
- **RemoteConnectionScreen**: 3ステップガイド + 接続フォーム + QR追加 / LAN検索 / 接続テスト (既存 `ConnectionFormState` / `LanDiscovery` を流用)
- **SettingsScreenV2**: アシスタント設定 / システム設定 / アプリ設定 の3グループ。音声設定・プロバイダ設定は詳細画面に分離
- **ScheduleScreen + ScheduleViewModel**: フィルタチップ + ON/OFF トグル + 新規作成ダイアログ (インメモリ仮実装)

### テーマ
- `Color.kt` をほぼ黒背景 (#0A0C10) / 濃グレーサーフェス / ソフトブルー (#8AB4F8) に調整。トークン名は不変のため既存画面もそのまま動作

### 文字列
- 新規文字列 95 キーを `values/strings.xml` (英語) と `values-ja/strings.xml` (日本語) の両方に追加

## 未実装 / 仮実装箇所
- スケジュール機能はインメモリのみ (永続化・実行バックエンドなし)
- チャットの「+」添付メニューはスタブ
- Android セットアップの接続テストは簡易シミュレーション
- ウェイクワード / プライバシー行はスタブダイアログ
- 通知トグルはローカル UI 状態のみ
- ドロワーの検索・ピン留めはプレースホルダー

## 検証
- `:app:compileDebugKotlin` ✅
- `:app:testDebugUnitTest` ✅ (既存ユニットテスト全て成功)
- `:app:assembleDebug` ✅ (APK ビルド成功)

## 削除・非配線化
- 旧下部タブと `HomeScreen` / 旧 `OpenCodeChatScreen` はナビゲーションから外れましたが、共有コンポーネント (メッセージバブル等) は `ChatHomeScreen` から再利用されるためファイルは維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb46FTEcypQt9ZVaPwQnic

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb46FTEcypQt9ZVaPwQnic)_