### PR TITLE
feat: bind-mount /system into PRoot for Android tool access

### DIFF
--- a/app/src/main/java/com/opencode/android/runtime/local/GitCloneRepository.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/GitCloneRepository.kt
@@ -59,6 +59,8 @@ class GitCloneRepository(
                     "-b",
                     "/sys",
                     "-b",
+                    "/system",
+                    "-b",
                     "${workspace.absolutePath}:/workspace",
                     "-w",
                     "/workspace",

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeCommandRunner.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeCommandRunner.kt
@@ -44,6 +44,8 @@ class LocalRuntimeCommandRunner(
                         "/proc",
                         "-b",
                         "/sys",
+                        "-b",
+                        "/system",
                         "-w",
                         "/root",
                         "/bin/sh",

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
@@ -209,6 +209,8 @@ class LocalRuntimeInstaller(
                 "/proc",
                 "-b",
                 "/sys",
+                "-b",
+                "/system",
                 "-w",
                 "/root",
                 "/bin/sh",

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -51,6 +51,8 @@ class LocalRuntimeProcessLauncher(
                 add("-b")
                 add("/sys")
                 add("-b")
+                add("/system")
+                add("-b")
                 add("${workspace.absolutePath}:/workspace")
                 add("-w")
                 add("/workspace")


### PR DESCRIPTION
Bind-mount the host Android `/system` directory into the PRoot environment so that Android system tools like `pm`, `am`, and `cmd` become accessible from within the runtime.