### PR TITLE
fix: use base64 data URLs for attachments to support remote servers

### DIFF
--- a/app/src/main/java/com/opencode/android/runtime/local/AttachmentImporter.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/AttachmentImporter.kt
@@ -4,31 +4,25 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.provider.OpenableColumns
+import android.util.Base64
 import com.opencode.android.core.api.PromptAttachment
-import java.io.File
+import java.io.ByteArrayOutputStream
 
-/**
- * Copies a user-picked file into the runtime's shared workspace so the OpenCode
- * server can read it, returning a [PromptAttachment] referencing the server-side
- * /workspace path.
- */
 class AttachmentImporter(
     private val context: Context,
-    private val runtimeDirectory: File = File(context.filesDir, "runtime"),
 ) {
     fun import(uri: Uri): PromptAttachment {
-        val workspace = File(runtimeDirectory, "workspace").apply { mkdirs() }
         val filename = sanitize(queryDisplayName(uri) ?: "attachment-${System.currentTimeMillis()}")
-        val destination = uniqueFile(workspace, filename)
-        context.contentResolver.openInputStream(uri).use { input ->
-            requireNotNull(input) { "Cannot open attachment input stream" }
-            destination.outputStream().use { output -> input.copyTo(output) }
-        }
         val mime = context.contentResolver.getType(uri) ?: "application/octet-stream"
+        val bytes = context.contentResolver.openInputStream(uri).use { input ->
+            requireNotNull(input) { "Cannot open attachment input stream" }
+            input.readBytes()
+        }
+        val encoded = Base64.encodeToString(bytes, Base64.NO_WRAP)
         return PromptAttachment(
-            filename = destination.name,
+            filename = filename,
             mime = mime,
-            url = "file:///workspace/${destination.name}",
+            url = "data:$mime;base64,$encoded",
         )
     }
 
@@ -36,12 +30,10 @@ class AttachmentImporter(
         bitmap: Bitmap,
         filename: String = "image-${System.currentTimeMillis()}.jpg",
     ): PromptAttachment {
-        val workspace = File(runtimeDirectory, "workspace").apply { mkdirs() }
-        val destination = uniqueFile(workspace, sanitize(filename))
-        destination.outputStream().use { output ->
-            check(bitmap.compress(Bitmap.CompressFormat.JPEG, 90, output)) { "Cannot encode attachment" }
-        }
-        return PromptAttachment(destination.name, "image/jpeg", "file:///workspace/${destination.name}")
+        val baos = ByteArrayOutputStream()
+        check(bitmap.compress(Bitmap.CompressFormat.JPEG, 90, baos)) { "Cannot encode attachment" }
+        val encoded = Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
+        return PromptAttachment(sanitize(filename), "image/jpeg", "data:image/jpeg;base64,$encoded")
     }
 
     private fun queryDisplayName(uri: Uri): String? =
@@ -51,22 +43,6 @@ class AttachmentImporter(
                 if (index >= 0 && cursor.moveToFirst()) cursor.getString(index) else null
             }
         }.getOrNull()
-
-    private fun uniqueFile(
-        dir: File,
-        name: String,
-    ): File {
-        var candidate = File(dir, name)
-        var counter = 1
-        val base = name.substringBeforeLast('.', name)
-        val extension = name.substringAfterLast('.', "").takeIf { it.isNotBlank() && it != name }
-        while (candidate.exists()) {
-            val suffixed = if (extension != null) "$base-$counter.$extension" else "$base-$counter"
-            candidate = File(dir, suffixed)
-            counter++
-        }
-        return candidate
-    }
 
     private fun sanitize(name: String): String = name.replace(Regex("[^a-zA-Z0-9._-]"), "_").ifBlank { "attachment" }
 }

--- a/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
+++ b/app/src/test/java/com/opencode/android/core/api/OpenCodeApiClientTest.kt
@@ -106,7 +106,7 @@ class OpenCodeApiClientTest {
                 "s1",
                 PromptRequest(
                     text = "",
-                    attachments = listOf(PromptAttachment("photo.jpg", "image/jpeg", "file:///workspace/photo.jpg")),
+                    attachments = listOf(PromptAttachment("photo.jpg", "image/jpeg", "data:image/jpeg;base64,/9j/4AAQ")),
                 ),
             )
 
@@ -114,7 +114,7 @@ class OpenCodeApiClientTest {
                 Json.parseToJsonElement(server.takeRequest().body.readUtf8())
                     .jsonObject["parts"]!!.jsonArray
             assertEquals("file", parts[0].jsonObject["type"]!!.jsonPrimitive.content)
-            assertEquals("file:///workspace/photo.jpg", parts[0].jsonObject["url"]!!.jsonPrimitive.content)
+            assertEquals("data:image/jpeg;base64,/9j/4AAQ", parts[0].jsonObject["url"]!!.jsonPrimitive.content)
         }
 
     @Test

--- a/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/opencode/android/feature/chat/ChatViewModelTest.kt
@@ -86,7 +86,7 @@ class ChatViewModelTest {
             val backend = FakeBackend()
             val viewModel = ChatViewModel(backend)
             advanceUntilIdle()
-            viewModel.addAttachment(PromptAttachment("photo.jpg", "image/jpeg", "file:///workspace/photo.jpg"))
+            viewModel.addAttachment(PromptAttachment("photo.jpg", "image/jpeg", "data:image/jpeg;base64,/9j/4AAQ"))
 
             viewModel.sendMessage("")
             advanceUntilIdle()


### PR DESCRIPTION
## Problem

When sending image/file attachments to a **remote** OpenCode server, the server tries to read the file at `/workspace/image-xxx.jpg` which doesn't exist on the remote host, causing:

```
UnknownError: PlatformError: NotFound: FileSystem.readFile (/workspace/image-xxx.jpg)
[cause]: Error: ENOENT: no such file or directory
```

This works on local because the Android app and the local OpenCode server share the same filesystem.

## Root Cause

`AttachmentImporter` was saving picked files/images to the local filesystem and returning a `file:///workspace/...` URL. The OpenCode server's `resolveUserPart` handler reads `file:` URLs from its own filesystem via `fsys.readFile`, which fails on remote servers where the file doesn't exist.

## Fix

Changed `AttachmentImporter` to encode file contents as base64 and return `data:<mime>;base64,...` URLs instead. The OpenCode server natively supports `data:` URLs in `resolveUserPart` — it passes them through without filesystem access, so they work on both local and remote servers.

### Changes
- `AttachmentImporter.kt` — read bytes into memory, base64-encode, return data URL; removed local file writing and `uniqueFile` helper
- Updated tests to use data URL format