### PR TITLE
fix: make the question tool answerable, not just visible

### DIFF
--- a/app/src/main/java/com/opencode/android/core/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/opencode/android/core/api/OpenCodeApiClient.kt
@@ -408,10 +408,17 @@ class OpenCodeApiClient(
         )
     }
 
+    /**
+     * Questions are answered on the request itself, not through the session that asked. Like
+     * `/event`, the question routes resolve to a single OpenCode instance — the one rooted at
+     * [directory], defaulting to the server's own working directory — so a request raised in any
+     * other workspace is invisible without it and the reply comes back as
+     * `QuestionNotFoundError`. Pass the directory the question was asked in.
+     */
     suspend fun answerQuestion(
-        sessionId: String,
         requestId: String,
         answers: List<List<String>>,
+        directory: String? = null,
     ): Boolean {
         val body =
             buildJsonObject {
@@ -425,10 +432,32 @@ class OpenCodeApiClient(
                 )
             }
         return post(
-            "session/${encodePath(sessionId)}/question/${encodePath(requestId)}",
+            "question/${encodePath(requestId)}/reply",
             body,
+            query("directory" to directory),
         )
     }
+
+    /** Declines a question outright, which fails the waiting tool call without killing the turn. */
+    suspend fun rejectQuestion(
+        requestId: String,
+        directory: String? = null,
+    ): Boolean =
+        post(
+            "question/${encodePath(requestId)}/reject",
+            JsonObject(emptyMap()),
+            query("directory" to directory),
+        )
+
+    /**
+     * Questions that are still waiting for an answer. They reach a client only through the event
+     * stream, so anything asked while this client was away — a reconnect, a restart, a session
+     * opened after the fact — has to be recovered here or the turn stays blocked with nothing on
+     * screen to unblock it.
+     */
+    suspend fun pendingQuestions(directory: String? = null): List<QuestionRequest> =
+        getList<QuestionRequest>("question", query("directory" to directory))
+            .map { request -> request.copy(directory = request.directory ?: directory) }
 
     /**
      * `GET /event` is scoped to a single OpenCode instance: the one rooted at the request's

--- a/app/src/main/java/com/opencode/android/core/api/OpenCodeApiModels.kt
+++ b/app/src/main/java/com/opencode/android/core/api/OpenCodeApiModels.kt
@@ -275,14 +275,23 @@ data class QuestionPrompt(
     val header: String? = null,
     val options: List<QuestionOption> = emptyList(),
     val placeholder: String? = null,
+    /** Whether more than one of [options] may be selected. OpenCode sets this per prompt. */
+    val multiple: Boolean = false,
+    /** Whether an answer outside [options] is accepted. OpenCode defaults this to true. */
+    val custom: Boolean = true,
 )
 
 @Serializable
 data class QuestionRequest(
     val id: String,
-    val sessionId: String,
+    @SerialName("sessionID") val sessionId: String,
     val questions: List<QuestionPrompt>,
-    val multiple: Boolean = false,
+    /**
+     * Workspace the request belongs to. The question routes are scoped to a single OpenCode
+     * instance, so replying needs the directory the question was asked in — it is not carried
+     * by the request itself, but by the `/global/event` envelope that delivered it.
+     */
+    val directory: String? = null,
 )
 
 sealed interface OpenCodeEvent {

--- a/app/src/main/java/com/opencode/android/core/api/OpenCodeEventParser.kt
+++ b/app/src/main/java/com/opencode/android/core/api/OpenCodeEventParser.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -77,7 +77,8 @@ class OpenCodeEventParser(
                             id = properties["id"]!!.jsonPrimitive.content,
                             sessionId = properties["sessionID"]!!.jsonPrimitive.content,
                             questions = questions,
-                            multiple = (properties["multiple"] as? JsonPrimitive)?.boolean ?: false,
+                            // Only `/global/event` carries the workspace, and answering needs it.
+                            directory = (envelope["directory"] as? JsonPrimitive)?.content,
                         ),
                     )
                 }
@@ -139,6 +140,9 @@ class OpenCodeEventParser(
                                 ?.mapNotNull { option -> parseQuestionOption(option) }
                                 .orEmpty(),
                         placeholder = (prompt["placeholder"] as? JsonPrimitive)?.content,
+                        // Both flags belong to the individual prompt, not to the request.
+                        multiple = (prompt["multiple"] as? JsonPrimitive)?.booleanOrNull ?: false,
+                        custom = (prompt["custom"] as? JsonPrimitive)?.booleanOrNull ?: true,
                     )
                 }
             }

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
@@ -81,10 +81,11 @@ data class PendingQuestionUi(
     val canSubmit: Boolean
         get() =
             request.questions.indices.all { index ->
+                val prompt = request.questions[index]
                 sanitizeQuestionAnswer(
-                    prompt = request.questions[index],
+                    prompt = prompt,
                     answers = selectedAnswers.getOrElse(index) { emptyList() },
-                    multiple = request.multiple,
+                    multiple = prompt.multiple,
                 ).isNotEmpty()
             }
 
@@ -460,6 +461,7 @@ class ChatViewModel(
             )
         }
         if (parent == null) resolveParentSession(sessionId)
