### PR TITLE
ci: register PR APK build workflow

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -3,6 +3,7 @@ name: Android APK
 on:
   pull_request:
     types: [labeled]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -1,0 +1,41 @@
+name: Android APK
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'build-apk' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Accept Android SDK licenses
+        run: yes | sdkmanager --licenses >/dev/null || true
+      - name: Install Android SDK packages
+        run: sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+      - name: Run unit tests
+        run: ./gradlew :app:testDebugUnitTest --no-daemon
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug --no-daemon
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencode-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/comment-apk.yml
+++ b/.github/workflows/comment-apk.yml
@@ -2,7 +2,7 @@ name: Comment APK Artifact
 
 on:
   workflow_run:
-    workflows: [Android APK]
+    workflows: [PR APK Build]
     types: [completed]
 
 permissions:

--- a/.github/workflows/comment-apk.yml
+++ b/.github/workflows/comment-apk.yml
@@ -1,0 +1,47 @@
+name: Comment APK Artifact
+
+on:
+  workflow_run:
+    workflows: [Android APK]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment or update APK link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const pullRequest = run.pull_requests?.[0];
+            if (!pullRequest) return;
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner, repo: context.repo.repo, run_id: run.id, per_page: 100,
+            });
+            const apk = artifacts.find((artifact) => artifact.name === 'opencode-debug-apk');
+            if (!apk) core.setFailed('The APK artifact was not found.');
+            if (!apk) return;
+            const marker = '<!-- opencode-debug-apk -->';
+            const body = `${marker}
+            **Debug APK built successfully**
+
+            [Download APK artifact](${apk.archive_download_url})<br>
+            [View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${run.id})
+
+            Commit: \\`${run.head_sha.slice(0, 12)}\\`  |  Artifact expires in 14 days.`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: pullRequest.number, per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pullRequest.number, body });
+            }

--- a/.github/workflows/pr-apk-build.yml
+++ b/.github/workflows/pr-apk-build.yml
@@ -1,0 +1,33 @@
+name: PR APK Build
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'build-apk' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+      - uses: android-actions/setup-android@v3
+      - run: yes | sdkmanager --licenses >/dev/null || true
+      - run: sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+      - run: chmod +x ./gradlew
+      - run: ./gradlew :app:testDebugUnitTest --no-daemon
+      - run: ./gradlew :app:assembleDebug --no-daemon
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opencode-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
Register a uniquely named PR APK workflow with label and manual triggers so GitHub immediately discovers the dispatch event.