### PR TITLE
fix: show favorites above recent models in the model picker

### DIFF
--- a/app/src/main/java/com/opencode/android/feature/chat/ModelAndRuntimePickerSheet.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ModelAndRuntimePickerSheet.kt
@@ -42,6 +42,8 @@ import com.opencode.android.core.api.OpenCodeProvider
 import com.opencode.android.runtime.RuntimeTarget
 import com.opencode.android.runtime.RuntimeType
 
+private const val MAX_RECENT_MODELS = 3
+
 /**
  * Bottom sheet opened from the chat screen's model chip. Lets the user pick both
  * the execution target (this Android device or a registered remote runtime) and
@@ -137,7 +139,7 @@ fun ModelAndRuntimePickerSheet(
                 val favoriteEntries =
                     providers.flatMap { provider ->
                         provider.models.values
-                            .filter { "$provider.id/${it.id}" in favoriteModelKeys }
+                            .filter { "${provider.id}/${it.id}" in favoriteModelKeys }
                             .filter { query.isBlank() || it.name.contains(query, true) || it.id.contains(query, true) }
                             .map { FavoriteEntry(provider, it) }
                     }.sortedBy { it.model.name.lowercase() }
@@ -151,6 +153,7 @@ fun ModelAndRuntimePickerSheet(
                         FavoriteEntry(provider, model)
                     }.filter { entry -> "${entry.provider.id}/${entry.model.id}" !in favoriteModelKeys }
                         .filter { query.isBlank() || it.model.name.contains(query, true) || it.model.id.contains(query, true) }
+                        .take(MAX_RECENT_MODELS)
 
                 if (favoriteEntries.isNotEmpty()) {
                     item {


### PR DESCRIPTION
## Summary
- The model picker's "お気に入り" (favorites) section never rendered because the filter built its lookup key as `"$provider.id/${it.id}"` — Kotlin only interpolates the identifier immediately after `$`, so this evaluated `provider.toString()` and appended the literal text `.id/...` instead of `provider.id`. That key never matched anything in `favoriteModelKeys`, so favorited models fell through to the "最近利用" (recent) list or the full provider list instead of appearing in their own section above recent.
- Fixed the key to `"${provider.id}/${it.id}"`, matching the correct pattern already used elsewhere in the same file (hidden models, recent-entries dedup, and the star toggle state).
- Also defensively capped the rendered recent list at 3 entries (`MAX_RECENT_MODELS`), matching the existing storage-side cap (`SecureSettingsRepository.MAX_RECENT_MODELS` / `AppPreferencesRepository.selectModel`'s `.take(3)`), so any previously-stored longer list can't display more than 3.
- Section order was already favorites-then-recent in the code; with the bug fixed, favorites now actually appear above recent as intended.

## Test plan
- [ ] Manual: star a model that is not in the recent list, reopen the model picker, confirm it appears under "お気に入り" above "最近利用".
- [ ] Manual: select more than 3 distinct models in sequence, confirm only the 3 most recent appear under "最近利用".
- Could not run a full Gradle build in this sandbox (no Android SDK available); change is a minimal, isolated fix to `ModelAndRuntimePickerSheet.kt`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JPgh5Ax2U4XfUzysSPKcgH)_