### PR TITLE
fix: 思考とツール実行が別行に割れるのを解消（メッセージをまたいで集約）

### DIFF
--- a/app/src/main/java/com/opencode/android/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/AssistantActivityGroup.kt
@@ -1,13 +1,21 @@
 package com.opencode.android.feature.chat
 
 /**
- * A single row of the assistant timeline: either body text, or a collapsed run of
+ * A single row of the chat timeline: a user bubble, assistant body text, or a collapsed run of
  * reasoning/tool/patch parts that the user can expand to inspect.
+ *
+ * Ids are namespaced by kind so they stay unique as `LazyColumn` keys across the whole transcript.
  */
 sealed interface TimelineEntry {
     val id: String
 
-    data class Body(override val id: String, val part: ChatPart.Text) : TimelineEntry
+    data class UserMessage(val message: ChatMessage) : TimelineEntry {
+        override val id: String get() = "user:${message.id}"
+    }
+
+    data class Body(val messageId: String, val part: ChatPart.Text) : TimelineEntry {
+        override val id: String get() = "body:${part.id}"
+    }
 
     data class Activity(override val id: String, val parts: List<ChatPart>) : TimelineEntry
 }
@@ -32,28 +40,44 @@ data class ActivitySummary(
 }
 
 /**
- * Collapses consecutive reasoning/tool/patch parts into a single [TimelineEntry.Activity], keeping
- * body text as its own entry so the narrative order of the answer is preserved.
+ * Flattens the transcript into rows, collapsing consecutive reasoning/tool/patch parts into a
+ * single [TimelineEntry.Activity] and keeping body text as its own entry so the narrative order of
+ * the answer is preserved.
+ *
+ * Grouping spans messages on purpose. OpenCode opens a new assistant message per model step, so a
+ * turn that calls tools arrives as several messages — `[read, read]`, then `[reasoning, text]`.
+ * Grouping inside a single message would leave those as two separate rows even though nothing
+ * separates them on screen, which is exactly what a collapsed run is meant to avoid. Only a user
+ * message or non-blank body text ends a run.
  *
  * Blank text parts do not split a run: the stream emits an empty text part before the assistant
  * starts writing, and treating it as a separator would break every run into single-step groups.
  */
