### PR TITLE
feat: collapse chat reasoning and tool calls into one expandable row

### DIFF
--- a/app/src/main/java/com/opencode/android/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/AssistantActivityGroup.kt
@@ -1,0 +1,117 @@
+package com.opencode.android.feature.chat
+
+/**
+ * A single row of the assistant timeline: either body text, or a collapsed run of
+ * reasoning/tool/patch parts that the user can expand to inspect.
+ */
+sealed interface TimelineEntry {
+    val id: String
+
+    data class Body(override val id: String, val part: ChatPart.Text) : TimelineEntry
+
+    data class Activity(override val id: String, val parts: List<ChatPart>) : TimelineEntry
+}
+
+/** Broad buckets used to summarise a run of tool calls in one line. */
+enum class ToolCategory { COMMAND, READ, EDIT, SUBAGENT, OTHER }
+
+/**
+ * Counts per category plus the part that is currently in flight, if any.
+ *
+ * While a run is still executing we surface the running step by name instead of a count, so the
+ * user can see what the agent is doing right now.
+ */
+data class ActivitySummary(
+    val counts: Map<ToolCategory, Int>,
+    val reasoningCount: Int,
+    val running: ChatPart.Tool?,
+    val hasError: Boolean,
+) {
+    val isEmpty: Boolean
+        get() = counts.isEmpty() && reasoningCount == 0
+}
+
+/**
+ * Collapses consecutive reasoning/tool/patch parts into a single [TimelineEntry.Activity], keeping
+ * body text as its own entry so the narrative order of the answer is preserved.
+ *
+ * Blank text parts do not split a run: the stream emits an empty text part before the assistant
+ * starts writing, and treating it as a separator would break every run into single-step groups.
+ */
+fun groupAssistantTimeline(parts: List<ChatPart>): List<TimelineEntry> {
+    val entries = mutableListOf<TimelineEntry>()
+    val pending = mutableListOf<ChatPart>()
+
+    fun flush() {
+        if (pending.isEmpty()) return
+        entries += TimelineEntry.Activity(pending.first().id, pending.toList())
+        pending.clear()
+    }
+
+    parts.forEach { part ->
+        if (part is ChatPart.Text && part.text.isNotBlank()) {
+            flush()
+            entries += TimelineEntry.Body(part.id, part)
+        } else if (part !is ChatPart.Text) {
+            pending += part
+        }
+    }
+    flush()
+    return entries
+}
+
+/**
+ * Re-resolves an activity group by id against the current messages.
+ *
+ * The detail sheet holds only the group id rather than a captured list, so a run that is still
+ * executing keeps streaming new steps into the open sheet. Group ids are stable as a run grows —
+ * see [groupAssistantTimeline].
+ */
+fun findActivityParts(
+    messages: List<ChatMessage>,
+    groupId: String,
+): List<ChatPart> =
+    messages
+        .asSequence()
+        .filterNot { it.isUser }
+        .flatMap { groupAssistantTimeline(it.parts).asSequence() }
+        .filterIsInstance<TimelineEntry.Activity>()
+        .firstOrNull { it.id == groupId }
+        ?.parts
+        .orEmpty()
+
+fun summarizeActivity(parts: List<ChatPart>): ActivitySummary {
+    val counts = mutableMapOf<ToolCategory, Int>()
+    var reasoning = 0
+    var running: ChatPart.Tool? = null
+    var hasError = false
+
+    parts.forEach { part ->
+        when (part) {
+            is ChatPart.Reasoning -> reasoning++
+            is ChatPart.Patch -> counts.increment(ToolCategory.EDIT)
+            is ChatPart.Tool -> {
+                counts.increment(part.name.toToolCategory())
+                if (part.status == ToolStatus.ERROR) hasError = true
+                if (running == null && (part.status == ToolStatus.RUNNING || part.status == ToolStatus.PENDING)) {
+                    running = part
+                }
+            }
+            is ChatPart.Text -> Unit
+        }
+    }
+    return ActivitySummary(counts = counts, reasoningCount = reasoning, running = running, hasError = hasError)
+}
+
+fun String.toToolCategory(): ToolCategory =
+    when (lowercase()) {
+        "bash", "shell" -> ToolCategory.COMMAND
+        "read", "glob", "grep", "list", "webfetch" -> ToolCategory.READ
+        "edit", "write", "patch", "multiedit" -> ToolCategory.EDIT
+        "task" -> ToolCategory.SUBAGENT
+        else -> ToolCategory.OTHER
+    }
+
+private fun MutableMap<ToolCategory, Int>.increment(category: ToolCategory) {
+    this[category] = (this[category] ?: 0) + 1
+}

