### PR TITLE
fix: inherit auto-approval for subagents and fix notification approval

### DIFF
--- a/app/src/main/java/com/opencode/android/core/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/opencode/android/core/api/OpenCodeApiClient.kt
@@ -402,10 +402,11 @@ class OpenCodeApiClient(
             buildJsonObject {
                 put("response", apiResponse)
             }
-        return post(
+        postWithoutResponse(
             "session/${encodePath(sessionId)}/permissions/${encodePath(permissionId)}",
             body,
         )
+        return true
     }
 
     /**
@@ -431,11 +432,12 @@ class OpenCodeApiClient(
                     },
                 )
             }
-        return post(
+        postWithoutResponse(
             "question/${encodePath(requestId)}/reply",
             body,
             query("directory" to directory),
         )
+        return true
     }
 
     /** Declines a question outright, which fails the waiting tool call without killing the turn. */
@@ -617,9 +619,10 @@ class OpenCodeApiClient(
     private suspend fun postWithoutResponse(
         path: String,
         body: JsonObject,
+        queryParameters: List<Pair<String, String>> = emptyList(),
     ) = withContext(Dispatchers.IO) {
         val request =
-            requestBuilder(path)
+            requestBuilder(path, queryParameters)
                 .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
                 .build()
         execute(request) { Unit }

--- a/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/opencode/android/feature/chat/ChatViewModel.kt
@@ -1029,7 +1029,6 @@ class ChatViewModel(
                 updateStreamingMessage(event.messageId, messageParts.values.toList())
             }
             is OpenCodeEvent.PermissionAsked -> {
-                if (event.request.sessionId != activeSession) return
                 if (_uiState.value.autoAcceptPermissions) {
                     val request = event.request
                     val autoBackend = backend ?: return
@@ -1047,6 +1046,7 @@ class ChatViewModel(
                     }
                     return
                 }
+                if (event.request.sessionId != activeSession) return
                 _uiState.update { state ->
                     state.copy(
                         permissions = state.permissions.filterNot { it.id == event.request.id } + event.request,

--- a/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
+++ b/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
@@ -149,6 +149,17 @@ class OpenCodeApiClientTest {
         }
 
     @Test
+    fun `permission response succeeds with empty body`() =
+        runBlocking {
+            server.enqueue(MockResponse())
+            val client = client()
+
+            val result = client.respondPermission("s1", "perm1", "once")
+
+            assertTrue(result)
+        }
+
+    @Test
     fun `remember once maps to always response`() =
         runBlocking {
             server.enqueue(MockResponse().setBody("true"))

--- a/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelTest.kt
@@ -152,6 +152,35 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun `auto accept approves subagent permissions from a different session`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+            viewModel.setAutoAcceptPermissions(true)
+            viewModel.sendMessage("Delegate work")
+            advanceUntilIdle()
+
+            backend.events.emit(
+                OpenCodeEvent.PermissionAsked(
+                    PermissionRequest(
+                        id = "perm-sub",
+                        sessionId = "subagent-session-42",
+                        permission = "bash",
+                        patterns = listOf("ls"),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.permissions.isEmpty())
+            val record = backend.permissionResponses.single()
+            assertEquals("subagent-session-42", record.sessionId)
+            assertEquals("perm-sub", record.permissionId)
+            assertEquals(PermissionResponse.ONCE, record.third)
+        }
+
+    @Test
     fun `streamed text is finalized when session becomes idle`() =
         runTest(dispatcher) {
             val backend = FakeBackend()


### PR DESCRIPTION
## Summary

- **Subagent auto-approval**: Move session filter after auto-approval check in `PermissionAsked` handler so subagent permissions are auto-approved like the main agent's when auto-accept is enabled
- **Notification approval**: Use `postWithoutResponse` for `respondPermission` and `answerQuestion` to avoid deserialization failures on empty/non-JSON response bodies that caused notification approval actions to silently fail

## Changes

### ChatViewModel.kt
The `PermissionAsked` handler previously filtered by `sessionId != activeSession` before checking `autoAcceptPermissions`. Subagent sessions have different session IDs, so their permission events were discarded before auto-approval was ever checked. Now the auto-approval check runs first for all sessions.

### OpenCodeApiClient.kt
`respondPermission()` and `answerQuestion()` used `post<Boolean>()` which tried to deserialize the HTTP response body as a JSON Boolean. If the server returned an empty or non-JSON body, deserialization threw and the approval silently failed (swallowed by `runCatching` in `PermissionActionReceiver`). Changed to `postWithoutResponse()` which only checks for HTTP success.

## Tests
- Added test for subagent auto-approval from a different session
- Added test for permission response succeeding with an empty HTTP body