-fun groupAssistantTimeline(parts: List<ChatPart>): List<TimelineEntry> {
+fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> {
     val entries = mutableListOf<TimelineEntry>()
     val pending = mutableListOf<ChatPart>()
 
     fun flush() {
         if (pending.isEmpty()) return
-        entries += TimelineEntry.Activity(pending.first().id, pending.toList())
+        entries += TimelineEntry.Activity("activity:${pending.first().id}", pending.toList())
         pending.clear()
     }
 
-    parts.forEach { part ->
-        if (part is ChatPart.Text && part.text.isNotBlank()) {
+    messages.forEach { message ->
+        if (message.isUser) {
             flush()
-            entries += TimelineEntry.Body(part.id, part)
-        } else if (part !is ChatPart.Text) {
-            pending += part
+            entries += TimelineEntry.UserMessage(message)
+            return@forEach
+        }
+        message.parts.forEach { part ->
+            when {
+                part !is ChatPart.Text -> pending += part
+                part.text.isNotBlank() -> {
+                    flush()
+                    entries += TimelineEntry.Body(message.id, part)
+                }
+                else -> Unit
+            }
         }
     }
     flush()
@@ -64,17 +88,14 @@ fun groupAssistantTimeline(parts: List<ChatPart>): List<TimelineEntry> {
  * Re-resolves an activity group by id against the current messages.
  *
  * The detail sheet holds only the group id rather than a captured list, so a run that is still
- * executing keeps streaming new steps into the open sheet. Group ids are stable as a run grows —
- * see [groupAssistantTimeline].
+ * executing keeps streaming new steps into the open sheet. Group ids are the id of the run's first
+ * part, so they stay stable as the run grows — see [groupConversationTimeline].
  */
 fun findActivityParts(
     messages: List<ChatMessage>,
     groupId: String,
 ): List<ChatPart> =
-    messages
-        .asSequence()
-        .filterNot { it.isUser }
-        .flatMap { groupAssistantTimeline(it.parts).asSequence() }
+    groupConversationTimeline(messages)
         .filterIsInstance<TimelineEntry.Activity>()
         .firstOrNull { it.id == groupId }
         ?.parts

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatHomeScreen.kt
@@ -177,6 +177,7 @@ fun ChatHomeScreen(
     val isAtBottom = remember { mutableStateOf(true) }
     var showActionSheet by remember { mutableStateOf<Pair<String, String>?>(null) }
     var activityGroupId by remember { mutableStateOf<String?>(null) }
+    val timelineEntries = remember(state.messages) { groupConversationTimeline(state.messages) }
     val clipboardManager = LocalClipboardManager.current
     val coroutineScope = rememberCoroutineScope()
     var showSlashCommands by remember { mutableStateOf(false) }
@@ -222,8 +223,8 @@ fun ChatHomeScreen(
         }.collect { atBottom -> isAtBottom.value = atBottom }
     }
 
-    LaunchedEffect(state.messages.size, state.permissions.size, state.pendingQuestions.size) {
-        val totalItems = state.messages.size + state.permissions.size + state.pendingQuestions.size
+    LaunchedEffect(timelineEntries.size, state.permissions.size, state.pendingQuestions.size) {
+        val totalItems = timelineEntries.size + state.permissions.size + state.pendingQuestions.size
         if (totalItems > 0 && isAtBottom.value) listState.animateScrollToItem(totalItems - 1)
     }
 
@@ -304,30 +305,40 @@ fun ChatHomeScreen(
                             onOpenRemoteSetup = onOpenRemoteSetup,
                         )
                     else -> {
-                        val lastAssistantId = state.messages.lastOrNull { !it.isUser }?.id
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize(),
                             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            items(state.messages, key = { it.id }) { message ->
+                            items(timelineEntries, key = { it.id }) { entry ->
+                                val copyable =
+                                    when (entry) {
+                                        is TimelineEntry.UserMessage -> entry.message.id to entry.message.text
+                                        is TimelineEntry.Body -> entry.messageId to entry.part.text
+                                        is TimelineEntry.Activity -> null
+                                    }
                                 Box(
                                     modifier =
-                                        Modifier.combinedClickable(
-                                            onClick = {},
-                                            onLongClick = { showActionSheet = message.id to message.text },
-                                        ),
+                                        if (copyable == null) {
+                                            Modifier
+                                        } else {
+                                            Modifier.combinedClickable(
+                                                onClick = {},
+                                                onLongClick = { showActionSheet = copyable },
+                                            )
+                                        },
                                 ) {
-                                    if (message.isUser) {
-                                        MessageBubble(message)
-                                    } else {
-                                        AssistantTimeline(
-                                            message,
-                                            showProcessing = state.isRunning && message.id == lastAssistantId,
-                                            onOpenActivity = { activityGroupId = it },
-                                        )
-                                    }
+                                    TimelineEntryRow(entry, onOpenActivity = { activityGroupId = it })
+                                }
+                            }
+                            if (state.isRunning && timelineEntries.isNotEmpty()) {
+                                item(key = "processing") {
+                                    Text(
+                                        text = stringResource(R.string.processing),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
                                 }
                             }
                             items(state.permissions, key = { "permission-${it.id}" }) { permission ->
@@ -364,7 +375,7 @@ fun ChatHomeScreen(
                         onClick = {
                             isAtBottom.value = true
                             coroutineScope.launch {
-                                val totalItems = state.messages.size + state.permissions.size + state.pendingQuestions.size
+                                val totalItems = timelineEntries.size + state.permissions.size + state.pendingQuestions.size
                                 if (totalItems > 0) listState.animateScrollToItem(totalItems - 1)
                             }
                         },

--- a/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
@@ -63,7 +63,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -124,6 +123,7 @@ fun OpenCodeChatScreen(
     val listState = rememberLazyListState()
     val isAtBottom = remember { mutableStateOf(true) }
     var activityGroupId by remember { mutableStateOf<String?>(null) }
+    val timelineEntries = remember(state.messages) { groupConversationTimeline(state.messages) }
 
     LaunchedEffect(listState) {
         snapshotFlow {
@@ -134,8 +134,8 @@ fun OpenCodeChatScreen(
         }.collect { atBottom -> isAtBottom.value = atBottom }
     }
 
-    LaunchedEffect(state.messages.size, state.permissions.size) {
-        val totalItems = state.messages.size + state.permissions.size
+    LaunchedEffect(timelineEntries.size, state.permissions.size) {
+        val totalItems = timelineEntries.size + state.permissions.size
         if (totalItems > 0 && isAtBottom.value) listState.animateScrollToItem(totalItems - 1)
     }
 
@@ -194,12 +194,8 @@ fun OpenCodeChatScreen(
                 }
             }
 
-            items(state.messages, key = { it.id }) { message ->
-                if (message.isUser) {
-                    MessageBubble(message)
-                } else {
-                    AssistantTimeline(message, onOpenActivity = { activityGroupId = it })
-                }
+            items(timelineEntries, key = { it.id }) { entry ->
+                TimelineEntryRow(entry, onOpenActivity = { activityGroupId = it })
             }
 
             items(state.permissions, key = { "permission-${it.id}" }) { permission ->
@@ -639,37 +635,24 @@ fun MessageBubble(message: ChatMessage) {
     }
 }
 
-// Not private: reused by ChatHomeScreen.kt (same package) for the redesigned chat screen.
+/**
+ * Renders one row produced by [groupConversationTimeline].
+ *
+ * Not private: reused by ChatHomeScreen.kt (same package) for the redesigned chat screen.
+ */
 @Composable
-fun AssistantTimeline(
-    message: ChatMessage,
-    showProcessing: Boolean = false,
+fun TimelineEntryRow(
+    entry: TimelineEntry,
     onOpenActivity: (String) -> Unit = {},
 ) {
-    val entries = remember(message.parts) { groupAssistantTimeline(message.parts) }
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        entries.forEach { entry ->
-            key(entry.id) {
-                when (entry) {
-                    is TimelineEntry.Body -> MarkdownText(entry.part.text)
-                    is TimelineEntry.Activity ->
-                        AssistantActivityRow(
-                            parts = entry.parts,
-                            onClick = { onOpenActivity(entry.id) },
-                        )
-                }
-            }
-        }
-        if (showProcessing) {
-            Text(
-                text = stringResource(R.string.processing),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+    when (entry) {
+        is TimelineEntry.UserMessage -> MessageBubble(entry.message)
+        is TimelineEntry.Body -> MarkdownText(entry.part.text)
+        is TimelineEntry.Activity ->
+            AssistantActivityRow(
+                parts = entry.parts,
+                onClick = { onOpenActivity(entry.id) },
             )
-        }
     }
 }
 

--- a/app/src/test/java/com/opencode/android/feature/chat/AssistantActivityGroupTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/AssistantActivityGroupTest.kt
@@ -13,14 +13,22 @@ class AssistantActivityGroupTest {
         title: String? = null,
     ) = ChatPart.Tool(id = id, name = name, status = status, title = title)
 
+    private fun assistant(
+        id: String,
+        vararg parts: ChatPart,
+    ) = ChatMessage(id = id, isUser = false, parts = parts.toList())
+
     @Test
     fun `collapses a consecutive run of tools into one activity entry`() {
         val entries =
-            groupAssistantTimeline(
+            groupConversationTimeline(
                 listOf(
-                    tool("t1", "bash"),
-                    ChatPart.Reasoning("r1", "thinking"),
-                    tool("t2", "read"),
+                    assistant(
+                        "m1",
+                        tool("t1", "bash"),
+                        ChatPart.Reasoning("r1", "thinking"),
+                        tool("t2", "read"),
+                    ),
                 ),
             )
 
@@ -30,15 +38,51 @@ class AssistantActivityGroupTest {
     }
 
     @Test
+    fun `collapses a run that spans several assistant messages`() {
+        // OpenCode opens a new assistant message per model step, so a turn that reads two files
+        // and then thinks arrives as two messages. It is still one uninterrupted run on screen.
+        val entries =
+            groupConversationTimeline(
+                listOf(
+                    ChatMessage(id = "m0", isUser = true, parts = listOf(ChatPart.Text("u1", "explain this repo"))),
+                    assistant("m1", tool("t1", "read"), tool("t2", "read")),
+                    assistant("m2", ChatPart.Reasoning("r1", "thinking"), ChatPart.Text("x1", "This repo is…")),
+                ),
+            )
+
+        assertEquals(3, entries.size)
+        assertTrue(entries[0] is TimelineEntry.UserMessage)
+        assertEquals(listOf("t1", "t2", "r1"), (entries[1] as TimelineEntry.Activity).parts.map { it.id })
+        assertEquals("This repo is…", (entries[2] as TimelineEntry.Body).part.text)
+    }
+
+    @Test
+    fun `a user message ends the preceding run`() {
+        val entries =
+            groupConversationTimeline(
+                listOf(
+                    assistant("m1", tool("t1", "read")),
+                    ChatMessage(id = "m2", isUser = true, parts = listOf(ChatPart.Text("u1", "next"))),
+                    assistant("m3", tool("t2", "read")),
+                ),
+            )
+
+        assertEquals(listOf("activity:t1", "user:m2", "activity:t2"), entries.map { it.id })
+    }
+
+    @Test
     fun `body text splits activity into separate groups`() {
         val entries =
-            groupAssistantTimeline(
+            groupConversationTimeline(
                 listOf(
-                    tool("t1", "bash"),
-                    ChatPart.Text("x1", "Exploring the codebase."),
-                    tool("t2", "edit"),
-                    tool("t3", "write"),
-                    ChatPart.Text("x2", "Done."),
+                    assistant(
+                        "m1",
+                        tool("t1", "bash"),
+                        ChatPart.Text("x1", "Exploring the codebase."),
+                        tool("t2", "edit"),
+                        tool("t3", "write"),
+                        ChatPart.Text("x2", "Done."),
+                    ),
                 ),
             )
 
@@ -52,13 +96,19 @@ class AssistantActivityGroupTest {
     @Test
     fun `blank text parts do not split a run`() {
         val entries =
-            groupAssistantTimeline(
+            groupConversationTimeline(
                 listOf(
-                    tool("t1", "bash"),
-                    ChatPart.Text("x1", ""),
-                    tool("t2", "bash"),
-                    ChatPart.Text("x2", "   "),
-                    tool("t3", "bash"),
+                    assistant(
+                        "m1",
+                        tool("t1", "bash"),
+                        ChatPart.Text("x1", ""),
+                        tool("t2", "bash"),
+                    ),
+                    assistant(
+                        "m2",
+                        ChatPart.Text("x2", "   "),
+                        tool("t3", "bash"),
+                    ),
                 ),
             )
 
@@ -70,9 +120,15 @@ class AssistantActivityGroupTest {
     fun `activity id is the id of its first part so compose keys stay stable`() {
         val parts = listOf(tool("first", "bash"), tool("second", "read"))
 
-        assertEquals("first", groupAssistantTimeline(parts).single().id)
-        // Appending to a growing run must not change the group identity.
-        assertEquals("first", groupAssistantTimeline(parts + tool("third", "read")).single().id)
+        assertEquals("activity:first", groupConversationTimeline(listOf(assistant("m1", *parts.toTypedArray()))).single().id)
+        // Appending to a growing run must not change the group identity — not even when the new
+        // step lands in the next assistant message.
+        assertEquals(
+            "activity:first",
+            groupConversationTimeline(
+                listOf(assistant("m1", *parts.toTypedArray()), assistant("m2", tool("third", "read"))),
+            ).single().id,
+        )
     }
 
     @Test
@@ -142,9 +198,9 @@ class AssistantActivityGroupTest {
                 ),
             )
 
-        assertEquals(listOf("b1", "b2"), findActivityParts(messages, "b1").map { it.id })
-        assertEquals(listOf("a1"), findActivityParts(messages, "a1").map { it.id })
-        assertTrue(findActivityParts(messages, "nope").isEmpty())
+        assertEquals(listOf("b1", "b2"), findActivityParts(messages, "activity:b1").map { it.id })
+        assertEquals(listOf("a1"), findActivityParts(messages, "activity:a1").map { it.id })
+        assertTrue(findActivityParts(messages, "activity:nope").isEmpty())
     }
 
     @Test
@@ -152,7 +208,7 @@ class AssistantActivityGroupTest {
         val growing =
             ChatMessage(id = "m1", isUser = false, parts = listOf(tool("a1", "bash"), tool("a2", "read")))
 
-        assertEquals(listOf("a1", "a2"), findActivityParts(listOf(growing), "a1").map { it.id })
+        assertEquals(listOf("a1", "a2"), findActivityParts(listOf(growing), "activity:a1").map { it.id })
     }
 
     @Test


### PR DESCRIPTION
## 対象

#87 で導入した集約行が、実機では**1行に畳まれず2行に割れて**いました。

```
✦ 2件のファイルを読み取りました   ›
✦ 1件の思考                      ›

このリポジトリは OpenCode Android — …
```

間に本文テキストは何もありません。「連続する思考/ツール実行を1行にまとめる」という #87 の目的が、実際に一番よく起きるパターンで達成できていない状態でした。

## 原因

`groupAssistantTimeline()` は **`message.parts` 単位**でしか畳んでいませんでした。

一方 OpenCode は**モデルのステップごとに assistant メッセージを新規作成**します。ツールを呼ぶターンは1メッセージでは終わらず、

| メッセージ | parts |
|---|---|
| `m1` | `[read, read]` |
| `m2` | `[reasoning, text]` |

のように分かれて届きます。`ChatHomeScreen` / `OpenCodeChatScreen` は `items(state.messages)` でメッセージ単位に描画し、その中で `AssistantTimeline` がメッセージ内だけを畳んでいたため、`m1` と `m2` は別の集約行になります。画面上は何も挟まっていないのに2行、というのがスクリーンショットの状態です。

ユニットテストが全件通っていたのは、テストが**1メッセージ内の parts 列**しか与えていなかったためです。この分割は #87 のテストでは構造上再現できません。

## 変更点

### `AssistantActivityGroup.kt`

- `groupAssistantTimeline(parts: List<ChatPart>)` を **`groupConversationTimeline(messages: List<ChatMessage>)`** に置き換え。トランスクリプト全体を横断して畳みます。runを区切るのは**ユーザーメッセージ**と**空でない本文テキスト**だけで、メッセージ境界は区切りになりません。
- `TimelineEntry.UserMessage` を追加。会話全体が1本の行リストになるので、ユーザー発言も同じリストの要素として扱います。
- エントリIDを種別で名前空間化（`user:` / `body:` / `activity:`）。1メッセージ1アイテムだった頃と違い、`LazyColumn` のキーがトランスクリプト全体で一意である必要があるためです。
- `activity:` のIDは従来どおり**run の先頭パートのID**なので、runが次のメッセージへ伸びてもグループの同一性は変わりません。開いたままのボトムシートに新しいステップが流れ込む挙動は維持されます。
- `findActivityParts()` はメッセージごとに畳み直す必要がなくなり、同じ関数の結果を引くだけになりました。

### `OpenCodeChatScreen.kt`

- メッセージ単位の `AssistantTimeline` を、行単位の **`TimelineEntryRow`** に置き換え。`MessageBubble` / `MarkdownText` / `AssistantActivityRow` の呼び分けだけを持ちます。
- `items(state.messages)` → `items(timelineEntries)`。

### `ChatHomeScreen.kt`

- 同じく行単位で描画。
- 長押しコピーは**ユーザー発言と本文テキストのみ**に付けました。集約行は `Surface(onClick)` を持っていてコピーする本文もないため、ラップしていません。
- 「処理中…」は最後の assistant メッセージの `Column` 内にありましたが、メッセージ単位の描画が無くなったのでリスト末尾の item に移しました。表示条件（`state.isRunning`）は同じです。
- 自動スクロールと「最下部へ」FABが使う件数を `state.messages.size` → `timelineEntries.size` に変更。アイテム数が行数になったためです。

## テスト

`AssistantActivityGroupTest.kt` を会話単位のAPIに更新し、今回の不具合を直接踏むケースを追加しました。

- **`collapses a run that spans several assistant messages`** — `[read, read]` / `[reasoning, text]` の2メッセージが**1つの Activity + 1つの Body** になること。修正前のコードでは Activity が2つになり落ちます
- **`a user message ends the preceding run`** — ユーザー発言はrunを区切ること
- **`activity id is …`** — runが次のメッセージへ伸びてもグループIDが変わらないこと（シートが開いたままでも壊れない）
- 既存の「本文テキストで分割」「空テキストでは分割しない」ケースも、複数メッセージにまたがる形に組み直しています

### ローカル実行結果

| コマンド | 結果 |
|---|---|
| `./gradlew :app:testDebugUnitTest` | ✅ 262件 / 失敗0（`AssistantActivityGroupTest` は新規2件を含む12件） |
| `./gradlew :app:lintDebug` | ✅ 0 errors, 138 warnings |
| `./gradlew detekt spotlessCheck` | ✅ |

`:app:assembleDebug` はローカルでは未実行です（CI の `test-and-build` が実行します）。

実機・エミュレータでの目視確認は行えていません（この環境にエミュレータなし）。**2行が1行に統合されることの見た目の確認はお願いします。**

## 補足

集約後のラベルは「2件のファイルを読み取りました」のままになります。`activitySummaryText()` は**ツールの件数がある場合は思考件数をラベルに出さない**設計（#87 のまま）で、思考ステップはシートの中に入ります。スクリーンショットの2行が、この1行に統合されます。