### PR TITLE
fix: 承認通知のクラッシュと質問ツールの行き止まりを解消

### DIFF
--- a/app/src/androidTest/java/com/opencode/android/ui/UiScreenshotInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/opencode/android/ui/UiScreenshotInstrumentedTest.kt
@@ -100,7 +100,10 @@ class UiScreenshotInstrumentedTest {
         capture("01-chat-empty", {
             composeRule.onNodeWithText("チャット").assertIsDisplayed()
             composeRule.onNodeWithText("GLM-5").assertIsDisplayed()
-            composeRule.onNodeWithText("project").assertIsDisplayed()
+            // The composer button row is attach / model / thinking … mic / send since the
+            // paseo redesign (5e290b1); the workspace chip it used to carry is gone, so this
+            // asserts the composer itself rather than a chip that no longer exists.
+            composeRule.onNodeWithText("OpenCodeにメッセージを送る…").assertIsDisplayed()
         }) { PreviewChatHome() }
 
         capture("02-runtime-not-ready", {

--- a/app/src/androidTest/java/com/opencode/android/ui/UiScreenshotInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/opencode/android/ui/UiScreenshotInstrumentedTest.kt
@@ -261,8 +261,11 @@ class UiScreenshotInstrumentedTest {
 
         capture("09-provider-settings", {
             composeRule.onNodeWithText("プロバイダ設定").assertIsDisplayed()
-            composeRule.onNodeWithText("保存済みの認証情報").assertIsDisplayed()
-            composeRule.onNodeWithText("APIキーを追加・更新").assertIsDisplayed()
+            // The screen is now a search field over provider rows; the old
+            // "saved credentials" / "add API key" sections are gone and their string
+            // resources are orphaned.
+            composeRule.onNodeWithText("プロバイダを検索…").assertIsDisplayed()
+            composeRule.onNodeWithText("Z.ai").assertIsDisplayed()
         }) {
             ProviderSettingsScreen(
                 state =
@@ -286,7 +289,10 @@ class UiScreenshotInstrumentedTest {
         capture("10-voice-settings", {
             composeRule.onNodeWithText("音声設定").assertIsDisplayed()
             composeRule.onNodeWithText("ウェイクワード").assertIsDisplayed()
-            composeRule.onNodeWithText("ウェイクワード用の追加パックはまだ導入されていません。").assertIsDisplayed()
+            // The "extra pack not installed" notice was dropped along with its string
+            // resource; the row now carries the invocation description instead.
+            composeRule.onNodeWithText("「Hey Mycroft」でハンズフリーでアシスタントを起動します。")
+                .assertIsDisplayed()
         }) {
             VoiceSettingsScreen(
                 ttsEnabled = true,

--- a/app/src/main/java/com/opencode/android/OpenCodeApplication.kt
+++ b/app/src/main/java/com/opencode/android/OpenCodeApplication.kt
@@ -186,6 +186,7 @@ class OpenCodeApplication : Application() {
                 registry = runtimeRegistry,
                 scope = applicationScope,
                 onPermissionAsked = notifications::notifyPermission,
+                onPermissionResolved = notifications::cancelPermission,
                 onSessionIdle = notifications::notifySessionComplete,
                 onSessionError = notifications::notifySessionError,
                 unreadStore = settings,

--- a/app/src/main/java/com/opencode/android/core/notification/PermissionActionReceiver.kt
+++ b/app/src/main/java/com/opencode/android/core/notification/PermissionActionReceiver.kt
@@ -3,12 +3,16 @@ package com.opencode.android.core.notification
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.opencode.android.OpenCodeApplication
+import com.opencode.android.R
 import com.opencode.android.runtime.PermissionResponse
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 
 class PermissionActionReceiver : BroadcastReceiver() {
     override fun onReceive(
@@ -23,22 +27,70 @@ class PermissionActionReceiver : BroadcastReceiver() {
 
         val response = PermissionResponse.entries.firstOrNull { it.apiValue == responseValue } ?: return
         val app = context.applicationContext as? OpenCodeApplication ?: return
+        val appContext = context.applicationContext
         val pending = goAsync()
         scope.launch {
             try {
-                val backend = app.runtimeRegistry.selected.value ?: return@launch
-                val ok = backend.respondToPermission(sessionId, permissionId, response, remember)
-                if (ok) {
-                    app.activityRepository.resolvePermission(permissionId)
-                    app.notifications.cancelPermission(permissionId)
-                }
+                // Everything below can throw: the local runtime may no longer be installed,
+                // the permission may already have been answered in-app (4xx), or the network
+                // may be down. An escaping exception here kills the whole process, so the tap
+                // on the notification must never propagate one.
+                val result =
+                    runCatching {
+                        // goAsync() only keeps the process alive for a short window, so a hung
+                        // request must not outlive it.
+                        withTimeout(RESPONSE_TIMEOUT_MS) {
+                            val backend =
+                                app.runtimeRegistry.selected.value
+                                    ?: error("No OpenCode runtime is selected")
+                            backend.respondToPermission(sessionId, permissionId, response, remember)
+                        }
+                    }
+
+                result
+                    .onSuccess { accepted ->
+                        if (accepted) {
+                            // Also cancels the notification and tells the chat screen to drop
+                            // the card for this request.
+                            runCatching { app.activityRepository.resolvePermission(permissionId) }
+                        } else {
+                            notifyFailure(app, appContext, sessionId)
+                        }
+                    }
+                    .onFailure { error ->
+                        Log.w(TAG, "Failed to answer permission $permissionId", error)
+                        notifyFailure(app, appContext, sessionId)
+                    }
             } finally {
-                pending.finish()
+                runCatching { pending.finish() }
             }
         }
     }
 
+    /**
+     * Leaves the approval notification in place (so the request is not silently lost) and tells
+     * the user the tap did not get through.
+     */
+    private fun notifyFailure(
+        app: OpenCodeApplication,
+        context: Context,
+        sessionId: String,
+    ) {
+        runCatching {
+            app.notifications.notifySessionError(
+                sessionId,
+                context.getString(R.string.notification_permission_failed),
+            )
+        }
+    }
+
     companion object {
-        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        private const val TAG = "PermissionAction"
+        private const val RESPONSE_TIMEOUT_MS = 8_000L
+        private val handler =
+            CoroutineExceptionHandler { _, error ->
+                Log.e(TAG, "Unhandled permission response failure", error)
+            }
+        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO + handler)
     }
 }

--- a/app/src/main/java/com/opencode/android/core/notification/RuntimeNotificationHelper.kt
+++ b/app/src/main/java/com/opencode/android/core/notification/RuntimeNotificationHelper.kt
@@ -33,7 +33,7 @@ class RuntimeNotificationHelper(private val context: Context) {
                 extras =
                     mapOf(
                         EXTRA_OPEN_ACTIVITY to true,
-                        EXTRA_SESSION_ID to request.sessionId,
+                        EXTRA_TARGET_SESSION_ID to request.sessionId,
                     ),
             )
         val allowOnce = permissionActionIntent(request, PermissionResponse.ONCE, remember = false)
@@ -75,7 +75,7 @@ class RuntimeNotificationHelper(private val context: Context) {
                 extras =
                     mapOf(
                         EXTRA_OPEN_CHAT to true,
-                        EXTRA_SESSION_ID to sessionId,
+                        EXTRA_TARGET_SESSION_ID to sessionId,
                     ),
             )
         val notification =
@@ -100,7 +100,7 @@ class RuntimeNotificationHelper(private val context: Context) {
                 extras =
                     mapOf(
                         EXTRA_OPEN_ACTIVITY to true,
-                        EXTRA_SESSION_ID to (sessionId.orEmpty()),
+                        EXTRA_TARGET_SESSION_ID to (sessionId.orEmpty()),
                     ),
             )
         val notification =
@@ -213,6 +213,9 @@ class RuntimeNotificationHelper(private val context: Context) {
         const val EXTRA_OPEN_ACTIVITY = "open_activity"
         const val EXTRA_OPEN_CHAT = "open_chat"
         const val EXTRA_SESSION_ID = "session_id"
+
+        /** The key [com.opencode.android.MainActivity] reads to jump straight to a session. */
+        const val EXTRA_TARGET_SESSION_ID = "target_session_id"
         const val EXTRA_PERMISSION_ID = "permission_id"
         const val EXTRA_PERMISSION_RESPONSE = "permission_response"
         const val EXTRA_PERMISSION_REMEMBER = "permission_remember"

--- a/app/src/main/java/com/opencode/android/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/opencode/android/data/repository/RuntimeActivityRepository.kt
@@ -47,6 +47,7 @@ class RuntimeActivityRepository(
     private val retryDelayMillis: Long = 2_000L,
     private val maxRetryDelayMillis: Long = 30_000L,
     private val onPermissionAsked: ((PermissionRequest) -> Unit)? = null,
+    private val onPermissionResolved: ((String) -> Unit)? = null,
     private val onSessionIdle: ((String) -> Unit)? = null,
     private val onSessionError: ((String?, String?) -> Unit)? = null,
     private val unreadStore: UnreadSessionStore? = null,
@@ -66,6 +67,14 @@ class RuntimeActivityRepository(
 
     private val mutableEvents = MutableSharedFlow<OpenCodeEvent>(extraBufferCapacity = 128)
     val events: SharedFlow<OpenCodeEvent> = mutableEvents.asSharedFlow()
+
+    /**
+     * Permission ids that have been answered somewhere in the app (notification action, activity
+     * screen, chat). OpenCode has no `permission.replied` event, so this is how other surfaces
+     * learn that a request they are still showing is already settled.
+     */
+    private val mutableResolvedPermissions = MutableSharedFlow<String>(extraBufferCapacity = 64)
+    val resolvedPermissions: SharedFlow<String> = mutableResolvedPermissions.asSharedFlow()
 
     init {
         scope.launch {
@@ -125,6 +134,8 @@ class RuntimeActivityRepository(
         mutableState.update { current ->
             current.copy(permissions = current.permissions.filterNot { it.id == permissionId })
         }
+        mutableResolvedPermissions.tryEmit(permissionId)
+        onPermissionResolved?.invoke(permissionId)
     }
 
     fun markSessionRead(sessionId: String) {

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
@@ -148,6 +148,7 @@ fun ChatHomeScreen(
     onSelectQuestionAnswer: (String, Int, String) -> Unit,
     onSubmitQuestion: (String) -> Unit,
     onCancelQuestion: (String) -> Unit = {},
+    onDismissQuestion: (String) -> Unit = {},
     autoAcceptPermissions: Boolean = false,
     onToggleAutoAccept: (Boolean) -> Unit = {},
     sendBehavior: String = "interrupt",
@@ -336,6 +337,7 @@ fun ChatHomeScreen(
                                     onAnswerSelected = onSelectQuestionAnswer,
                                     onSubmit = onSubmitQuestion,
                                     onCancel = onCancelQuestion,
+                                    onDismiss = onDismissQuestion,
                                 )
                             }
                             if (state.isThinking) {

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
@@ -147,6 +147,7 @@ fun ChatHomeScreen(
     onToggleFavorite: (String, String) -> Unit = { _, _ -> },
     onSelectQuestionAnswer: (String, Int, String) -> Unit,
     onSubmitQuestion: (String) -> Unit,
+    onCancelQuestion: (String) -> Unit = {},
     autoAcceptPermissions: Boolean = false,
     onToggleAutoAccept: (Boolean) -> Unit = {},
     sendBehavior: String = "interrupt",
@@ -334,6 +335,7 @@ fun ChatHomeScreen(
                                     question = question,
                                     onAnswerSelected = onSelectQuestionAnswer,
                                     onSubmit = onSubmitQuestion,
+                                    onCancel = onCancelQuestion,
                                 )
                             }
                             if (state.isThinking) {

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
@@ -825,9 +825,22 @@ class ChatViewModel(
     }
 
     /**
-     * Dismisses a question without answering it. OpenCode has no "declined" reply for the question
-     * tool, so the only honest way out is to stop the turn that is waiting on the answer — leaving
-     * the card up with no escape is what made answering feel mandatory.
+     * Hides the question card and leaves the turn alone, so the user can ignore the question and
+     * just keep typing. The request stays open on the OpenCode side; this only affects what the
+     * chat shows.
+     */
+    fun dismissQuestion(questionId: String) {
+        _uiState.update { state ->
+            state.copy(
+                pendingQuestions = state.pendingQuestions.filterNot { it.request.id == questionId },
+            )
+        }
+    }
+
+    /**
+     * Dismisses a question and stops the turn that is waiting on the answer. OpenCode has no
+     * "declined" reply for the question tool, so this is the way to end a turn outright rather
+     * than answering it — [dismissQuestion] is the lighter option that only clears the card.
      */
     fun cancelQuestion(questionId: String) {
         val pendingQuestion = _uiState.value.pendingQuestions.firstOrNull { it.request.id == questionId } ?: return

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
@@ -222,6 +222,7 @@ class ChatViewModel(
      * test clock advances through forever, so it stays off unless the real app asks for it.
      */
     private val monitorConnectionQuality: Boolean = false,
+    private val resolvedPermissionFlow: Flow<String>? = null,
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow(
@@ -248,6 +249,17 @@ class ChatViewModel(
     private val connectionMonitor = ConnectionQualityMonitor(viewModelScope)
 
     init {
+        // A permission answered from the notification (or the activity screen) never comes back
+        // as an event, so without this the chat keeps showing a card for a settled request.
+        resolvedPermissionFlow?.let { flow ->
+            viewModelScope.launch {
+                flow.collect { permissionId ->
+                    _uiState.update { state ->
+                        state.copy(permissions = state.permissions.filterNot { it.id == permissionId })
+                    }
+                }
+            }
+        }
         if (backend != null) {
             viewModelScope.launch {
                 // Only real transitions are reported, so merely opening an idle chat is not
@@ -809,6 +821,30 @@ class ChatViewModel(
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * Dismisses a question without answering it. OpenCode has no "declined" reply for the question
+     * tool, so the only honest way out is to stop the turn that is waiting on the answer — leaving
+     * the card up with no escape is what made answering feel mandatory.
+     */
+    fun cancelQuestion(questionId: String) {
+        val pendingQuestion = _uiState.value.pendingQuestions.firstOrNull { it.request.id == questionId } ?: return
+        _uiState.update { state ->
+            state.copy(
+                pendingQuestions = state.pendingQuestions.filterNot { it.request.id == questionId },
+            )
+        }
+        val currentBackend = backend ?: return
+        viewModelScope.launch {
+            runCatching { currentBackend.abortSession(pendingQuestion.request.sessionId) }
+                .onSuccess {
+                    _uiState.update { it.copy(isRunning = false, isThinking = false) }
+                }
+                .onFailure { error ->
+                    _uiState.update { it.copy(error = error.safeMessage()) }
+                }
         }
     }
 

--- a/app/src/main/java/com/opencode/android/feature/chat/QuestionCard.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/QuestionCard.kt
@@ -8,11 +8,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
@@ -33,6 +38,7 @@ fun QuestionCard(
     onAnswerSelected: (String, Int, String) -> Unit,
     onSubmit: (String) -> Unit,
     onCancel: (String) -> Unit = {},
+    onDismiss: (String) -> Unit = {},
 ) {
     Card(
         modifier =
@@ -45,9 +51,32 @@ fun QuestionCard(
             ),
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
+            // Closing the card leaves the turn running, so the question can simply be ignored and
+            // a normal message typed instead.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                IconButton(
+                    onClick = { onDismiss(question.request.id) },
+                    enabled = !question.isSubmitting,
+                    modifier =
+                        Modifier
+                            .size(28.dp)
+                            .testTag("question-dismiss-${question.request.id}"),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.question_dismiss),
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
             question.request.questions.forEachIndexed { index, prompt ->
                 val selectedAnswers = question.selectedAnswers.getOrElse(index) { emptyList() }
                 val optionLabels = prompt.options.map { it.label }.toSet()

--- a/app/src/main/java/com/opencode/android/feature/chat/QuestionCard.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/QuestionCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +32,7 @@ fun QuestionCard(
     question: PendingQuestionUi,
     onAnswerSelected: (String, Int, String) -> Unit,
     onSubmit: (String) -> Unit,
+    onCancel: (String) -> Unit = {},
 ) {
     Card(
         modifier =
@@ -98,17 +100,27 @@ fun QuestionCard(
                         }
                     }
 
-                    if (prompt.options.isEmpty() || prompt.placeholder != null) {
-                        OutlinedTextField(
-                            value = fallbackText,
-                            onValueChange = { onAnswerSelected(question.request.id, index, it) },
-                            modifier = Modifier.fillMaxWidth(),
-                            placeholder = {
-                                Text(prompt.placeholder ?: stringResource(R.string.message_hint))
-                            },
-                            singleLine = !question.request.multiple,
+                    // Always offered, including alongside options: the presented choices are not
+                    // always exhaustive, and there was previously no way to answer anything else.
+                    if (prompt.options.isNotEmpty()) {
+                        Text(
+                            text = stringResource(R.string.question_free_text_label),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
+                    OutlinedTextField(
+                        value = fallbackText,
+                        onValueChange = { onAnswerSelected(question.request.id, index, it) },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .testTag("question-free-text-${question.request.id}-$index"),
+                        placeholder = {
+                            Text(prompt.placeholder ?: stringResource(R.string.message_hint))
+                        },
+                        singleLine = !question.request.multiple,
+                    )
                 }
             }
 
@@ -122,18 +134,28 @@ fun QuestionCard(
 
             Spacer(Modifier.height(2.dp))
 
-            Button(
-                onClick = { onSubmit(question.request.id) },
-                enabled = question.canSubmit && !question.isSubmitting,
-                modifier =
-                    Modifier
-                        .align(Alignment.End)
-                        .testTag("question-submit-${question.request.id}"),
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (question.isSubmitting) {
-                    CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
-                } else {
-                    Text(stringResource(R.string.continue_label))
+                TextButton(
+                    onClick = { onCancel(question.request.id) },
+                    enabled = !question.isSubmitting,
+                    modifier = Modifier.testTag("question-cancel-${question.request.id}"),
+                ) {
+                    Text(stringResource(R.string.question_cancel))
+                }
+                Button(
+                    onClick = { onSubmit(question.request.id) },
+                    enabled = question.canSubmit && !question.isSubmitting,
+                    modifier = Modifier.testTag("question-submit-${question.request.id}"),
+                ) {
+                    if (question.isSubmitting) {
+                        CircularProgressIndicator(modifier = Modifier.height(18.dp), strokeWidth = 2.dp)
+                    } else {
+                        Text(stringResource(R.string.continue_label))
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/opencode/android/ui/OpenCodeApp.kt
+++ b/app/src/main/java/com/opencode/android/ui/OpenCodeApp.kt
@@ -690,6 +690,7 @@ fun OpenCodeApp(
                         onSelectQuestionAnswer = chatViewModel::selectQuestionAnswer,
                         onSubmitQuestion = chatViewModel::submitQuestion,
                         onCancelQuestion = chatViewModel::cancelQuestion,
+                        onDismissQuestion = chatViewModel::dismissQuestion,
                         autoAcceptPermissions = settingsState.autoAcceptPermissions,
                         onToggleAutoAccept = settingsViewModel::setAutoAcceptPermissions,
                         onSendMessage = chatViewModel::sendMessage,

--- a/app/src/main/java/com/opencode/android/ui/OpenCodeApp.kt
+++ b/app/src/main/java/com/opencode/android/ui/OpenCodeApp.kt
@@ -229,6 +229,7 @@ fun OpenCodeApp(
                             }
                         },
                         monitorConnectionQuality = true,
+                        resolvedPermissionFlow = app.activityRepository.resolvedPermissions,
                     )
                 },
         )
@@ -688,6 +689,7 @@ fun OpenCodeApp(
                         onToggleFavorite = settingsViewModel::toggleFavoriteModel,
                         onSelectQuestionAnswer = chatViewModel::selectQuestionAnswer,
                         onSubmitQuestion = chatViewModel::submitQuestion,
+                        onCancelQuestion = chatViewModel::cancelQuestion,
                         autoAcceptPermissions = settingsState.autoAcceptPermissions,
                         onToggleAutoAccept = settingsViewModel::setAutoAcceptPermissions,
                         onSendMessage = chatViewModel::sendMessage,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">الجلسة %1$s خاملة</string>
     <string name="notification_error_title">خطأ في OpenCode</string>
     <string name="notification_error_body">فشلت جلسة</string>
+    <string name="notification_permission_failed">تعذّر إرسال الموافقة. افتح التطبيق وحاول مرة أخرى.</string>
     <string name="provider_credentials">اتصالات الموفرين</string>
     <string name="provider_credentials_help">اتصل بالموفرين من خلال بيئة تشغيل OpenCode المحددة. يتم توفير طرق تسجيل الدخول المتاحة بواسطة OpenCode.</string>
     <string name="provider_id_hint">معرف الموفر (مثال: openai)</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">جارٍ الاتصال…</string>
     <string name="provider_auth_failed">فشلت مصادقة الموفر. حاول مرة أخرى.</string>
     <string name="continue_label">متابعة</string>
+    <string name="question_free_text_label">أخرى (اكتب إجابتك)</string>
+    <string name="question_cancel">الإجابة لاحقًا (إيقاف)</string>
     <string name="assistant_runtime">بيئة تشغيل المساعد</string>
     <string name="assistant_workspace">مسار مساحة عمل المساعد</string>
     <string name="import_workspace_folder">استيراد مجلد إلى مساحة العمل المحلية</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">متابعة</string>
     <string name="question_free_text_label">أخرى (اكتب إجابتك)</string>
     <string name="question_cancel">الإجابة لاحقًا (إيقاف)</string>
+    <string name="question_dismiss">إغلاق السؤال</string>
     <string name="assistant_runtime">بيئة تشغيل المساعد</string>
     <string name="assistant_workspace">مسار مساحة عمل المساعد</string>
     <string name="import_workspace_folder">استيراد مجلد إلى مساحة العمل المحلية</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">Continuar</string>
     <string name="question_free_text_label">Otro (escribe tu respuesta)</string>
     <string name="question_cancel">Responder después (detener)</string>
+    <string name="question_dismiss">Cerrar la pregunta</string>
     <string name="assistant_runtime">Entorno de ejecución del asistente</string>
     <string name="assistant_workspace">Ruta del espacio de trabajo del asistente</string>
     <string name="import_workspace_folder">Importar carpeta al espacio de trabajo local</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">La sesión %1$s está inactiva</string>
     <string name="notification_error_title">Error de OpenCode</string>
     <string name="notification_error_body">Una sesión falló</string>
+    <string name="notification_permission_failed">No se pudo enviar la aprobación. Abre la app e inténtalo de nuevo.</string>
     <string name="provider_credentials">Conexiones de proveedores</string>
     <string name="provider_credentials_help">Conecta proveedores a través del entorno de ejecución OpenCode seleccionado. Los métodos de inicio de sesión disponibles son proporcionados por OpenCode.</string>
     <string name="provider_id_hint">ID del proveedor (ej. openai)</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">Conectando…</string>
     <string name="provider_auth_failed">La autenticación del proveedor falló. Inténtalo de nuevo.</string>
     <string name="continue_label">Continuar</string>
+    <string name="question_free_text_label">Otro (escribe tu respuesta)</string>
+    <string name="question_cancel">Responder después (detener)</string>
     <string name="assistant_runtime">Entorno de ejecución del asistente</string>
     <string name="assistant_workspace">Ruta del espacio de trabajo del asistente</string>
     <string name="import_workspace_folder">Importar carpeta al espacio de trabajo local</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">Continuer</string>
     <string name="question_free_text_label">Autre (saisissez votre réponse)</string>
     <string name="question_cancel">Répondre plus tard (arrêter)</string>
+    <string name="question_dismiss">Fermer la question</string>
     <string name="assistant_runtime">Environnement d\'exécution de l\'assistant</string>
     <string name="assistant_workspace">Chemin de l\'espace de travail de l\'assistant</string>
     <string name="import_workspace_folder">Importer un dossier dans l\'espace de travail local</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">La session %1$s est inactive</string>
     <string name="notification_error_title">Erreur OpenCode</string>
     <string name="notification_error_body">Une session a échoué</string>
+    <string name="notification_permission_failed">Impossible d\'envoyer l\'approbation. Ouvrez l\'application et réessayez.</string>
     <string name="provider_credentials">Connexions des fournisseurs</string>
     <string name="provider_credentials_help">Connectez les fournisseurs via l\'environnement d\'exécution OpenCode sélectionné. Les méthodes de connexion disponibles sont fournies par OpenCode.</string>
     <string name="provider_id_hint">ID du fournisseur (ex. openai)</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">Connexion…</string>
     <string name="provider_auth_failed">L\'authentification du fournisseur a échoué. Réessayez.</string>
     <string name="continue_label">Continuer</string>
+    <string name="question_free_text_label">Autre (saisissez votre réponse)</string>
+    <string name="question_cancel">Répondre plus tard (arrêter)</string>
     <string name="assistant_runtime">Environnement d\'exécution de l\'assistant</string>
     <string name="assistant_workspace">Chemin de l\'espace de travail de l\'assistant</string>
     <string name="import_workspace_folder">Importer un dossier dans l\'espace de travail local</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">続ける</string>
     <string name="question_free_text_label">その他（自由入力）</string>
     <string name="question_cancel">回答せず中断</string>
+    <string name="question_dismiss">質問を閉じる</string>
     <string name="assistant_runtime">アシスト実行先</string>
     <string name="assistant_workspace">アシスト作業フォルダ</string>
     <string name="import_workspace_folder">フォルダをローカル作業領域へ取り込む</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">セッション %1$s が待機中です</string>
     <string name="notification_error_title">OpenCodeエラー</string>
     <string name="notification_error_body">セッションが失敗しました</string>
+    <string name="notification_permission_failed">承認を送信できませんでした。アプリを開いてもう一度お試しください。</string>
     <string name="provider_credentials">プロバイダー接続</string>
     <string name="provider_credentials_help">選択中のOpenCode実行先を通じて接続します。利用可能なログイン方法はOpenCodeから取得します。</string>
     <string name="provider_id_hint">プロバイダーID（例: openai）</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">接続中…</string>
     <string name="provider_auth_failed">プロバイダー認証に失敗しました。もう一度お試しください。</string>
     <string name="continue_label">続ける</string>
+    <string name="question_free_text_label">その他（自由入力）</string>
+    <string name="question_cancel">回答せず中断</string>
     <string name="assistant_runtime">アシスト実行先</string>
     <string name="assistant_workspace">アシスト作業フォルダ</string>
     <string name="import_workspace_folder">フォルダをローカル作業領域へ取り込む</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">Continuar</string>
     <string name="question_free_text_label">Outro (digite sua resposta)</string>
     <string name="question_cancel">Responder depois (parar)</string>
+    <string name="question_dismiss">Fechar a pergunta</string>
     <string name="assistant_runtime">Ambiente de execução do assistente</string>
     <string name="assistant_workspace">Caminho do espaço de trabalho do assistente</string>
     <string name="import_workspace_folder">Importar pasta para o espaço de trabalho local</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">A sessão %1$s está ociosa</string>
     <string name="notification_error_title">Erro do OpenCode</string>
     <string name="notification_error_body">Uma sessão falhou</string>
+    <string name="notification_permission_failed">Não foi possível enviar a aprovação. Abra o app e tente novamente.</string>
     <string name="provider_credentials">Conexões de provedores</string>
     <string name="provider_credentials_help">Conecte provedores através do ambiente de execução OpenCode selecionado. Os métodos de login disponíveis são fornecidos pelo OpenCode.</string>
     <string name="provider_id_hint">ID do provedor (ex. openai)</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">Conectando…</string>
     <string name="provider_auth_failed">A autenticação do provedor falhou. Tente novamente.</string>
     <string name="continue_label">Continuar</string>
+    <string name="question_free_text_label">Outro (digite sua resposta)</string>
+    <string name="question_cancel">Responder depois (parar)</string>
     <string name="assistant_runtime">Ambiente de execução do assistente</string>
     <string name="assistant_workspace">Caminho do espaço de trabalho do assistente</string>
     <string name="import_workspace_folder">Importar pasta para o espaço de trabalho local</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">Продолжить</string>
     <string name="question_free_text_label">Другое (введите свой ответ)</string>
     <string name="question_cancel">Ответить позже (остановить)</string>
+    <string name="question_dismiss">Закрыть вопрос</string>
     <string name="assistant_runtime">Среда выполнения ассистента</string>
     <string name="assistant_workspace">Путь к рабочему пространству ассистента</string>
     <string name="import_workspace_folder">Импортировать папку в локальное рабочее пространство</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">Сессия %1$s бездействует</string>
     <string name="notification_error_title">Ошибка OpenCode</string>
     <string name="notification_error_body">Сессия завершилась с ошибкой</string>
+    <string name="notification_permission_failed">Не удалось отправить подтверждение. Откройте приложение и попробуйте снова.</string>
     <string name="provider_credentials">Подключения провайдеров</string>
     <string name="provider_credentials_help">Подключайте провайдеров через выбранную среду выполнения OpenCode. Доступные способы входа предоставляются OpenCode.</string>
     <string name="provider_id_hint">ID провайдера (напр. openai)</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">Подключение…</string>
     <string name="provider_auth_failed">Аутентификация провайдера не удалась. Попробуйте снова.</string>
     <string name="continue_label">Продолжить</string>
+    <string name="question_free_text_label">Другое (введите свой ответ)</string>
+    <string name="question_cancel">Ответить позже (остановить)</string>
     <string name="assistant_runtime">Среда выполнения ассистента</string>
     <string name="assistant_workspace">Путь к рабочему пространству ассистента</string>
     <string name="import_workspace_folder">Импортировать папку в локальное рабочее пространство</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">会话 %1$s 处于空闲状态</string>
     <string name="notification_error_title">OpenCode 错误</string>
     <string name="notification_error_body">会话失败</string>
+    <string name="notification_permission_failed">无法发送授权。请打开应用后重试。</string>
     <string name="provider_credentials">提供商连接</string>
     <string name="provider_credentials_help">通过所选的 OpenCode 运行时连接提供商。可用的登录方式由 OpenCode 提供。</string>
     <string name="provider_id_hint">提供商 ID（例如 openai）</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">正在连接…</string>
     <string name="provider_auth_failed">提供商身份验证失败。请重试。</string>
     <string name="continue_label">继续</string>
+    <string name="question_free_text_label">其他（自行输入答案）</string>
+    <string name="question_cancel">稍后回答（停止）</string>
     <string name="assistant_runtime">助手运行时</string>
     <string name="assistant_workspace">助手工作区路径</string>
     <string name="import_workspace_folder">将文件夹导入本地工作区</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">继续</string>
     <string name="question_free_text_label">其他（自行输入答案）</string>
     <string name="question_cancel">稍后回答（停止）</string>
+    <string name="question_dismiss">关闭问题</string>
     <string name="assistant_runtime">助手运行时</string>
     <string name="assistant_workspace">助手工作区路径</string>
     <string name="import_workspace_folder">将文件夹导入本地工作区</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="continue_label">Continue</string>
     <string name="question_free_text_label">Other (type your own answer)</string>
     <string name="question_cancel">Answer later (stop)</string>
+    <string name="question_dismiss">Dismiss question</string>
     <string name="assistant_runtime">Assistant runtime</string>
     <string name="assistant_workspace">Assistant workspace path</string>
     <string name="import_workspace_folder">Import folder into local workspace</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_complete_body">Session %1$s is idle</string>
     <string name="notification_error_title">OpenCode error</string>
     <string name="notification_error_body">A session failed</string>
+    <string name="notification_permission_failed">Could not send the approval. Open the app and try again.</string>
     <string name="provider_credentials">Provider connections</string>
     <string name="provider_credentials_help">Connect providers through the selected OpenCode runtime. Available sign-in methods are supplied by OpenCode.</string>
     <string name="provider_id_hint">Provider id (e.g. openai)</string>
@@ -130,6 +131,8 @@
     <string name="provider_auth_in_progress">Connecting…</string>
     <string name="provider_auth_failed">Provider authentication failed. Try again.</string>
     <string name="continue_label">Continue</string>
+    <string name="question_free_text_label">Other (type your own answer)</string>
+    <string name="question_cancel">Answer later (stop)</string>
     <string name="assistant_runtime">Assistant runtime</string>
     <string name="assistant_workspace">Assistant workspace path</string>
     <string name="import_workspace_folder">Import folder into local workspace</string>

--- a/app/src/test/java/com/opencode/android/data/repository/RuntimeActivityRepositoryTest.kt
+++ b/app/src/test/java/com/opencode/android/data/repository/RuntimeActivityRepositoryTest.kt
@@ -21,9 +21,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -195,6 +197,41 @@ class RuntimeActivityRepositoryTest {
 
             repository.markSessionRead("ses_old")
             assertTrue(unread.unreadSessionIds.isEmpty())
+        }
+
+    @Test
+    fun `resolving a permission cancels its notification and tells other surfaces`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val cancelled = mutableListOf<String>()
+            val repository =
+                RuntimeActivityRepository(
+                    registry = registry,
+                    scope = TestScope(dispatcher),
+                    onPermissionResolved = { cancelled += it },
+                )
+            val observed = mutableListOf<String>()
+            val collector =
+                launch(dispatcher) {
+                    repository.resolvedPermissions.collect { observed += it }
+                }
+            // runCurrent, not advanceUntilIdle: the event stream retries with a backoff delay
+            // forever, so advancing virtual time here would never go idle.
+            runCurrent()
+
+            repository.resolvePermission("perm-1")
+            runCurrent()
+
+            assertEquals("notification cancel callback", listOf("perm-1"), cancelled)
+            assertEquals("resolvedPermissions subscribers", listOf("perm-1"), observed)
+            collector.cancel()
         }
 
     private class FakeUnreadStore(

--- a/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelQuestionTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelQuestionTest.kt
@@ -172,6 +172,27 @@ class ChatViewModelQuestionTest {
         }
 
     @Test
+    fun `dismissing a question only hides the card and leaves the turn running`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+            backend.events.emit(
+                OpenCodeEvent.QuestionAsked(request(id = "q-1", sessionId = "session-1")),
+            )
+            advanceUntilIdle()
+
+            viewModel.dismissQuestion("q-1")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.pendingQuestions.isEmpty())
+            assertTrue(backend.abortedSessions.isEmpty())
+            assertTrue(backend.answeredQuestions.isEmpty())
+        }
+
+    @Test
     fun `cancelling a question drops the card and stops the waiting turn`() =
         runTest(dispatcher) {
             val backend = FakeBackend()

--- a/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelQuestionTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelQuestionTest.kt
@@ -142,6 +142,58 @@ class ChatViewModelQuestionTest {
             assertFalse(pending.isSubmitting)
         }
 
+    @Test
+    fun `free text answer is accepted even when the question offers options`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+            backend.events.emit(
+                OpenCodeEvent.QuestionAsked(
+                    request(
+                        id = "q-1",
+                        sessionId = "session-1",
+                        options = listOf("src", "docs"),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.selectQuestionAnswer("q-1", 0, "neither, use scripts/")
+            assertTrue(viewModel.uiState.value.pendingQuestions.single().canSubmit)
+
+            viewModel.submitQuestion("q-1")
+            advanceUntilIdle()
+
+            assertEquals(listOf(listOf("neither, use scripts/")), backend.answeredQuestions.single().answers)
+            assertTrue(viewModel.uiState.value.pendingQuestions.isEmpty())
+        }
+
+    @Test
+    fun `cancelling a question drops the card and stops the waiting turn`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+            backend.events.emit(
+                OpenCodeEvent.QuestionAsked(request(id = "q-1", sessionId = "session-1")),
+            )
+            advanceUntilIdle()
+            assertEquals("q-1", viewModel.uiState.value.pendingQuestions.single().request.id)
+
+            viewModel.cancelQuestion("q-1")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.pendingQuestions.isEmpty())
+            assertEquals(listOf("session-1"), backend.abortedSessions)
+            assertTrue(backend.answeredQuestions.isEmpty())
+            assertFalse(viewModel.uiState.value.isRunning)
+        }
+
     private fun request(
         id: String,
         sessionId: String,
@@ -171,6 +223,7 @@ class ChatViewModelQuestionTest {
         override val kind: BackendKind = BackendKind.REMOTE
         val events = MutableSharedFlow<OpenCodeEvent>(extraBufferCapacity = 20)
         val answeredQuestions = mutableListOf<AnswerRecord>()
+        val abortedSessions = mutableListOf<String>()
 
         override suspend fun health(): OpenCodeHealth = OpenCodeHealth(true, "test")
 
@@ -198,7 +251,10 @@ class ChatViewModelQuestionTest {
             request: PromptRequest,
         ) = Unit
 
-        override suspend fun abortSession(sessionId: String): Boolean = true
+        override suspend fun abortSession(sessionId: String): Boolean {
+            abortedSessions += sessionId
+            return true
+        }
 
         override suspend fun respondToPermission(
             sessionId: String,

--- a/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelTest.kt
@@ -450,6 +450,38 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun `permission answered from the notification removes the chat card`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val resolved = MutableSharedFlow<String>(extraBufferCapacity = 8)
+            val viewModel = ChatViewModel(backend, resolvedPermissionFlow = resolved)
+            advanceUntilIdle()
+            viewModel.sendMessage("Check git")
+            advanceUntilIdle()
+
+            backend.events.emit(
+                OpenCodeEvent.PermissionAsked(
+                    PermissionRequest(
+                        id = "perm1",
+                        sessionId = "s1",
+                        permission = "bash",
+                        patterns = listOf("git status"),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+            assertEquals("perm1", viewModel.uiState.value.permissions.single().id)
+
+            // OpenCode emits no "permission.replied" event, so the notification receiver
+            // announces the resolution through this flow instead.
+            resolved.emit("perm1")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.permissions.isEmpty())
+            assertTrue(backend.permissionResponses.isEmpty())
+        }
+
+    @Test
     fun `history load maps tool parts alongside text parts`() =
         runTest(dispatcher) {
             val backend = FakeBackend()


### PR DESCRIPTION
## 対象の不具合

1. **承認ツールの通知で「許可」を押すとクラッシュする**
2. **質問ツールに回答する以外の選択肢がない / 自由記入の回答ができない**

## 1. 承認通知のクラッシュ

### 原因

`PermissionActionReceiver` は通知アクションを受けて `respondToPermission` を呼びますが、素の `scope.launch { try { … } finally { … } }` の中で実行していました（`catch` なし）。この経路は現実的な失敗が全部例外になります。

- `LocalOpenCodeBackend.delegate()` — Android ローカルランタイム未インストール時に `IllegalStateException`
- `OpenCodeApiClient.respondPermission` — 4xx（**アプリ内で既に回答済みの承認**が最も多い）や通信断で `OpenCodeApiException`

`SupervisorJob` スコープに `CoroutineExceptionHandler` もないため、例外がコルーチンの外へ抜けてスレッドの既定ハンドラに到達し、**プロセスごと落ちて**いました。

### 修正

- 処理全体を `runCatching` で包み、スコープに `CoroutineExceptionHandler` を付与
- `goAsync()` の生存時間に合わせて **8秒のタイムアウト**を設定（応答が固まってもブロードキャスト枠を超えない）
- `pending.finish()` の二重呼び出しでも落ちないよう保護

### 4xx を誘発していた「消えない通知」も修正

承認をアプリ内で回答しても通知が残るため、後からその通知を押すと確実に 4xx → クラッシュしていました。

- どこで回答しても `RuntimeActivityRepository.resolvePermission` を通り、そこで**通知をキャンセル**するようにしました
- OpenCode には `permission.replied` イベントが存在しないため、新設の `resolvedPermissions` フローで解決済み ID を配信し、**チャット画面に残っていた承認カードも消える**ようにしました
- 応答が本当に失敗した場合は承認通知を残したまま、「送信できなかった」ことを伝える通知を出します

### ついでに直した通知タップの不整合

通知の Intent はセッション ID を `session_id` で渡していましたが、`MainActivity` が読むキーは `target_session_id` でした。そのため**通知本体をタップしても該当セッションへ飛ばない**状態だったので、Activity 向け Intent は Activity が読むキーを使うようにしました。

## 2. 質問ツール

### 自由記入がなかった

`QuestionCard` は `prompt.options.isEmpty() || prompt.placeholder != null` のときだけテキスト入力を描画していました。つまり**選択肢付きの質問には選択肢以外を答える手段がありませんでした**。

常に自由入力欄を出すようにし、選択肢がある場合は「その他（自由入力）」ラベルを添えています。回答の正規化ロジック（`updateQuestionAnswerSelection` / `sanitizeQuestionAnswer`）は元から選択肢と併存する自由入力を扱えるため、ロジック側の変更は不要でした。

### 回答する以外の選択肢がなかった

カードには「続ける」ボタンしかなく、回答するまで無効。閉じる手段もありませんでした。逃げ道を2つ用意しています。

| 操作 | 回答 | ターン | 用途 |
|---|---|---|---|
| **×**（カード右上） | 送らない | **走ったまま** | 質問を無視して普通にメッセージを送りたいとき |
| **回答せず中断** | 送らない | 停止（`abortSession`） | このターンをやめたいとき |
| **続ける** | 送る | 継続 | 通常の回答 |

× は画面からカードを消すだけで、OpenCode 側には何も送りません。質問 API に「拒否」応答が無いため、ターンを終わらせたい場合は中断が唯一の正直な手段になります。

## 検証

- `./gradlew :app:testDebugUnitTest` — **250件成功 / 失敗0**
- `./gradlew :app:lintDebug :app:assembleDebug detekt spotlessCheck` — 成功
- CI 全チェック緑（test-and-build / capture / commitlint / check-translations）

追加したテスト:

- `dismissing a question only hides the card and leaves the turn running`
- `cancelling a question drops the card and stops the waiting turn`
- `free text answer is accepted even when the question offers options`
- `resolving a permission cancels its notification and tells other surfaces`
- `permission answered from the notification removes the chat card`

実機・エミュレータでの動作確認は未実施です（この環境にエミュレータがありません）。通知アクションからの承認と、選択肢付き質問への自由記入・× での無視は端末での確認をお願いします。

## 付随して直したCI（本題とは別）

`capture`（エミュレータスクリーンショット）は **7/23 以降どのPRでも失敗し続けていました**。`UiScreenshotInstrumentedTest` が、UI改修で削除された要素を検証したままだったためです。参照コードが1つも残っていない孤児リソースを見ていたので、現在描画されているものへ差し替えました。

- `01-chat-empty` — ワークスペースチップ（`5e290b1` で削除）→ コンポーザーのプレースホルダー
- `09-provider-settings` — 「保存済みの認証情報」「APIキーを追加・更新」（画面刷新で消滅）→ 検索欄とプロバイダ行
- `10-voice-settings` — 「ウェイクワード用の追加パックはまだ導入されていません。」（削除済み）→ ウェイクワード行の説明文

これで #80 以降で初めて `capture` が緑になりました。

## 補足

新規文字列4件は `values` / `values-ja` に加え、既存の ar / es / fr / pt-rBR / ru / zh-rCN すべてに追加済みです（キー欠落なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3eN8AmoAcBDCTEeMTY3ba