### PR TITLE
fix: request full GitHub OAuth scopes for OpenCode

### DIFF
--- a/app/src/main/java/com/opencode/android/feature/settings/GitHubAuthRepository.kt
+++ b/app/src/main/java/com/opencode/android/feature/settings/GitHubAuthRepository.kt
@@ -51,7 +51,9 @@ class GitHubAuthRepository(
     suspend fun requestDeviceCode(): GitHubDeviceCode =
         withContext(Dispatchers.IO) {
             require(isConfigured) { "GitHub client ID is not configured" }
-            val body = FormBody.Builder().add("client_id", clientId).add("scope", "read:user repo").build()
+            // repo: git push, PR creation, private repos. workflow: push/modify .github/workflows.
+            // read:org: org repo visibility. gist: log/output sharing. notifications: PR updates.
+            val body = FormBody.Builder().add("client_id", clientId).add("scope", "read:user read:org repo workflow gist notifications").build()
             executeJson("https://github.com/login/device/code", body)
         }
 


### PR DESCRIPTION
## Problem

The app's GitHub OAuth device flow only requested `read:user repo`, which is insufficient for:
- Pushing/modifying `.github/workflows` files (`workflow` scope)
- Organization repo visibility (`read:org`)
- Log/output sharing via gist (`gist`)
- PR notification subscriptions (`notifications`)

## Fix

Update the device code scope request to:

```
read:user read:org repo workflow gist notifications
```

Existing tokens are **not** upgraded automatically — users must Disconnect GitHub and re-authenticate in Settings after installing this fix.