### PR TITLE
ci: i18nチェックを実際に落ちるようにし、誰も見ないカバレッジを削除

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -75,16 +75,6 @@ jobs:
         if: github.event_name == 'push'
         run: ./gradlew :app:assembleRelease
 
-      - name: Generate coverage report
-        run: ./gradlew :app:jacocoTestReport
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-coverage-report
-          path: app/build/reports/jacoco/
-          if-no-files-found: error
-
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -26,7 +26,7 @@ jobs:
 
             if [ -n "$missing" ]; then
               count=$(echo "$missing" | wc -l | tr -d ' ')
-              echo "::warning file=$file::[$lang] Missing $count translation(s): $(echo $missing | tr '\n' ' ')"
+              echo "::error file=$file::[$lang] Missing $count translation(s): $(echo $missing | tr '\n' ' ')"
               MISSING_FOUND=1
             fi
 
@@ -38,7 +38,9 @@ jobs:
 
           if [ "$MISSING_FOUND" -eq 1 ]; then
             echo ""
-            echo "Some translations are incomplete. See warnings above."
-          else
-            echo "All translations are complete."
+            echo "Some translations are incomplete. See the errors above."
+            echo "Add the missing keys to every values-*/strings.xml, or remove them from the source."
+            exit 1
           fi
+
+          echo "All translations are complete."

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "app/src/main/res/values*/strings.xml"
+      # Without this, a change to the check itself never runs the check.
+      - ".github/workflows/i18n-check.yml"
 
 jobs:
   check-translations:

--- a/.last-release
+++ b/.last-release
@@ -1,3 +1,0 @@
-tag=v0.2.0
-source_sha=da6b778811ca61162a8339933ba37785c6f9b195
-workflow_run=29745485309

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.devtools.ksp")
     id("androidx.baselineprofile")
-    id("jacoco")
 }
 
 val repoRoot = rootProject.projectDir
@@ -241,42 +240,4 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
-}
-
-// The base jacoco plugin only wires a report task to the JVM `test` task, which an Android module
-// does not have — so `:app:jacocoTestReport` did not exist and CI's coverage step failed outright.
-tasks.register<JacocoReport>("jacocoTestReport") {
-    dependsOn("testDebugUnitTest")
-    group = "verification"
-    description = "Generates a coverage report for the debug unit tests."
-
-    reports {
-        html.required.set(true)
-        xml.required.set(true)
-    }
-
-    val generated =
-        listOf(
-            "**/R.class",
-            "**/R$*.class",
-            "**/BuildConfig.*",
-            "**/Manifest*.*",
-            "**/*Test*.*",
-            "**/*_Factory*.*",
-            "**/*Composable*.*",
-            "**/*\$\$serializer.*",
-        )
-    classDirectories.setFrom(
-        fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) { exclude(generated) },
-    )
-    sourceDirectories.setFrom(files("src/main/java"))
-    // Only the unit test coverage directories, never the whole build directory: scanning that
-    // makes Gradle treat every other task's output as an undeclared input of this one, which fails
-    // the build as soon as a release variant is assembled in the same invocation.
-    executionData.setFrom(
-        fileTree(layout.buildDirectory.dir("jacoco")) { include("*.exec") },
-        fileTree(layout.buildDirectory.dir("outputs/unit_test_code_coverage")) {
-            include("**/*.exec")
-        },
-    )
 }


### PR DESCRIPTION
残っている CI を一つずつ「実際に何を買っているか」で見直した結果の3件です。

## 1. i18n-check を実際に落ちるようにした

**このチェックは構造上、絶対に失敗しませんでした。** `exit 1` がどこにもなく、`::warning` を出すだけです。

しかも、指摘自体は正しかったのに誰も対応していませんでした。`model_visibility_title` / `_row` / `_caption` が**日本語以外の6ロケール全部で欠落**した状態でリリースまで到達しています。

**チェック対象が壊れているのに緑のままのチェックは、あることで CI 全体の信頼を下げます。** 欠落を `::error` にして `exit 1` するようにしました。

現在のツリーで先に空実行して確認済みで、**欠落ゼロなのでマージしても main は赤くなりません**。

## 2. jacoco カバレッジを削除

- 閾値なし（`violationRules` なし）
- バッジなし
- README / CONTRIBUTING に言及なし
- Codecov 等への送信なし

**誰も開かない HTML をアーティファクトに置いているだけ**でした。レポートタスク・プラグイン・ワークフローの2ステップを削除しています。

カバレッジが必要になったら、**実際に落ちるルール付き**で戻すべきです。

## 3. `.last-release` を削除

v0.2.0 時点の残骸です。

```
tag=v0.2.0
source_sha=da6b778811ca61162a8339933ba37785c6f9b195
workflow_run=29745485309
```

ワークフロー・スクリプト・ドキュメントのどれからも読まれていません（`release.yml` はタグを `.release-version` から解決します）。

## 触らなかったもの

- **commitlint** — 実利は「履歴が読みやすい」だけ（リリースノートは PR タイトルから生成されるのでコミット規約は関与しない）ですが、13秒なので消す理由もありません
- **pages.yml** — `pages/**` 変更時のみ。妥当
- **android.yml の本体**（detekt / spotless / testDebugUnitTest / lintDebug / assembleDebug）— すべて実質的な価値あり

## 気づいた点（このPRでは未対応）

`release.yml` は **`.release-version` を書き換えて main に push するだけでリリースが公開されます**。ガードは何もないので、誤って触れば意図しないリリースが出ます。タグ重複チェックや environment protection を足すことはできますが、運用の好みが絡むので手を付けていません。

## 検証

- `testDebugUnitTest` / `lintDebug` / `assembleDebug` / `detekt` / `spotlessCheck` → 成功
- 新しい i18n ゲートを現在のリソースに対して空実行 → PASS
- 両ワークフローの YAML パース確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3eN8AmoAcBDCTEeMTY3ba

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3eN8AmoAcBDCTEeMTY3ba)_