### PR TITLE
fix: subscribe to the cross-instance event stream so runs do not stall

### DIFF
--- a/app/src/main/java/com/opencode/android/core/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/opencode/android/core/api/OpenCodeApiClient.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -44,6 +46,10 @@ class OpenCodeApiClient(
     // connection is saved, so an endpoint the current rules reject has to surface as a failed
     // request rather than as an exception escaping into a UI callback.
     private val baseUrl: HttpUrl by lazy { OpenCodeUrl.normalize(profile.baseUrl).getOrThrow() }
+
+    @Volatile
+    private var eventPath: String = GLOBAL_EVENT_PATH
+
     private val providerAuthHttpClient: OkHttpClient =
         httpClient.newBuilder()
             .readTimeout(PROVIDER_AUTH_TIMEOUT_MINUTES, TimeUnit.MINUTES)
@@ -424,8 +430,25 @@ class OpenCodeApiClient(
         )
     }
 
+    /**
+     * `GET /event` is scoped to a single OpenCode instance: the one rooted at the request's
+     * `directory` query parameter, which falls back to the server's own working directory. A
+     * session created in any other workspace therefore emits nothing on that stream — no reply
+     * text, no tool output, and no permission request, so a run that needs approval waits
+     * forever on a request that never reaches the client. Subscribe to the cross-instance
+     * `/global/event` stream instead, and fall back only for servers that predate it.
+     */
     fun events(): Flow<OpenCodeEvent> =