+        refreshPendingQuestions(sessionId)
         viewModelScope.launch {
             runCatching { currentBackend.listMessages(sessionId) }
                 .onSuccess { messages ->
@@ -792,7 +794,7 @@ class ChatViewModel(
                                 prompt = prompt,
                                 current = pending.selectedAnswers.getOrElse(questionIndex) { emptyList() },
                                 answer = answer,
-                                multiple = pending.request.multiple,
+                                multiple = prompt.multiple,
                             )
                         pending.copy(selectedAnswers = updatedAnswers, error = null)
                     },
@@ -802,14 +804,14 @@ class ChatViewModel(
 
     fun submitQuestion(questionId: String) {
         val currentBackend = backend ?: return
-        val sessionId = _uiState.value.sessionId ?: return
         val pendingQuestion = _uiState.value.pendingQuestions.firstOrNull { it.request.id == questionId } ?: return
         val answers =
             pendingQuestion.request.questions.indices.map { index ->
+                val prompt = pendingQuestion.request.questions[index]
                 sanitizeQuestionAnswer(
-                    prompt = pendingQuestion.request.questions[index],
+                    prompt = prompt,
                     answers = pendingQuestion.selectedAnswers.getOrElse(index) { emptyList() },
-                    multiple = pendingQuestion.request.multiple,
+                    multiple = prompt.multiple,
                 )
             }
         if (answers.any { it.isEmpty() }) {
@@ -844,9 +846,9 @@ class ChatViewModel(
         viewModelScope.launch {
             runCatching {
                 currentBackend.answerQuestion(
-                    sessionId = sessionId,
                     requestId = questionId,
                     answers = answers,
+                    directory = pendingQuestion.workspaceDirectory(),
                 )
             }.onSuccess { accepted ->
                 _uiState.update { state ->
@@ -885,6 +887,38 @@ class ChatViewModel(
     }
 
     /**
+     * The directory the question routes have to be scoped to. What the event stream reported is
+     * authoritative; the selected workspace is the fallback for the older per-instance `/event`
+     * stream, whose frames carry no directory.
+     */
+    private fun PendingQuestionUi.workspaceDirectory(): String? = request.directory ?: _uiState.value.selectedWorkspacePath
+
+    /**
+     * Recovers questions that are already waiting for an answer. A question reaches the chat as an
+     * event and nowhere else, so one asked while this client was not listening — before the app
+     * opened the session, or across a dropped event stream — would otherwise leave the turn
+     * blocked with nothing on screen to unblock it.
+     */
+    private fun refreshPendingQuestions(sessionId: String) {
+        val currentBackend = backend ?: return
+        viewModelScope.launch {
+            val pending =
+                runCatching { currentBackend.pendingQuestions(_uiState.value.selectedWorkspacePath) }
+                    .getOrElse { return@launch }
+                    .filter { it.sessionId == sessionId }
+            if (pending.isEmpty()) return@launch
+            _uiState.update { state ->
+                if (state.sessionId != sessionId) return@update state
+                val known = state.pendingQuestions.map { it.request.id }.toSet()
+                state.copy(
+                    pendingQuestions =
+                        state.pendingQuestions + pending.filterNot { it.id in known }.map(PendingQuestionUi::from),
+                )
+            }
+        }
+    }
+
+    /**
      * Hides the question card and leaves the turn alone, so the user can ignore the question and
      * just keep typing. The request stays open on the OpenCode side; this only affects what the
      * chat shows.
@@ -898,9 +932,9 @@ class ChatViewModel(
     }
 
     /**
-     * Dismisses a question and stops the turn that is waiting on the answer. OpenCode has no
-     * "declined" reply for the question tool, so this is the way to end a turn outright rather
-     * than answering it — [dismissQuestion] is the lighter option that only clears the card.
+     * Declines the question. OpenCode fails the waiting tool call with "the user dismissed this
+     * question", which the agent can react to — unlike [dismissQuestion], which only clears the
+     * card and leaves the request open.
      */
     fun cancelQuestion(questionId: String) {
         val pendingQuestion = _uiState.value.pendingQuestions.firstOrNull { it.request.id == questionId } ?: return
@@ -911,13 +945,14 @@ class ChatViewModel(
         }
         val currentBackend = backend ?: return
         viewModelScope.launch {
-            runCatching { currentBackend.abortSession(pendingQuestion.request.sessionId) }
-                .onSuccess {
-                    _uiState.update { it.copy(isRunning = false, isThinking = false) }
-                }
-                .onFailure { error ->
-                    _uiState.update { it.copy(error = error.safeMessage()) }
-                }
+            runCatching {
+                currentBackend.rejectQuestion(
+                    requestId = questionId,
+                    directory = pendingQuestion.workspaceDirectory(),
+                )
+            }.onFailure { error ->
+                _uiState.update { it.copy(error = error.safeMessage()) }
+            }
         }
     }
 
@@ -956,6 +991,7 @@ class ChatViewModel(
                                 }
                             }
                     }
+                    refreshPendingQuestions(session)
                 }
                 drainOfflineQueue()
             }
@@ -1346,7 +1382,8 @@ private fun sanitizeQuestionAnswer(
 
     val optionLabels = prompt.options.map { it.label }.toSet()
     val selectedOptions = normalizedAnswers.filter { it in optionLabels }.distinct()
-    val fallback = normalizedAnswers.lastOrNull { it !in optionLabels }
+    // A prompt with `custom` off only accepts its own options, so never submit a typed answer.
+    val fallback = normalizedAnswers.lastOrNull { it !in optionLabels }?.takeIf { prompt.custom }
     return if (multiple) {
         selectedOptions + listOfNotNull(fallback)
     } else {

--- a/app/src/main/java/com/opencode/android/feature/chat/QuestionCard.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/QuestionCard.kt
@@ -105,7 +105,7 @@ fun QuestionCard(
                                     .clickable { onAnswerSelected(question.request.id, index, option.label) },
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            if (question.request.multiple) {
+                            if (prompt.multiple) {
                                 Checkbox(
                                     checked = selected,
                                     onCheckedChange = { onAnswerSelected(question.request.id, index, option.label) },
@@ -129,27 +129,30 @@ fun QuestionCard(
                         }
                     }
 
-                    // Always offered, including alongside options: the presented choices are not
-                    // always exhaustive, and there was previously no way to answer anything else.
-                    if (prompt.options.isNotEmpty()) {
-                        Text(
-                            text = stringResource(R.string.question_free_text_label),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    // Offered alongside the options too, because the presented choices are not
+                    // always exhaustive. `custom` is how OpenCode says a prompt only accepts its
+                    // own options, so a typed answer is dropped when it is off.
+                    if (prompt.options.isEmpty() || prompt.custom) {
+                        if (prompt.options.isNotEmpty()) {
+                            Text(
+                                text = stringResource(R.string.question_free_text_label),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        OutlinedTextField(
+                            value = fallbackText,
+                            onValueChange = { onAnswerSelected(question.request.id, index, it) },
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .testTag("question-free-text-${question.request.id}-$index"),
+                            placeholder = {
+                                Text(prompt.placeholder ?: stringResource(R.string.message_hint))
+                            },
+                            singleLine = !prompt.multiple,
                         )
                     }
-                    OutlinedTextField(
-                        value = fallbackText,
-                        onValueChange = { onAnswerSelected(question.request.id, index, it) },
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .testTag("question-free-text-${question.request.id}-$index"),
-                        placeholder = {
-                            Text(prompt.placeholder ?: stringResource(R.string.message_hint))
-                        },
-                        singleLine = !question.request.multiple,
-                    )
                 }
             }
 

--- a/app/src/main/java/com/opencode/android/runtime/OpenCodeBackend.kt
+++ b/app/src/main/java/com/opencode/android/runtime/OpenCodeBackend.kt
@@ -21,6 +21,7 @@ import com.opencode.android.core.api.PromptRequest
 import com.opencode.android.core.api.ProviderAuthAuthorization
 import com.opencode.android.core.api.ProviderAuthMethod
 import com.opencode.android.core.api.ProviderCatalog
+import com.opencode.android.core.api.QuestionRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -162,10 +163,17 @@ interface OpenCodeBackend {
     ): Boolean
 
     suspend fun answerQuestion(
-        sessionId: String,
         requestId: String,
         answers: List<List<String>>,
+        directory: String?,
     ): Boolean = unsupported("question answers")
+
+    suspend fun rejectQuestion(
+        requestId: String,
+        directory: String?,
+    ): Boolean = unsupported("question rejection")
+
+    suspend fun pendingQuestions(directory: String?): List<QuestionRequest> = emptyList()
 
     suspend fun archiveSession(sessionId: String): OpenCodeSession = unsupported("session archive")
 

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalOpenCodeBackend.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalOpenCodeBackend.kt
@@ -21,6 +21,7 @@ import com.opencode.android.core.api.PromptRequest
 import com.opencode.android.core.api.ProviderAuthAuthorization
 import com.opencode.android.core.api.ProviderAuthMethod
 import com.opencode.android.core.api.ProviderCatalog
+import com.opencode.android.core.api.QuestionRequest
 import com.opencode.android.data.connection.ConnectionProfile
 import com.opencode.android.runtime.BackendKind
 import com.opencode.android.runtime.OpenCodeBackend
@@ -194,10 +195,17 @@ class LocalOpenCodeBackend(
     ): Boolean = delegate().respondToPermission(sessionId, permissionId, response, remember)
 
     override suspend fun answerQuestion(
-        sessionId: String,
         requestId: String,
         answers: List<List<String>>,
-    ): Boolean = delegate().answerQuestion(sessionId, requestId, answers)
+        directory: String?,
+    ): Boolean = delegate().answerQuestion(requestId, answers, directory)
+
+    override suspend fun rejectQuestion(
+        requestId: String,
+        directory: String?,
+    ): Boolean = delegate().rejectQuestion(requestId, directory)
+
+    override suspend fun pendingQuestions(directory: String?): List<QuestionRequest> = delegate().pendingQuestions(directory)
 
     override suspend fun archiveSession(sessionId: String): OpenCodeSession = delegate().archiveSession(sessionId)
 

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeTarget.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeTarget.kt
@@ -17,6 +17,7 @@ import com.opencode.android.core.api.PromptRequest
 import com.opencode.android.core.api.ProviderAuthAuthorization
 import com.opencode.android.core.api.ProviderAuthMethod
 import com.opencode.android.core.api.ProviderCatalog
+import com.opencode.android.core.api.QuestionRequest
 import com.opencode.android.runtime.BackendKind
 import com.opencode.android.runtime.LocalRuntimeStatus
 import com.opencode.android.runtime.PermissionResponse
@@ -271,10 +272,17 @@ class LocalRuntimeTarget(
     ): Boolean = backend.summarizeSession(sessionId, providerId, modelId)
 
     override suspend fun answerQuestion(
-        sessionId: String,
         requestId: String,
         answers: List<List<String>>,
-    ): Boolean = backend.answerQuestion(sessionId, requestId, answers)
+        directory: String?,
+    ): Boolean = backend.answerQuestion(requestId, answers, directory)
+
+    override suspend fun rejectQuestion(
+        requestId: String,
+        directory: String?,
+    ): Boolean = backend.rejectQuestion(requestId, directory)
+
+    override suspend fun pendingQuestions(directory: String?): List<QuestionRequest> = backend.pendingQuestions(directory)
 
     override suspend fun initAgentsMd(sessionId: String): Boolean = backend.initAgentsMd(sessionId)
 

--- a/app/src/main/java/com/opencode/android/runtime/remote/RemoteOpenCodeBackend.kt
+++ b/app/src/main/java/com/opencode/android/runtime/remote/RemoteOpenCodeBackend.kt
@@ -22,6 +22,7 @@ import com.opencode.android.core.api.PromptRequest
 import com.opencode.android.core.api.ProviderAuthAuthorization
 import com.opencode.android.core.api.ProviderAuthMethod
 import com.opencode.android.core.api.ProviderCatalog
+import com.opencode.android.core.api.QuestionRequest
 import com.opencode.android.data.connection.ConnectionProfile
 import com.opencode.android.runtime.BackendKind
 import com.opencode.android.runtime.OpenCodeBackend
@@ -163,10 +164,17 @@ class RemoteOpenCodeBackend(
         )
 
     override suspend fun answerQuestion(
-        sessionId: String,
         requestId: String,
         answers: List<List<String>>,
-    ): Boolean = client.answerQuestion(sessionId, requestId, answers)
+        directory: String?,
+    ): Boolean = client.answerQuestion(requestId, answers, directory)
+
+    override suspend fun rejectQuestion(
+        requestId: String,
+        directory: String?,
+    ): Boolean = client.rejectQuestion(requestId, directory)
+
+    override suspend fun pendingQuestions(directory: String?): List<QuestionRequest> = client.pendingQuestions(directory)
 
     override suspend fun archiveSession(sessionId: String): OpenCodeSession = client.archiveSession(sessionId)
 

--- a/app/src/main/java/com/opencode/android/runtime/remote/RemoteRuntimeTarget.kt
+++ b/app/src/main/java/com/opencode/android/runtime/remote/RemoteRuntimeTarget.kt
@@ -17,6 +17,7 @@ import com.opencode.android.core.api.PromptRequest
 import com.opencode.android.core.api.ProviderAuthAuthorization
 import com.opencode.android.core.api.ProviderAuthMethod
 import com.opencode.android.core.api.ProviderCatalog
+import com.opencode.android.core.api.QuestionRequest
 import com.opencode.android.data.connection.ConnectionProfile
 import com.opencode.android.runtime.BackendKind
 import com.opencode.android.runtime.PermissionResponse
@@ -242,10 +243,17 @@ class RemoteRuntimeTarget(
     ): Boolean = backend.summarizeSession(sessionId, providerId, modelId)
 
     override suspend fun answerQuestion(
-        sessionId: String,
         requestId: String,
         answers: List<List<String>>,
-    ): Boolean = backend.answerQuestion(sessionId, requestId, answers)
+        directory: String?,
+    ): Boolean = backend.answerQuestion(requestId, answers, directory)
+
+    override suspend fun rejectQuestion(
+        requestId: String,
+        directory: String?,
+    ): Boolean = backend.rejectQuestion(requestId, directory)
+
+    override suspend fun pendingQuestions(directory: String?): List<QuestionRequest> = backend.pendingQuestions(directory)
 
     override suspend fun initAgentsMd(sessionId: String): Boolean = backend.initAgentsMd(sessionId)
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">فشلت مصادقة الموفر. حاول مرة أخرى.</string>
     <string name="continue_label">متابعة</string>
     <string name="question_free_text_label">أخرى (اكتب إجابتك)</string>
-    <string name="question_cancel">الإجابة لاحقًا (إيقاف)</string>
+    <string name="question_cancel">رفض الإجابة</string>
     <string name="question_dismiss">إغلاق السؤال</string>
     <string name="assistant_runtime">بيئة تشغيل المساعد</string>
     <string name="assistant_workspace">مسار مساحة عمل المساعد</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">La autenticación del proveedor falló. Inténtalo de nuevo.</string>
     <string name="continue_label">Continuar</string>
     <string name="question_free_text_label">Otro (escribe tu respuesta)</string>
-    <string name="question_cancel">Responder después (detener)</string>
+    <string name="question_cancel">No responder</string>
     <string name="question_dismiss">Cerrar la pregunta</string>
     <string name="assistant_runtime">Entorno de ejecución del asistente</string>
     <string name="assistant_workspace">Ruta del espacio de trabajo del asistente</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">L\'authentification du fournisseur a échoué. Réessayez.</string>
     <string name="continue_label">Continuer</string>
     <string name="question_free_text_label">Autre (saisissez votre réponse)</string>
-    <string name="question_cancel">Répondre plus tard (arrêter)</string>
+    <string name="question_cancel">Ne pas répondre</string>
     <string name="question_dismiss">Fermer la question</string>
     <string name="assistant_runtime">Environnement d\'exécution de l\'assistant</string>
     <string name="assistant_workspace">Chemin de l\'espace de travail de l\'assistant</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">プロバイダー認証に失敗しました。もう一度お試しください。</string>
     <string name="continue_label">続ける</string>
     <string name="question_free_text_label">その他（自由入力）</string>
-    <string name="question_cancel">回答せず中断</string>
+    <string name="question_cancel">回答しない</string>
     <string name="question_dismiss">質問を閉じる</string>
     <string name="assistant_runtime">アシスト実行先</string>
     <string name="assistant_workspace">アシスト作業フォルダ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">A autenticação do provedor falhou. Tente novamente.</string>
     <string name="continue_label">Continuar</string>
     <string name="question_free_text_label">Outro (digite sua resposta)</string>
-    <string name="question_cancel">Responder depois (parar)</string>
+    <string name="question_cancel">Não responder</string>
     <string name="question_dismiss">Fechar a pergunta</string>
     <string name="assistant_runtime">Ambiente de execução do assistente</string>
     <string name="assistant_workspace">Caminho do espaço de trabalho do assistente</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">Аутентификация провайдера не удалась. Попробуйте снова.</string>
     <string name="continue_label">Продолжить</string>
     <string name="question_free_text_label">Другое (введите свой ответ)</string>
-    <string name="question_cancel">Ответить позже (остановить)</string>
+    <string name="question_cancel">Не отвечать</string>
     <string name="question_dismiss">Закрыть вопрос</string>
     <string name="assistant_runtime">Среда выполнения ассистента</string>
     <string name="assistant_workspace">Путь к рабочему пространству ассистента</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">提供商身份验证失败。请重试。</string>
     <string name="continue_label">继续</string>
     <string name="question_free_text_label">其他（自行输入答案）</string>
-    <string name="question_cancel">稍后回答（停止）</string>
+    <string name="question_cancel">不回答</string>
     <string name="question_dismiss">关闭问题</string>
     <string name="assistant_runtime">助手运行时</string>
     <string name="assistant_workspace">助手工作区路径</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <string name="provider_auth_failed">Provider authentication failed. Try again.</string>
     <string name="continue_label">Continue</string>
     <string name="question_free_text_label">Other (type your own answer)</string>
-    <string name="question_cancel">Answer later (stop)</string>
+    <string name="question_cancel">Decline to answer</string>
     <string name="question_dismiss">Dismiss question</string>
     <string name="assistant_runtime">Assistant runtime</string>
     <string name="assistant_workspace">Assistant workspace path</string>

--- a/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
+++ b/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
@@ -162,20 +162,51 @@ class OpenCodeApiClientTest {
         }
 
     @Test
-    fun `answers question request`() =
+    fun `answers question request on the workspace it was asked in`() =
         runBlocking {
             server.enqueue(MockResponse().setBody("true"))
             val client = client()
 
-            val result = client.answerQuestion("s1", "q-1", listOf(listOf("src"), listOf("docs", "tests")))
+            val result = client.answerQuestion("q-1", listOf(listOf("src"), listOf("docs", "tests")), "/workspace/repo")
 
             assertTrue(result)
             val request = server.takeRequest()
-            assertEquals("/session/s1/question/q-1", request.path)
+            // Questions are answered on the request, and the route resolves one OpenCode instance:
+            // without the directory the server looks in its own and reports the request as missing.
+            assertEquals("/question/q-1/reply?directory=%2Fworkspace%2Frepo", request.path)
             val answers = Json.parseToJsonElement(request.body.readUtf8()).jsonObject["answers"]!!.jsonArray
             assertEquals("src", answers[0].jsonArray[0].jsonPrimitive.content)
             assertEquals("docs", answers[1].jsonArray[0].jsonPrimitive.content)
             assertEquals("tests", answers[1].jsonArray[1].jsonPrimitive.content)
+        }
+
+    @Test
+    fun `rejects question request`() =
+        runBlocking {
+            server.enqueue(MockResponse().setBody("true"))
+            val client = client()
+
+            assertTrue(client.rejectQuestion("q-1", "/workspace/repo"))
+            assertEquals("/question/q-1/reject?directory=%2Fworkspace%2Frepo", server.takeRequest().path)
+        }
+
+    @Test
+    fun `lists pending questions and tags them with the workspace`() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """[{"id":"q-1","sessionID":"s1","questions":[{"question":"Run it?","options":[{"label":"Yes"}]}]}]""",
+                ),
+            )
+            val client = client()
+
+            val pending = client.pendingQuestions("/workspace/repo")
+
+            assertEquals("/question?directory=%2Fworkspace%2Frepo", server.takeRequest().path)
+            assertEquals("q-1", pending.single().id)
+            assertEquals("s1", pending.single().sessionId)
+            // The listing does not echo the directory back, but answering still needs it.
+            assertEquals("/workspace/repo", pending.single().directory)
         }
 
     @Test

--- a/app/src/test/java/com/opencode/android/core/api/OpenCodeEventParserTest.kt
+++ b/app/src/test/java/com/opencode/android/core/api/OpenCodeEventParserTest.kt
@@ -87,18 +87,39 @@ class OpenCodeEventParserTest {
     fun `parses question asked with options`() {
         val event =
             parser.parse(
-                """{"type":"question.asked","properties":{"id":"q-1","sessionID":"s1","multiple":true,"questions":[{"question":"Pick a folder","header":"Folder","options":[{"label":"src","description":"Source code"},{"label":"docs"}],"placeholder":"Type a path"}]}}""",
+                """{"directory":"/workspace/repo","project":"global","payload":{"type":"question.asked","properties":{"id":"q-1","sessionID":"s1","questions":[{"question":"Pick a folder","header":"Folder","options":[{"label":"src","description":"Source code"},{"label":"docs"}],"placeholder":"Type a path","multiple":true}]}}}""",
             ) as OpenCodeEvent.QuestionAsked
 
         val request = event.request
         assertEquals("q-1", request.id)
         assertEquals("s1", request.sessionId)
-        assertTrue(request.multiple)
-        assertEquals("Pick a folder", request.questions.single().question)
-        assertEquals("Folder", request.questions.single().header)
-        assertEquals("Type a path", request.questions.single().placeholder)
-        assertEquals(listOf("src", "docs"), request.questions.single().options.map { it.label })
-        assertEquals("Source code", request.questions.single().options.first().description)
+        // Replying is scoped to the workspace the question came from, and only the envelope says
+        // which one that is.
+        assertEquals("/workspace/repo", request.directory)
+        val prompt = request.questions.single()
+        assertEquals("Pick a folder", prompt.question)
+        assertEquals("Folder", prompt.header)
+        assertEquals("Type a path", prompt.placeholder)
+        // OpenCode carries `multiple` on the prompt, not on the request around it.
+        assertTrue(prompt.multiple)
+        assertEquals(listOf("src", "docs"), prompt.options.map { it.label })
+        assertEquals("Source code", prompt.options.first().description)
+    }
+
+    @Test
+    fun `question prompts default to single choice and a typed answer`() {
+        val event =
+            parser.parse(
+                """{"type":"question.asked","properties":{"id":"q-4","sessionID":"s1","questions":[{"question":"Run it?","options":[{"label":"Yes"}]},{"question":"Which one?","options":[{"label":"A"}],"custom":false}]}}""",
+            ) as OpenCodeEvent.QuestionAsked
+
+        val prompts = event.request.questions
+        assertTrue(!prompts.first().multiple)
+        assertTrue(prompts.first().custom)
+        // `custom: false` means the prompt takes nothing but its own options.
+        assertTrue(!prompts.last().custom)
+        // The per-instance stream carries no workspace to scope the reply to.
+        assertEquals(null, event.request.directory)
     }
 
     @Test
@@ -110,7 +131,7 @@ class OpenCodeEventParserTest {
 
         assertEquals("Continue?", event.request.questions.single().question)
         assertTrue(event.request.questions.single().options.isEmpty())
-        assertTrue(!event.request.multiple)
+        assertTrue(!event.request.questions.single().multiple)
     }
 
     @Test

--- a/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelQuestionTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelQuestionTest.kt
@@ -193,7 +193,7 @@ class ChatViewModelQuestionTest {
         }
 
     @Test
-    fun `cancelling a question drops the card and stops the waiting turn`() =
+    fun `cancelling a question declines it instead of killing the turn`() =
         runTest(dispatcher) {
             val backend = FakeBackend()
             val viewModel = ChatViewModel(backend)
@@ -201,7 +201,7 @@ class ChatViewModelQuestionTest {
             viewModel.openSession("session-1")
             advanceUntilIdle()
             backend.events.emit(
-                OpenCodeEvent.QuestionAsked(request(id = "q-1", sessionId = "session-1")),
+                OpenCodeEvent.QuestionAsked(request(id = "q-1", sessionId = "session-1", directory = "/workspace/repo")),
             )
             advanceUntilIdle()
             assertEquals("q-1", viewModel.uiState.value.pendingQuestions.single().request.id)
@@ -210,9 +210,116 @@ class ChatViewModelQuestionTest {
             advanceUntilIdle()
 
             assertTrue(viewModel.uiState.value.pendingQuestions.isEmpty())
-            assertEquals(listOf("session-1"), backend.abortedSessions)
+            assertEquals(listOf("q-1" to "/workspace/repo"), backend.rejectedQuestions)
+            assertTrue(backend.abortedSessions.isEmpty())
             assertTrue(backend.answeredQuestions.isEmpty())
-            assertFalse(viewModel.uiState.value.isRunning)
+        }
+
+    @Test
+    fun `answering is scoped to the workspace the question came from`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+            backend.events.emit(
+                OpenCodeEvent.QuestionAsked(request(id = "q-1", sessionId = "session-1", directory = "/workspace/repo")),
+            )
+            advanceUntilIdle()
+
+            viewModel.selectQuestionAnswer("q-1", 0, "src")
+            viewModel.submitQuestion("q-1")
+            advanceUntilIdle()
+
+            assertEquals("/workspace/repo", backend.answeredQuestions.single().directory)
+        }
+
+    @Test
+    fun `multi select prompts keep every chosen option`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+            backend.events.emit(
+                OpenCodeEvent.QuestionAsked(
+                    request(
+                        id = "q-1",
+                        sessionId = "session-1",
+                        options = listOf("src", "docs"),
+                        multiple = true,
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.selectQuestionAnswer("q-1", 0, "src")
+            viewModel.selectQuestionAnswer("q-1", 0, "docs")
+            viewModel.submitQuestion("q-1")
+            advanceUntilIdle()
+
+            assertEquals(listOf(listOf("src", "docs")), backend.answeredQuestions.single().answers)
+        }
+
+    @Test
+    fun `a prompt that refuses custom answers submits only its own options`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+            backend.events.emit(
+                OpenCodeEvent.QuestionAsked(
+                    request(id = "q-1", sessionId = "session-1", options = listOf("src"), custom = false),
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.selectQuestionAnswer("q-1", 0, "somewhere else")
+            assertFalse(viewModel.uiState.value.pendingQuestions.single().canSubmit)
+
+            viewModel.selectQuestionAnswer("q-1", 0, "src")
+            viewModel.submitQuestion("q-1")
+            advanceUntilIdle()
+
+            assertEquals(listOf(listOf("src")), backend.answeredQuestions.single().answers)
+        }
+
+    @Test
+    fun `a question asked before the session was open is recovered`() =
+        runTest(dispatcher) {
+            val backend =
+                FakeBackend(
+                    pending =
+                        listOf(
+                            request(id = "q-1", sessionId = "session-1"),
+                            request(id = "q-2", sessionId = "session-2"),
+                        ),
+                )
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+
+            // Only the open session's question, and only because it was fetched: no event carried it.
+            assertEquals(listOf("q-1"), viewModel.uiState.value.pendingQuestions.map { it.request.id })
+        }
+
+    @Test
+    fun `a recovered question is not duplicated by its event`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend(pending = listOf(request(id = "q-1", sessionId = "session-1")))
+            val viewModel = ChatViewModel(backend)
+
+            viewModel.openSession("session-1")
+            advanceUntilIdle()
+            backend.events.emit(OpenCodeEvent.QuestionAsked(request(id = "q-1", sessionId = "session-1")))
+            advanceUntilIdle()
+
+            assertEquals(listOf("q-1"), viewModel.uiState.value.pendingQuestions.map { it.request.id })
         }
 
     private fun request(
@@ -221,10 +328,13 @@ class ChatViewModelQuestionTest {
         question: String = "Pick a folder",
         options: List<String> = listOf("src"),
         placeholder: String? = null,
+        multiple: Boolean = false,
+        custom: Boolean = true,
+        directory: String? = null,
     ) = QuestionRequest(
         id = id,
         sessionId = sessionId,
-        multiple = false,
+        directory = directory,
         questions =
             listOf(
                 QuestionPrompt(
@@ -232,18 +342,22 @@ class ChatViewModelQuestionTest {
                     header = "Folder",
                     options = options.map(::QuestionOption),
                     placeholder = placeholder,
+                    multiple = multiple,
+                    custom = custom,
                 ),
             ),
     )
 
     private class FakeBackend(
         private val answerResult: Boolean = true,
+        private val pending: List<QuestionRequest> = emptyList(),
     ) : OpenCodeBackend {
         override val id: String = "fake"
         override val displayName: String = "Fake"
         override val kind: BackendKind = BackendKind.REMOTE
         val events = MutableSharedFlow<OpenCodeEvent>(extraBufferCapacity = 20)
         val answeredQuestions = mutableListOf<AnswerRecord>()
+        val rejectedQuestions = mutableListOf<Pair<String, String?>>()
         val abortedSessions = mutableListOf<String>()
 
         override suspend fun health(): OpenCodeHealth = OpenCodeHealth(true, "test")
@@ -285,20 +399,30 @@ class ChatViewModelQuestionTest {
         ): Boolean = true
 
         override suspend fun answerQuestion(
-            sessionId: String,
             requestId: String,
             answers: List<List<String>>,
+            directory: String?,
         ): Boolean {
-            answeredQuestions += AnswerRecord(sessionId, requestId, answers)
+            answeredQuestions += AnswerRecord(requestId, answers, directory)
             return answerResult
         }
+
+        override suspend fun rejectQuestion(
+            requestId: String,
+            directory: String?,
+        ): Boolean {
+            rejectedQuestions += requestId to directory
+            return true
+        }
+
+        override suspend fun pendingQuestions(directory: String?): List<QuestionRequest> = pending
 
         override fun events(): Flow<OpenCodeEvent> = events
     }
 
     private data class AnswerRecord(
-        val sessionId: String,
         val requestId: String,
         val answers: List<List<String>>,
+        val directory: String?,
     )
 }

--- a/app/src/test/java/com/opencode/android/runtime/local/LocalOpenCodeBackendTest.kt
+++ b/app/src/test/java/com/opencode/android/runtime/local/LocalOpenCodeBackendTest.kt
@@ -69,10 +69,10 @@ class LocalOpenCodeBackendTest {
                     },
                 )
 
-            assertTrue(backend.answerQuestion("s1", "q-1", listOf(listOf("src"), listOf("docs", "tests"))))
+            assertTrue(backend.answerQuestion("q-1", listOf(listOf("src"), listOf("docs", "tests")), "/workspace/repo"))
 
             val request = server.takeRequest()
-            assertEquals("/session/s1/question/q-1", request.path)
+            assertEquals("/question/q-1/reply?directory=%2Fworkspace%2Frepo", request.path)
             assertEquals("""{"answers":[["src"],["docs","tests"]]}""", request.body.readUtf8())
         }
 }

--- a/app/src/test/java/com/opencode/android/runtime/remote/RemoteOpenCodeBackendTest.kt
+++ b/app/src/test/java/com/opencode/android/runtime/remote/RemoteOpenCodeBackendTest.kt
@@ -77,10 +77,10 @@ class RemoteOpenCodeBackendTest {
                     ),
                 )
 
-            assertTrue(backend.answerQuestion("s1", "q-1", listOf(listOf("src"), listOf("docs", "tests"))))
+            assertTrue(backend.answerQuestion("q-1", listOf(listOf("src"), listOf("docs", "tests")), "/workspace/repo"))
 
             val request = server.takeRequest()
-            assertEquals("/session/s1/question/q-1", request.path)
+            assertEquals("/question/q-1/reply?directory=%2Fworkspace%2Frepo", request.path)
             assertEquals("""{"answers":[["src"],["docs","tests"]]}""", request.body.readUtf8())
         }
 }


### PR DESCRIPTION
## 症状

質問ツールが画面に出ない。スクショのとおり `question` が普通のツール行（`実行中`）として並ぶだけで、回答カードが出ず、`考え中…` のまま止まる。

## 前提：表示されない原因は #91 で修正済み

ご指摘のとおりでした。`/event` はインスタンス単位のストリームなので、`question.asked` がそもそもアプリに届いていませんでした。#91（`/global/event` へ移行）が main に入っており、**このPRはその上にリベースしています**。カードが出ない件自体は #91 で直ります。

このPRは、**カードが出たあとに残っていた壊れ**です。すべて実際の opencode 1.18.5 サーバー（`local-runtime-manifest.json` がピンしているバージョン）を起動し、スタブのモデルプロバイダで `question` ツールを実際に呼ばせて確認しました。

## 直したもの

### 1. 回答の送信先が存在しないルートだった（本丸）

アプリは `POST /session/{sessionID}/question/{requestID}` に送っていましたが、opencode にこのルートはありません。SPAフォールバックが `200 text/html` を返すため、期待している boolean へのデコードが例外になり、カードは `OpenCode question failed` を出したまま、エージェントは待ち続けます。

実際のルートは `POST /question/{requestID}/reply`（body は `{"answers":[[label]]}`）です。

```
POST /session/{sid}/question/{qid}  -> 200 text/html   ← 存在しない
POST /question/{qid}/reply          -> true            ← 正しい
```

### 2. 質問ルートも `directory` スコープだった（#91 と同じ罠）

`/question/*` は `?directory=` が無いとサーバー自身の作業ディレクトリを見にいき、`QuestionNotFoundError` を返します。ローカルランタイムはサーバーを `-w /root` で起動し、ワークスペースは `/workspace` 配下なので、これも例外ではなく通常ケースです。

```
POST /question/{qid}/reply                      -> 404 QuestionNotFoundError
POST /question/{qid}/reply?directory=/…/repo    -> true
```

ワークスペースはリクエスト本体には含まれず、`/global/event` のエンベロープにだけ載ってきます。そのため `QuestionRequest` に `directory` を持たせ、届いたイベントの値をそのまま回答に使います。旧サーバー（`/event` フォールバック）向けには選択中のワークスペースにフォールバックします。

なお `/api/session/{sid}/question/{qid}/reply` は別ストアで、`directory` を付けても 404 でした。使いません。

### 3. `multiple` を1階層上から読んでいた

`multiple` は**各質問**のフィールドで、リクエスト側にはありません。そのため複数選択の質問がラジオボタンで描画され、1件しか送信されませんでした。プロンプトごとに読むようにしています。

あわせて `custom`（そのプロンプトが選択肢以外を受け付けるか、既定 true）にも対応し、`false` のときは自由入力欄を出さず、入力があっても送信しません。

### 4. 「回答せず中断」がターンごと殺していた

質問APIに「拒否」が無いという前提で `abortSession` を呼んでいましたが、`POST /question/{requestID}/reject` がその拒否です。待っているツール呼び出しだけが `The user dismissed this question` で失敗し、エージェントはそれを見て続行できます。文言が実態と合わなくなるので、8言語すべて `回答しない` 相当に変更しました。

### 5. 聞き逃した質問が永久に失われる

質問はイベントでしか届かないので、アプリが見ていない間に出た質問（セッションを開く前、イベントストリームの再接続中）は復帰できませんでした。セッションを開いたときと再接続時に `GET /question` を引くようにしたので、カードが出ずにターンだけ止まる状態にはなりません。

## 実サーバーでの確認

opencode 1.18.5 を起動し、スタブプロバイダに `question` ツールを呼ばせて確認：

- `question.asked` がエンベロープに `directory` を載せて届く
- `GET /question?directory=…` が保留中のリクエストを返す
- reply が `true` を返し、ツールが回答つきで再開する（`User has answered your questions: …`）
- reject が `true` を返し、ツールが `The user dismissed this question` で失敗する

## テスト

`./gradlew detekt spotlessCheck :app:testDebugUnitTest :app:lintDebug` — BUILD SUCCESSFUL、281テスト、失敗0。

追加したカバレッジ：reply / reject のルートと `directory`、保留質問の一覧、イベントエンベロープのワークスペース、プロンプト単位の `multiple` / `custom`、セッションを開く前に出た質問の復帰。

## 未確認

実機での動作確認はしていません（このセッションに端末がないため）。サーバー側の契約は、実際に 1.18.5 を起動して確認しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXCZKvZcGB5gkHj6W4kuyR)_