--- a/app/src/main/java/com/opencode/android/feature/chat/AssistantActivityRow.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/AssistantActivityRow.kt
@@ -1,0 +1,196 @@
+package com.opencode.android.feature.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Hub
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.opencode.android.R
+
+/**
+ * One collapsed line standing in for a whole run of reasoning/tool calls.
+ *
+ * While a step is still in flight the row names that step so the user can see what the agent is
+ * doing; once the run settles it collapses to per-category counts.
+ */
+@Composable
+fun AssistantActivityRow(
+    parts: List<ChatPart>,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (parts.isEmpty()) return
+    val summary = summarizeActivity(parts)
+    if (summary.isEmpty) return
+
+    val running = summary.running
+    val accent =
+        when {
+            summary.hasError -> MaterialTheme.colorScheme.error
+            running != null -> MaterialTheme.colorScheme.primary
+            else -> MaterialTheme.colorScheme.onSurfaceVariant
+        }
+
+    Surface(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (running != null) {
+                CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp, color = accent)
+            } else {
+                Icon(
+                    if (summary.hasError) Icons.Default.ErrorOutline else Icons.Default.AutoAwesome,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+            if (running != null) {
+                Text(
+                    text = running.name,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                )
+                Text(
+                    text = running.title.orEmpty(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                ToolStatusChip(running.status)
+            } else {
+                Text(
+                    text = activitySummaryText(summary),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = accent,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = stringResource(R.string.activity_details_open),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Full step-by-step breakdown of one activity run. Hosted at screen level rather than inside the
+ * message list item, so scrolling the message off screen cannot dismiss an open sheet.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AssistantActivitySheet(
+    parts: List<ChatPart>,
+    onDismiss: () -> Unit,
+) {
+    val summary = summarizeActivity(parts)
+    val title = if (summary.isEmpty) stringResource(R.string.activity_details_title) else activitySummaryText(summary)
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = 8.dp, end = 16.dp, bottom = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onDismiss) {
+                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.activity_details_close))
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(parts, key = { it.id }) { part ->
+                when (part) {
+                    is ChatPart.Reasoning -> ReasoningCard(part)
+                    is ChatPart.Tool -> ToolCard(part)
+                    is ChatPart.Patch -> PatchCard(part)
+                    is ChatPart.Text -> Unit
+                }
+            }
+            item { Column(modifier = Modifier.padding(bottom = 32.dp)) {} }
+        }
+    }
+}
+
+@Composable
+private fun activitySummaryText(summary: ActivitySummary): String {
+    val phrases = mutableListOf<String>()
+    ToolCategory.entries.forEach { category ->
+        val count = summary.counts[category] ?: return@forEach
+        phrases += stringResource(category.summaryStringRes(), count)
+    }
+    if (phrases.isEmpty() && summary.reasoningCount > 0) {
+        phrases += stringResource(R.string.activity_summary_reasoning, summary.reasoningCount)
+    }
+    return phrases.joinToString(stringResource(R.string.activity_summary_separator))
+}
+
+private fun ToolCategory.summaryStringRes(): Int =
+    when (this) {
+        ToolCategory.COMMAND -> R.string.activity_summary_commands
+        ToolCategory.READ -> R.string.activity_summary_reads
+        ToolCategory.EDIT -> R.string.activity_summary_edits
+        ToolCategory.SUBAGENT -> R.string.activity_summary_subagents
+        ToolCategory.OTHER -> R.string.activity_summary_tools
+    }
+
+internal fun toolCategoryIcon(category: ToolCategory): ImageVector =
+    when (category) {
+        ToolCategory.COMMAND -> Icons.Default.Terminal
+        ToolCategory.READ -> Icons.Default.Visibility
+        ToolCategory.EDIT -> Icons.Default.Description
+        ToolCategory.SUBAGENT -> Icons.Default.Hub
+        ToolCategory.OTHER -> Icons.Default.Build
+    }

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
@@ -176,6 +176,7 @@ fun ChatHomeScreen(
     val runtimeNotReady = errorKind == ChatErrorKind.RUNTIME_NOT_READY && state.messages.isEmpty()
     val isAtBottom = remember { mutableStateOf(true) }
     var showActionSheet by remember { mutableStateOf<Pair<String, String>?>(null) }
+    var activityGroupId by remember { mutableStateOf<String?>(null) }
     val clipboardManager = LocalClipboardManager.current
     val coroutineScope = rememberCoroutineScope()
     var showSlashCommands by remember { mutableStateOf(false) }
@@ -324,6 +325,7 @@ fun ChatHomeScreen(
                                         AssistantTimeline(
                                             message,
                                             showProcessing = state.isRunning && message.id == lastAssistantId,
+                                            onOpenActivity = { activityGroupId = it },
                                         )
                                     }
                                 }
@@ -504,6 +506,13 @@ fun ChatHomeScreen(
             onToggleFavorite = onToggleFavorite,
             onDismiss = { showModelPicker = false },
         )
+    }
+
+    activityGroupId?.let { groupId ->
+        val parts = findActivityParts(state.messages, groupId)
+        if (parts.isNotEmpty()) {
+            AssistantActivitySheet(parts = parts, onDismiss = { activityGroupId = null })
+        }
     }
 
     showActionSheet?.let { (_, content) ->

--- a/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Compress
@@ -124,6 +123,7 @@ fun OpenCodeChatScreen(
     var input by remember { mutableStateOf("") }
     val listState = rememberLazyListState()
     val isAtBottom = remember { mutableStateOf(true) }
+    var activityGroupId by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(listState) {
         snapshotFlow {
@@ -198,7 +198,7 @@ fun OpenCodeChatScreen(
                 if (message.isUser) {
                     MessageBubble(message)
                 } else {
-                    AssistantTimeline(message)
+                    AssistantTimeline(message, onOpenActivity = { activityGroupId = it })
                 }
             }
 
@@ -276,6 +276,13 @@ fun OpenCodeChatScreen(
                     Icon(Icons.AutoMirrored.Filled.Send, contentDescription = stringResource(R.string.send_description))
                 }
             }
+        }
+    }
+
+    activityGroupId?.let { groupId ->
+        val parts = findActivityParts(state.messages, groupId)
+        if (parts.isNotEmpty()) {
+            AssistantActivitySheet(parts = parts, onDismiss = { activityGroupId = null })
         }
     }
 }
@@ -637,18 +644,22 @@ fun MessageBubble(message: ChatMessage) {
 fun AssistantTimeline(
     message: ChatMessage,
     showProcessing: Boolean = false,
+    onOpenActivity: (String) -> Unit = {},
 ) {
+    val entries = remember(message.parts) { groupAssistantTimeline(message.parts) }
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        message.parts.forEach { part ->
-            key(part.id) {
-                when (part) {
-                    is ChatPart.Text -> MarkdownText(part.text)
-                    is ChatPart.Reasoning -> ReasoningCard(part)
-                    is ChatPart.Tool -> ToolCard(part)
-                    is ChatPart.Patch -> PatchCard(part)
+        entries.forEach { entry ->
+            key(entry.id) {
+                when (entry) {
+                    is TimelineEntry.Body -> MarkdownText(entry.part.text)
+                    is TimelineEntry.Activity ->
+                        AssistantActivityRow(
+                            parts = entry.parts,
+                            onClick = { onOpenActivity(entry.id) },
+                        )
                 }
             }
         }
@@ -890,8 +901,9 @@ private fun renderInline(
         }
     }
 
+// Not private: reused by AssistantActivityRow.kt (same package) for the activity detail sheet.
 @Composable
-private fun ReasoningCard(
+fun ReasoningCard(
     part: ChatPart.Reasoning,
     autoExpand: Boolean = false,
 ) {
@@ -939,8 +951,9 @@ private fun ReasoningCard(
     }
 }
 
+// Not private: reused by AssistantActivityRow.kt (same package) for the activity detail sheet.
 @Composable
-private fun ToolCard(part: ChatPart.Tool) {
+fun ToolCard(part: ChatPart.Tool) {
     var expanded by remember { mutableStateOf(part.status == ToolStatus.RUNNING) }
     Card(
         modifier =
@@ -953,7 +966,7 @@ private fun ToolCard(part: ChatPart.Tool) {
         Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 Icon(
-                    Icons.Default.Build,
+                    toolCategoryIcon(part.name.toToolCategory()),
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(15.dp),
@@ -1042,8 +1055,9 @@ private fun ToolCard(part: ChatPart.Tool) {
     }
 }
 
+// Not private: reused by AssistantActivityRow.kt (same package) for the collapsed activity row.
 @Composable
-private fun ToolStatusChip(status: ToolStatus) {
+fun ToolStatusChip(status: ToolStatus) {
     val (label, color) =
         when (status) {
             ToolStatus.PENDING -> stringResource(R.string.tool_status_pending) to MaterialTheme.colorScheme.onSurfaceVariant
@@ -1066,8 +1080,9 @@ private fun ToolStatusChip(status: ToolStatus) {
     }
 }
 
+// Not private: reused by AssistantActivityRow.kt (same package) for the activity detail sheet.
 @Composable
-private fun PatchCard(part: ChatPart.Patch) {
+fun PatchCard(part: ChatPart.Patch) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(10.dp),

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">الإدخال</string>
     <string name="tool_output_label">الإخراج</string>
     <string name="tool_output_truncated">…تم اقتطاع الإخراج</string>
+    <string name="activity_summary_commands">تم تنفيذ %1$d أمر</string>
+    <string name="activity_summary_reads">تم قراءة %1$d ملف</string>
+    <string name="activity_summary_edits">تم تعديل %1$d ملف</string>
+    <string name="activity_summary_subagents">تم تشغيل %1$d وكيل فرعي</string>
+    <string name="activity_summary_tools">تم استخدام %1$d أداة</string>
+    <string name="activity_summary_reasoning">%1$d عملية تفكير</string>
+    <string name="activity_summary_separator">، </string>
+    <string name="activity_details_title">النشاط</string>
+    <string name="activity_details_open">إظهار تفاصيل النشاط</string>
+    <string name="activity_details_close">إغلاق</string>
     <string name="file_changes_title">تغييرات الملفات</string>
     <string name="file_changes_generic">تم تغيير الملفات</string>
     <string name="workspace_folder_label">مجلد العمل</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">Entrada</string>
     <string name="tool_output_label">Salida</string>
     <string name="tool_output_truncated">…salida truncada</string>
+    <string name="activity_summary_commands">Se ejecutaron %1$d comando(s)</string>
+    <string name="activity_summary_reads">Se leyeron %1$d archivo(s)</string>
+    <string name="activity_summary_edits">Se editaron %1$d archivo(s)</string>
+    <string name="activity_summary_subagents">Se ejecutaron %1$d subagente(s)</string>
+    <string name="activity_summary_tools">Se usaron %1$d herramienta(s)</string>
+    <string name="activity_summary_reasoning">%1$d razonamiento(s)</string>
+    <string name="activity_summary_separator">, </string>
+    <string name="activity_details_title">Actividad</string>
+    <string name="activity_details_open">Mostrar detalles de la actividad</string>
+    <string name="activity_details_close">Cerrar</string>
     <string name="file_changes_title">Cambios en archivos</string>
     <string name="file_changes_generic">Se han modificado archivos</string>
     <string name="workspace_folder_label">Carpeta de trabajo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">Entrée</string>
     <string name="tool_output_label">Sortie</string>
     <string name="tool_output_truncated">…sortie tronquée</string>
+    <string name="activity_summary_commands">%1$d commande(s) exécutée(s)</string>
+    <string name="activity_summary_reads">%1$d fichier(s) lu(s)</string>
+    <string name="activity_summary_edits">%1$d fichier(s) modifié(s)</string>
+    <string name="activity_summary_subagents">%1$d sous-agent(s) exécuté(s)</string>
+    <string name="activity_summary_tools">%1$d outil(s) utilisé(s)</string>
+    <string name="activity_summary_reasoning">%1$d raisonnement(s)</string>
+    <string name="activity_summary_separator">, </string>
+    <string name="activity_details_title">Activité</string>
+    <string name="activity_details_open">Afficher les détails de l\'activité</string>
+    <string name="activity_details_close">Fermer</string>
     <string name="file_changes_title">Modifications de fichiers</string>
     <string name="file_changes_generic">Des fichiers ont été modifiés</string>
     <string name="workspace_folder_label">Dossier de travail</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">入力</string>
     <string name="tool_output_label">出力</string>
     <string name="tool_output_truncated">…出力を省略しました</string>
+    <string name="activity_summary_commands">%1$d件のコマンドを実行しました</string>
+    <string name="activity_summary_reads">%1$d件のファイルを読み取りました</string>
+    <string name="activity_summary_edits">%1$d件のファイルを編集しました</string>
+    <string name="activity_summary_subagents">%1$d件のサブエージェントを実行しました</string>
+    <string name="activity_summary_tools">%1$d件のツールを使用しました</string>
+    <string name="activity_summary_reasoning">%1$d件の思考</string>
+    <string name="activity_summary_separator">、</string>
+    <string name="activity_details_title">実行内容</string>
+    <string name="activity_details_open">実行内容の詳細を表示</string>
+    <string name="activity_details_close">閉じる</string>
     <string name="file_changes_title">ファイル変更</string>
     <string name="file_changes_generic">ファイルが変更されました</string>
     <string name="workspace_folder_label">作業フォルダ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">Entrada</string>
     <string name="tool_output_label">Saída</string>
     <string name="tool_output_truncated">…saída truncada</string>
+    <string name="activity_summary_commands">%1$d comando(s) executado(s)</string>
+    <string name="activity_summary_reads">%1$d arquivo(s) lido(s)</string>
+    <string name="activity_summary_edits">%1$d arquivo(s) editado(s)</string>
+    <string name="activity_summary_subagents">%1$d subagente(s) executado(s)</string>
+    <string name="activity_summary_tools">%1$d ferramenta(s) usada(s)</string>
+    <string name="activity_summary_reasoning">%1$d raciocínio(s)</string>
+    <string name="activity_summary_separator">, </string>
+    <string name="activity_details_title">Atividade</string>
+    <string name="activity_details_open">Mostrar detalhes da atividade</string>
+    <string name="activity_details_close">Fechar</string>
     <string name="file_changes_title">Alterações de arquivos</string>
     <string name="file_changes_generic">Arquivos foram alterados</string>
     <string name="workspace_folder_label">Pasta de trabalho</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">Ввод</string>
     <string name="tool_output_label">Вывод</string>
     <string name="tool_output_truncated">…вывод обрезан</string>
+    <string name="activity_summary_commands">Выполнено команд: %1$d</string>
+    <string name="activity_summary_reads">Прочитано файлов: %1$d</string>
+    <string name="activity_summary_edits">Изменено файлов: %1$d</string>
+    <string name="activity_summary_subagents">Запущено субагентов: %1$d</string>
+    <string name="activity_summary_tools">Использовано инструментов: %1$d</string>
+    <string name="activity_summary_reasoning">Размышлений: %1$d</string>
+    <string name="activity_summary_separator">, </string>
+    <string name="activity_details_title">Действия</string>
+    <string name="activity_details_open">Показать подробности действий</string>
+    <string name="activity_details_close">Закрыть</string>
     <string name="file_changes_title">Изменения файлов</string>
     <string name="file_changes_generic">Файлы были изменены</string>
     <string name="workspace_folder_label">Рабочая папка</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">输入</string>
     <string name="tool_output_label">输出</string>
     <string name="tool_output_truncated">…输出已截断</string>
+    <string name="activity_summary_commands">执行了 %1$d 条命令</string>
+    <string name="activity_summary_reads">读取了 %1$d 个文件</string>
+    <string name="activity_summary_edits">编辑了 %1$d 个文件</string>
+    <string name="activity_summary_subagents">运行了 %1$d 个子代理</string>
+    <string name="activity_summary_tools">使用了 %1$d 个工具</string>
+    <string name="activity_summary_reasoning">思考 %1$d 次</string>
+    <string name="activity_summary_separator">、</string>
+    <string name="activity_details_title">执行内容</string>
+    <string name="activity_details_open">显示执行详情</string>
+    <string name="activity_details_close">关闭</string>
     <string name="file_changes_title">文件更改</string>
     <string name="file_changes_generic">文件已更改</string>
     <string name="workspace_folder_label">工作文件夹</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,16 @@
     <string name="tool_input_label">Input</string>
     <string name="tool_output_label">Output</string>
     <string name="tool_output_truncated">…output truncated</string>
+    <string name="activity_summary_commands">Ran %1$d command(s)</string>
+    <string name="activity_summary_reads">Read %1$d file(s)</string>
+    <string name="activity_summary_edits">Edited %1$d file(s)</string>
+    <string name="activity_summary_subagents">Ran %1$d subagent(s)</string>
+    <string name="activity_summary_tools">Used %1$d tool(s)</string>
+    <string name="activity_summary_reasoning">Thought %1$d time(s)</string>
+    <string name="activity_summary_separator">, </string>
+    <string name="activity_details_title">Activity</string>
+    <string name="activity_details_open">Show activity details</string>
+    <string name="activity_details_close">Close</string>
     <string name="file_changes_title">File changes</string>
     <string name="file_changes_generic">Files were changed</string>
     <string name="workspace_folder_label">Working folder</string>

--- a/app/src/test/java/com/opencode/android/feature/chat/AssistantActivityGroupTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/AssistantActivityGroupTest.kt
@@ -1,0 +1,166 @@
+package com.opencode.android.feature.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AssistantActivityGroupTest {
+    private fun tool(
+        id: String,
+        name: String,
+        status: ToolStatus = ToolStatus.COMPLETED,
+        title: String? = null,
+    ) = ChatPart.Tool(id = id, name = name, status = status, title = title)
+
+    @Test
+    fun `collapses a consecutive run of tools into one activity entry`() {
+        val entries =
+            groupAssistantTimeline(
+                listOf(
+                    tool("t1", "bash"),
+                    ChatPart.Reasoning("r1", "thinking"),
+                    tool("t2", "read"),
+                ),
+            )
+
+        assertEquals(1, entries.size)
+        val activity = entries.single() as TimelineEntry.Activity
+        assertEquals(3, activity.parts.size)
+    }
+
+    @Test
+    fun `body text splits activity into separate groups`() {
+        val entries =
+            groupAssistantTimeline(
+                listOf(
+                    tool("t1", "bash"),
+                    ChatPart.Text("x1", "Exploring the codebase."),
+                    tool("t2", "edit"),
+                    tool("t3", "write"),
+                    ChatPart.Text("x2", "Done."),
+                ),
+            )
+
+        assertEquals(4, entries.size)
+        assertEquals(listOf("t1"), (entries[0] as TimelineEntry.Activity).parts.map { it.id })
+        assertEquals("Exploring the codebase.", (entries[1] as TimelineEntry.Body).part.text)
+        assertEquals(listOf("t2", "t3"), (entries[2] as TimelineEntry.Activity).parts.map { it.id })
+        assertEquals("Done.", (entries[3] as TimelineEntry.Body).part.text)
+    }
+
+    @Test
+    fun `blank text parts do not split a run`() {
+        val entries =
+            groupAssistantTimeline(
+                listOf(
+                    tool("t1", "bash"),
+                    ChatPart.Text("x1", ""),
+                    tool("t2", "bash"),
+                    ChatPart.Text("x2", "   "),
+                    tool("t3", "bash"),
+                ),
+            )
+
+        assertEquals(1, entries.size)
+        assertEquals(listOf("t1", "t2", "t3"), (entries.single() as TimelineEntry.Activity).parts.map { it.id })
+    }
+
+    @Test
+    fun `activity id is the id of its first part so compose keys stay stable`() {
+        val parts = listOf(tool("first", "bash"), tool("second", "read"))
+
+        assertEquals("first", groupAssistantTimeline(parts).single().id)
+        // Appending to a growing run must not change the group identity.
+        assertEquals("first", groupAssistantTimeline(parts + tool("third", "read")).single().id)
+    }
+
+    @Test
+    fun `counts tools by category and treats patch parts as edits`() {
+        val summary =
+            summarizeActivity(
+                listOf(
+                    tool("t1", "bash"),
+                    tool("t2", "Bash"),
+                    tool("t3", "read"),
+                    tool("t4", "grep"),
+                    tool("t5", "glob"),
+                    tool("t6", "task"),
+                    tool("t7", "todowrite"),
+                    ChatPart.Patch("p1", listOf("A.kt")),
+                    ChatPart.Reasoning("r1", "thinking"),
+                ),
+            )
+
+        assertEquals(2, summary.counts[ToolCategory.COMMAND])
+        assertEquals(3, summary.counts[ToolCategory.READ])
+        assertEquals(1, summary.counts[ToolCategory.EDIT])
+        assertEquals(1, summary.counts[ToolCategory.SUBAGENT])
+        assertEquals(1, summary.counts[ToolCategory.OTHER])
+        assertEquals(1, summary.reasoningCount)
+        assertNull(summary.running)
+    }
+
+    @Test
+    fun `surfaces the first in-flight tool while the run is still executing`() {
+        val summary =
+            summarizeActivity(
+                listOf(
+                    tool("t1", "bash"),
+                    tool("t2", "bash", status = ToolStatus.RUNNING, title = "gh run watch"),
+                    tool("t3", "read", status = ToolStatus.PENDING),
+                ),
+            )
+
+        assertEquals("t2", summary.running?.id)
+        assertEquals("gh run watch", summary.running?.title)
+    }
+
+    @Test
+    fun `flags a run that contains a failed tool`() {
+        val summary = summarizeActivity(listOf(tool("t1", "bash"), tool("t2", "bash", status = ToolStatus.ERROR)))
+
+        assertTrue(summary.hasError)
+        assertNull(summary.running)
+    }
+
+    @Test
+    fun `resolves an activity group by id across messages`() {
+        val messages =
+            listOf(
+                ChatMessage(id = "m0", isUser = true, parts = listOf(ChatPart.Text("u1", "go"))),
+                ChatMessage(
+                    id = "m1",
+                    isUser = false,
+                    parts =
+                        listOf(
+                            tool("a1", "bash"),
+                            ChatPart.Text("x1", "Now editing."),
+                            tool("b1", "edit"),
+                            tool("b2", "write"),
+                        ),
+                ),
+            )
+
+        assertEquals(listOf("b1", "b2"), findActivityParts(messages, "b1").map { it.id })
+        assertEquals(listOf("a1"), findActivityParts(messages, "a1").map { it.id })
+        assertTrue(findActivityParts(messages, "nope").isEmpty())
+    }
+
+    @Test
+    fun `resolving a group picks up steps appended while the run is still going`() {
+        val growing =
+            ChatMessage(id = "m1", isUser = false, parts = listOf(tool("a1", "bash"), tool("a2", "read")))
+
+        assertEquals(listOf("a1", "a2"), findActivityParts(listOf(growing), "a1").map { it.id })
+    }
+
+    @Test
+    fun `reasoning-only run is not empty`() {
+        val summary = summarizeActivity(listOf(ChatPart.Reasoning("r1", "thinking")))
+
+        assertTrue(summary.counts.isEmpty())
+        assertEquals(1, summary.reasoningCount)
+        assertTrue(!summary.isEmpty)
+    }
+}


### PR DESCRIPTION
## 概要

エージェントが1ターンで多数のツールを呼ぶと、「思考」「bash …」「read …」のカードが1件ずつ積み上がり、肝心の回答本文がスクロールの遥か下に埋もれていた。

Claude のチャットと同じように、連続する思考/ツール実行を **1行のサマリ**に集約し、タップするとボトムシートで全ステップを確認できるようにした。

## Before / After

**Before** — パーツごとに1カード

```
🔧 bash  git tag --sort=-versi…  完了 ⌄
🧠 思考                              ⌄
🔧 bash  gh run watch 30156…     完了 ⌄
🧠 思考                              ⌄
🔧 read  workspace/openco…       完了 ⌄
🧠 思考                              ⌄
🧠 思考                              ⌄

リリース番号も確認したところ…
```

**After** — 1行に集約、タップでボトムシート

```
✦ 3件のコマンドを実行しました、4件の…  ›

リリース番号も確認したところ…

✦ 2件のファイルを編集しました        ›

以上で対応完了です。
```

実行中は件数に畳まず、進行中のステップ名を出したままにする:

```
⟳ bash  gh run watch 30156…   実行中  ›
   ↓ 完了後
✦ 3件のコマンドを実行しました、4件の…    ›
```

## 変更点

- **`AssistantActivityGroup.kt`（新規）** — 純粋関数のグルーピング/集計。`groupAssistantTimeline()` が本文テキストを区切りとして連続する Reasoning/Tool/Patch を1グループに畳む。ストリーミング開始時に来る空テキストパートは区切りにしない（区切りにすると1件ずつ分断される）。グループIDは先頭パートのIDなので、runが伸びても Compose の `key` が安定する。
- **`AssistantActivityRow.kt`（新規）** — 集約行とボトムシート。シートの中身は既存の `ReasoningCard` / `ToolCard` / `PatchCard` をそのまま再利用しているので、入力/出力の展開や出力の切り詰め表示は従来どおり。
- **`AssistantTimeline`** — `message.parts` を直接回す代わりにグルーピング結果を描画。
- シート状態は画面側（`ChatHomeScreen` / `OpenCodeChatScreen`）に持ち上げた。LazyColumn の item 内に置くと、開いたまま item が画面外に出た瞬間に破棄されてしまうため。
- シートはパーツのスナップショットではなく**グループIDを保持**し、`findActivityParts()` で毎回 `state.messages` から引き直す。実行中のグループを開くと新しいステップがそのまま流れ込む。
- ツールアイコンを固定の `Build` から種別マップ（`Terminal` / `Visibility` / `Description` / `Hub`）に変更。
- 文字列を10キー追加。`i18n-check.yml` がキー一致を検査するため、8ロケール全部に入れた。リポジトリは plurals リソースを一切使っていないので、慣習どおり `%1$d` プレースホルダの通常の string リソースで統一。

## テスト

`AssistantActivityGroupTest.kt` を新規追加（10ケース）:

- 連続ツールが1グループに畳まれる / 本文テキストで分割される
- 空・空白のみのテキストパートでは分割されない
- グループIDが先頭パートIDと一致し、runが伸びても変わらない
- カテゴリ別カウント、`ChatPart.Patch` を編集として数える
- 実行中は最初の in-flight ツールを返す、エラーを含む run にフラグが立つ
- `findActivityParts()` がメッセージ横断でグループを解決する

### ローカル実行結果

| コマンド | 結果 |
|---|---|
| `./gradlew spotlessCheck` | ✅ |
| `./gradlew :app:testDebugUnitTest` | ✅ 10/10 |
| `./gradlew :app:lintDebug` | ✅ 0 errors |
| `./gradlew :app:assembleDebug` | ✅ |

`lintDebug` に `PluralsCandidate` の警告が6件増えるが、これは既存の `%1$d` + 単語の文字列（`values/strings.xml` の 174 / 388-390 / 553-554 行など）と同じパターンで、リポジトリが plurals リソースを使っていない方針に合わせたもの。エラーは0件。

### 未実施

実機/エミュレータでの目視確認（実行中 → 畳まれる → タップでシートが開く → シートを開いたままチャットが伸びても閉じない）は行えていない。ロジックはユニットテストで担保しているが、見た目の最終確認は別途必要。