-        singleEventStream().retryWhen { cause, attempt ->
+        flow { emitAll(singleEventStream(eventPath)) }.retryWhen { cause, attempt ->
+            if (
+                eventPath == GLOBAL_EVENT_PATH &&
+                cause is OpenCodeApiException &&
+                cause.statusCode in GLOBAL_EVENT_UNSUPPORTED_CODES
+            ) {
+                eventPath = INSTANCE_EVENT_PATH
+                return@retryWhen true
+            }
+
             val retryable = cause !is OpenCodeApiException || cause.statusCode >= 500
             if (!retryable) return@retryWhen false
 
@@ -436,14 +459,14 @@ class OpenCodeApiClient(
             true
         }
 
-    private fun singleEventStream(): Flow<OpenCodeEvent> =
+    private fun singleEventStream(path: String): Flow<OpenCodeEvent> =
         channelFlow {
             val eventClient =
                 httpClient.newBuilder()
                     .readTimeout(0, TimeUnit.MILLISECONDS)
                     .build()
             val request =
-                requestBuilder("event")
+                requestBuilder(path)
                     .header("Accept", "text/event-stream")
                     .header("Cache-Control", "no-cache")
                     .get()
@@ -658,6 +681,9 @@ class OpenCodeApiClient(
         private const val MAX_ERROR_BODY_CHARS = 240
         private const val EVENT_BUFFER_CAPACITY = 512
         private const val PROVIDER_AUTH_TIMEOUT_MINUTES = 6L
+        private const val GLOBAL_EVENT_PATH = "global/event"
+        private const val INSTANCE_EVENT_PATH = "event"
+        private val GLOBAL_EVENT_UNSUPPORTED_CODES = setOf(400, 404, 405, 501)
 
         val defaultJson: Json =
             Json {

--- a/app/src/main/java/com/opencode/android/core/api/OpenCodeApiModels.kt
+++ b/app/src/main/java/com/opencode/android/core/api/OpenCodeApiModels.kt
@@ -288,6 +288,8 @@ data class QuestionRequest(
 sealed interface OpenCodeEvent {
     data object ServerConnected : OpenCodeEvent
 
+    data class MessageUpdated(val info: OpenCodeMessageInfo) : OpenCodeEvent
+
     data class MessagePartUpdated(val part: OpenCodePart) : OpenCodeEvent
 
     data class MessagePartDelta(
@@ -300,9 +302,14 @@ sealed interface OpenCodeEvent {
 
     data class PermissionAsked(val request: PermissionRequest) : OpenCodeEvent
 
+    data class PermissionReplied(val sessionId: String, val requestId: String) : OpenCodeEvent
+
     data class QuestionAsked(val request: QuestionRequest) : OpenCodeEvent
 
     data class SessionIdle(val sessionId: String) : OpenCodeEvent
+
+    /** Replacement for the deprecated `session.idle`: status is `idle`, `busy` or `retry`. */
+    data class SessionStatusChanged(val sessionId: String, val status: String) : OpenCodeEvent
 
     data class SessionError(val sessionId: String?, val message: String?) : OpenCodeEvent
 

--- a/app/src/main/java/com/opencode/android/core/api/OpenCodeEventParser.kt
+++ b/app/src/main/java/com/opencode/android/core/api/OpenCodeEventParser.kt
@@ -16,15 +16,26 @@ class OpenCodeEventParser(
         },
 ) {
     fun parse(raw: String): OpenCodeEvent {
-        val root =
+        val envelope =
             runCatching { json.parseToJsonElement(raw).jsonObject }.getOrNull()
                 ?: return OpenCodeEvent.Unknown("invalid", raw)
+        // `/global/event` wraps each instance event as {directory, project, workspace, payload};
+        // the per-instance `/event` stream emits the event object directly.
+        val root = envelope["payload"] as? JsonObject ?: envelope
         val type = root["type"]?.jsonPrimitive?.content ?: return OpenCodeEvent.Unknown("missing-type", raw)
-        val properties = root["properties"]?.jsonObject ?: JsonObject(emptyMap())
+        val properties = root["properties"] as? JsonObject ?: JsonObject(emptyMap())
 
         return runCatching {
             when (type) {
                 "server.connected" -> OpenCodeEvent.ServerConnected
+                "message.updated" -> {
+                    val info =
+                        json.decodeFromJsonElement(
+                            OpenCodeMessageInfo.serializer(),
+                            properties["info"]!!.jsonObject,
+                        )
+                    OpenCodeEvent.MessageUpdated(info)
+                }
                 "message.part.updated" -> {
                     val part = json.decodeFromJsonElement(OpenCodePart.serializer(), properties["part"]!!.jsonObject)
                     OpenCodeEvent.MessagePartUpdated(part)
@@ -70,15 +81,47 @@ class OpenCodeEventParser(
                         ),
                     )
                 }
+                "permission.replied" ->
+                    OpenCodeEvent.PermissionReplied(
+                        sessionId = properties["sessionID"]!!.jsonPrimitive.content,
+                        requestId = properties["requestID"]!!.jsonPrimitive.content,
+                    )
                 "session.idle" -> OpenCodeEvent.SessionIdle(properties["sessionID"]!!.jsonPrimitive.content)
+                "session.status" ->
+                    OpenCodeEvent.SessionStatusChanged(
+                        sessionId = properties["sessionID"]!!.jsonPrimitive.content,
+                        status = properties["status"]!!.jsonObject["type"]!!.jsonPrimitive.content,
+                    )
                 "session.error" ->
                     OpenCodeEvent.SessionError(
                         sessionId = (properties["sessionID"] as? JsonPrimitive)?.content,
-                        message = properties["error"]?.toString(),
+                        message = describeError(properties["error"]),
                     )
                 else -> OpenCodeEvent.Unknown(type, raw)
             }
         }.getOrElse { OpenCodeEvent.Unknown(type, raw) }
+    }
+
+    /**
+     * OpenCode reports session failures as a named error object, e.g.
+     * `{"name":"ProviderAuthError","data":{"message":"..."}}`. Prefer the human-readable message
+     * over dumping the raw JSON into the chat.
+     */
+    private fun describeError(element: kotlinx.serialization.json.JsonElement?): String? {
+        if (element == null) return null
+        (element as? JsonPrimitive)?.let { return it.content }
+        val error = element as? JsonObject ?: return element.toString()
+        val message =
+            ((error["data"] as? JsonObject)?.get("message") as? JsonPrimitive)
+                ?.content
+                ?.takeIf { it.isNotBlank() }
+        val name = (error["name"] as? JsonPrimitive)?.content?.takeIf { it.isNotBlank() }
+        return when {
+            message != null && name != null -> "$name: $message"
+            message != null -> message
+            name != null -> name
+            else -> error.toString()
+        }
     }
 
     private fun parseQuestionPrompt(element: kotlinx.serialization.json.JsonElement): QuestionPrompt? =

--- a/app/src/main/java/com/opencode/android/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/opencode/android/data/repository/RuntimeActivityRepository.kt
@@ -225,6 +225,30 @@ class RuntimeActivityRepository(
                 appendLog("実行完了", null, event.sessionId)
                 onSessionIdle?.invoke(event.sessionId)
             }
+            is OpenCodeEvent.MessageUpdated -> {
+                mutableState.update { current ->
+                    current.copy(activeSessionIds = current.activeSessionIds + event.info.sessionId)
+                }
+            }
+            is OpenCodeEvent.PermissionReplied -> {
+                mutableState.update { current ->
+                    current.copy(permissions = current.permissions.filterNot { it.id == event.requestId })
+                }
+            }
+            is OpenCodeEvent.SessionStatusChanged -> {
+                // Completion notifications stay driven by session.idle so a finished run is
+                // never announced twice.
+                mutableState.update { current ->
+                    current.copy(
+                        activeSessionIds =
+                            if (event.status == "idle") {
+                                current.activeSessionIds - event.sessionId
+                            } else {
+                                current.activeSessionIds + event.sessionId
+                            },
+                    )
+                }
+            }
             is OpenCodeEvent.SessionError -> {
                 event.sessionId?.let { sessionId ->
                     mutableState.update { current ->

--- a/app/src/main/java/com/opencode/android/feature/assistant/OpenCodeVoiceSession.kt
+++ b/app/src/main/java/com/opencode/android/feature/assistant/OpenCodeVoiceSession.kt
@@ -224,7 +224,19 @@ class OpenCodeVoiceSession(context: Context) :
                                     showError(event.message ?: context.getString(R.string.voice_processing_failed))
                                 }
                             }
+                            is OpenCodeEvent.PermissionReplied -> {
+                                if (
+                                    event.sessionId == sessionId &&
+                                    permissionRequest.value?.id == event.requestId
+                                ) {
+                                    permissionRequest.value = null
+                                }
+                            }
+                            // session.idle above is the single completion signal for voice;
+                            // handling session.status too would finish the same turn twice.
                             OpenCodeEvent.ServerConnected,
+                            is OpenCodeEvent.MessageUpdated,
+                            is OpenCodeEvent.SessionStatusChanged,
                             is OpenCodeEvent.QuestionAsked,
                             is OpenCodeEvent.Unknown,
                             -> Unit

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
@@ -254,6 +254,9 @@ class ChatViewModel(
     private var tts: TextToSpeech? = null
     private var contextLimit: Long = 0L
     private val streamedParts = mutableMapOf<String, LinkedHashMap<String, ChatPart>>()
+
+    /** Message id to role, learned from `message.updated`, so user echoes can be skipped. */
+    private val messageRoles = mutableMapOf<String, String>()
     private val connectionMonitor = ConnectionQualityMonitor(viewModelScope)
 
     init {
@@ -441,6 +444,7 @@ class ChatViewModel(
         // because the old chat happened to be mid-turn when the user navigated away.
         val switchingSession = _uiState.value.sessionId != sessionId
         streamedParts.clear()
+        messageRoles.clear()
         _uiState.update {
             it.copy(
                 sessionId = sessionId,
@@ -520,6 +524,7 @@ class ChatViewModel(
 
     fun newSession() {
         streamedParts.clear()
+        messageRoles.clear()
         _uiState.update {
             it.copy(
                 sessionId = null,
@@ -954,10 +959,17 @@ class ChatViewModel(
                 }
                 drainOfflineQueue()
             }
+            is OpenCodeEvent.MessageUpdated -> {
+                if (event.info.sessionId != activeSession) return
+                messageRoles[event.info.id] = event.info.role
+            }
             is OpenCodeEvent.MessagePartUpdated -> {
                 val part = event.part
                 if (part.sessionId != activeSession) return
                 val messageId = part.messageId ?: part.id ?: return
+                // The server echoes the user's own prompt back as parts too; rendering those
+                // would duplicate the bubble the composer already added.
+                if (messageRoles[messageId] == "user") return
                 val partId = part.id ?: messageId
                 val chatPart = part.toChatPart() ?: return
                 val messageParts = streamedParts.getOrPut(messageId) { linkedMapOf() }
@@ -1017,23 +1029,28 @@ class ChatViewModel(
                     )
                 }
             }
+            is OpenCodeEvent.PermissionReplied -> {
+                // Answered elsewhere — another device, or the TUI. Drop the stale card.
+                if (event.sessionId != activeSession) return
+                _uiState.update { state ->
+                    state.copy(permissions = state.permissions.filterNot { it.id == event.requestId })
+                }
+            }
+            is OpenCodeEvent.SessionStatusChanged -> {
+                // session.idle is deprecated in favour of session.status; treat idle the same way,
+                // and let a busy status pick up a run that was started from another client.
+                if (event.sessionId != activeSession) return
+                when (event.status) {
+                    "idle" -> handleSessionIdle(event.sessionId)
+                    "busy", "retry" ->
+                        if (!_uiState.value.isRunning) {
+                            _uiState.update { it.copy(isRunning = true) }
+                        }
+                }
+            }
             is OpenCodeEvent.SessionIdle -> {
                 if (event.sessionId != activeSession) return
-                streamedParts.clear()
-                _uiState.update { state ->
-                    state.copy(
-                        messages =
-                            state.messages.map { message ->
-                                if (message.isStreaming) message.copy(isStreaming = false) else message
-                            },
-                        isRunning = false,
-                        isThinking = false,
-                    )
-                }
-                refreshContextUsage(event.sessionId)
-                refreshMessages(event.sessionId)
-                onSessionCreated()
-                drainQueue()
+                handleSessionIdle(event.sessionId)
             }
             is OpenCodeEvent.SessionError -> {
                 if (event.sessionId != null && event.sessionId != activeSession) return
@@ -1047,6 +1064,24 @@ class ChatViewModel(
             }
             is OpenCodeEvent.Unknown -> Unit
         }
+    }
+
+    private fun handleSessionIdle(sessionId: String) {
+        streamedParts.clear()
+        _uiState.update { state ->
+            state.copy(
+                messages =
+                    state.messages.map { message ->
+                        if (message.isStreaming) message.copy(isStreaming = false) else message
+                    },
+                isRunning = false,
+                isThinking = false,
+            )
+        }
+        refreshContextUsage(sessionId)
+        refreshMessages(sessionId)
+        onSessionCreated()
+        drainQueue()
     }
 
     private fun refreshMessages(sessionId: String) {
@@ -1107,6 +1142,7 @@ class ChatViewModel(
     }
 
     private fun toUiMessage(message: OpenCodeMessage): ChatMessage? {
+        messageRoles[message.info.id] = message.info.role
         val parts = message.parts.mapNotNull { it.toChatPart() }
         val attachments =
             message.parts.mapNotNull { part ->

--- a/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/OpenCodeChatScreen.kt
@@ -589,8 +589,7 @@ private fun AgentSelector(
 private val TOOL_CALL_ECHO_REGEX =
     Regex("""Called the [A-Za-z][A-Za-z ]*? tool with the following input: \{(?:[^{}]|\{[^{}]*\})*\}""")
 
-private fun String.hideToolCallEcho(): String =
-    TOOL_CALL_ECHO_REGEX.replace(this, "").replace(Regex("[ \t]+\n"), "\n").trim()
+private fun String.hideToolCallEcho(): String = TOOL_CALL_ECHO_REGEX.replace(this, "").replace(Regex("[ \t]+\n"), "\n").trim()
 
 // Not private: reused by ChatHomeScreen.kt (same package) for the redesigned chat screen.
 @Composable

--- a/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
+++ b/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
@@ -324,7 +324,30 @@ class OpenCodeApiClientTest {
 
             assertTrue(events[0] is OpenCodeEvent.ServerConnected)
             assertEquals("s1", (events[1] as OpenCodeEvent.SessionIdle).sessionId)
-            assertEquals("/event", server.takeRequest().path)
+            // The cross-instance stream is required: `/event` only carries events for the
+            // instance rooted at the server's own working directory, so a session created in
+            // any other workspace would emit nothing there.
+            assertEquals("/global/event", server.takeRequest().path)
+            assertEquals("/global/event", server.takeRequest().path)
+        }
+
+    @Test
+    fun `event stream falls back to the instance route on older servers`() =
+        runBlocking {
+            server.enqueue(MockResponse().setResponseCode(404).setBody("not found"))
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Type", "text/event-stream")
+                    .setBody("data: {\"type\":\"session.idle\",\"properties\":{\"sessionID\":\"s1\"}}\n\n"),
+            )
+
+            val events =
+                withTimeout(3_000) {
+                    client().events().take(1).toList()
+                }
+
+            assertEquals("s1", (events.single() as OpenCodeEvent.SessionIdle).sessionId)
+            assertEquals("/global/event", server.takeRequest().path)
             assertEquals("/event", server.takeRequest().path)
         }
 

--- a/app/src/test/java/com/opencode/android/core/api/OpenCodeEventParserTest.kt
+++ b/app/src/test/java/com/opencode/android/core/api/OpenCodeEventParserTest.kt
@@ -130,4 +130,70 @@ class OpenCodeEventParserTest {
         assertTrue(event is OpenCodeEvent.Unknown)
         assertEquals("question.asked", (event as OpenCodeEvent.Unknown).type)
     }
+
+    @Test
+    fun `unwraps the global event stream envelope`() {
+        val event =
+            parser.parse(
+                """{"directory":"/workspace/project","project":"prj","payload":{"id":"evt_1","type":"message.part.delta","properties":{"sessionID":"s1","messageID":"m1","partID":"p1","field":"text","delta":"Hi"}}}""",
+            ) as OpenCodeEvent.MessagePartDelta
+
+        assertEquals("s1", event.sessionId)
+        assertEquals("Hi", event.delta)
+    }
+
+    @Test
+    fun `unwraps a permission request from the global event stream`() {
+        val event =
+            parser.parse(
+                """{"directory":"/workspace/project","payload":{"id":"evt_2","type":"permission.asked","properties":{"id":"perm1","sessionID":"s1","permission":"bash","patterns":["git status"],"metadata":{}}}}""",
+            ) as OpenCodeEvent.PermissionAsked
+
+        assertEquals("perm1", event.request.id)
+        assertEquals("s1", event.request.sessionId)
+    }
+
+    @Test
+    fun `parses message updated event`() {
+        val event =
+            parser.parse(
+                """{"type":"message.updated","properties":{"sessionID":"s1","info":{"id":"m1","sessionID":"s1","role":"user","time":{"created":1}}}}""",
+            ) as OpenCodeEvent.MessageUpdated
+
+        assertEquals("m1", event.info.id)
+        assertEquals("user", event.info.role)
+    }
+
+    @Test
+    fun `parses permission replied event`() {
+        val event =
+            parser.parse(
+                """{"type":"permission.replied","properties":{"sessionID":"s1","requestID":"perm1","reply":"once"}}""",
+            ) as OpenCodeEvent.PermissionReplied
+
+        assertEquals("s1", event.sessionId)
+        assertEquals("perm1", event.requestId)
+    }
+
+    @Test
+    fun `parses session status event`() {
+        val event =
+            parser.parse(
+                """{"type":"session.status","properties":{"sessionID":"s1","status":{"type":"busy"}}}""",
+            ) as OpenCodeEvent.SessionStatusChanged
+
+        assertEquals("s1", event.sessionId)
+        assertEquals("busy", event.status)
+    }
+
+    @Test
+    fun `session error reports the readable message instead of raw json`() {
+        val event =
+            parser.parse(
+                """{"type":"session.error","properties":{"sessionID":"s1","error":{"name":"ProviderAuthError","data":{"message":"missing api key"}}}}""",
+            ) as OpenCodeEvent.SessionError
+
+        assertEquals("s1", event.sessionId)
+        assertEquals("ProviderAuthError: missing api key", event.message)
+    }
 }


### PR DESCRIPTION
#90 の差し替えです。中身は同一で、履歴を最新 main の上の1コミットに整理しました（#90 はコンフリクト解消のマージコミットが commitlint を落としていました）。

## 症状

ツールカードが `保留中` / `実行中` のまま固まり、実行が再開しない。本文は途中まで出るのに、そこで止まる。

## 原因

`GET /event` は **インスタンス単位** のストリームです。OpenCode 1.18.3 のサーバー実装で確認しました：

- `routes/instance/httpapi/groups/event.ts` — `/event` に `WorkspaceRoutingMiddleware` + `InstanceContextMiddleware` が付いている
- `middleware/workspace-routing.ts` — `directory` クエリが無い場合は `process.cwd()` にフォールバックする
- `middleware/instance-context.ts` — その `directory` でインスタンスをロードする

アプリは `POST /session?directory=<選択した作業フォルダ>` でセッションを作る一方、`/event` には `directory` を渡していませんでした。ローカルランタイムはサーバーを `-w /root` で起動し、作業フォルダは `/workspace` 配下にあるので、**これは例外ケースではなく通常ケース**です。結果、自分のセッションのイベントが1件も届きません。

固まる理由はここから直結します。**承認要求がクライアントに届く経路はイベントストリームだけです** — 承認要求の一覧APIは存在せず（`/session/:id/permissions/:permissionID` は回答用のみ）、`listMessages` にも含まれません。したがって：

1. `permission.asked` が届かない
2. → 「自動」設定が発火しない
3. → サーバーは与えられるはずのない承認を待ち続ける
4. → ツールカードが `保留中` / `実行中` のまま固まる

固まる直前まで本文が出ていたのは、メッセージのポーリングが履歴を追従していたためです。ポーリングがタイムアウトすると完全に停止します。

なお `prompt_async` 自体は届きます（セッションスコープのルートはミドルウェアがセッションIDから `directory` を解決するため）。実行は始まるのに画面が追従しない、という症状と一致します。

## 変更内容

**本丸**: 横断ストリーム `GET /global/event` を購読し、`{directory, project, workspace, payload}` エンベロープを展開します。`/global/event` を持たないサーバーには `/event` へフォールバックします。

加えて、これまで無視していた3つのイベントに対応しました：

- `message.updated` — メッセージの role を記録し、サーバーがユーザー発言を part として返してくるぶんをアシスタント吹き出しとして二重表示しないように
- `permission.replied` — 他クライアントで応答済みの承認カードを消す
- `session.status` — 非推奨の `session.idle` の後継。busy 状態で他クライアント発の実行にも追従

`session.error` は生JSONではなく、名前付きエラーのメッセージを表示するようにしました。

## 注記

- 当初の作業は main から93コミット遅れた地点で書かれており全ファイルでコンフリクトしたため、**最新 main の上で作り直しています。** 当時入れていた耐障害性の改善（イベント購読の張り直し、delta の取りこぼし、再接続時の再取得、送信後ポーリング、自動スクロール追従）は、その後 main 側で独立に実装済みだったため、この差分には含まれません。
- `OpenCodeChatScreen.kt` の spotless 違反1行を含みます。これは main 由来で `spotlessCheck` を落とすため、このPRのCIをブロックしていました。

## テスト

ローカルでCIと同じゲートを実行し、すべて成功：

- `./gradlew detekt spotlessCheck :app:testDebugUnitTest :app:lintDebug` — BUILD SUCCESSFUL、48テストクラス、失敗0

新規テスト：

- `/global/event` エンベロープの展開（イベント本体・承認要求）
- `/global/event` が404のときの `/event` フォールバック
- `message.updated` / `permission.replied` / `session.status` のパース
- `session.error` が読める文言になること

## 未確認

実機での動作確認はしていません（このセッションに端末もサーバーもないため）。サーバー側の契約は OpenCode 1.18.3 のソースを直接読んで突き合わせています。

---
_Generated by [Claude Code](https://claude.ai/code/session_016rtC9N13Hwd3GXqmTnwit3)_