### PR TITLE
feat: add Android system paths to PRoot guest PATH

### DIFF
--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
@@ -262,7 +262,7 @@ class LocalRuntimeInstaller(
             writeText(
                 "export HOME=/root\n" +
                     "export TMPDIR=/tmp\n" +
-                    "export PATH=/usr/local/bin:/usr/bin:/bin\n" +
+                    "export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/system/bin:/system/xbin\n" +
                     "export OPENCODE_CONFIG_DIR=/root/.config/opencode\n",
             )
         }

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -263,7 +263,7 @@ internal fun localRuntimeEnvironment(
         put("USER", "root")
         put("LOGNAME", "root")
         put("SHELL", "/bin/bash")
-        put("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+        put("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/system/bin:/system/xbin")
         put("TMPDIR", "/tmp")
         put("XDG_CONFIG_HOME", "/root/.config")
         put("XDG_CACHE_HOME", "/root/.cache")

--- a/app/src/test/java/com/opencode/android/runtime/local/LocalRuntimeProcessLauncherTest.kt
+++ b/app/src/test/java/com/opencode/android/runtime/local/LocalRuntimeProcessLauncherTest.kt
@@ -26,7 +26,7 @@ class LocalRuntimeProcessLauncherTest {
 
         assertEquals("/root", environment["HOME"])
         assertEquals(
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/system/bin:/system/xbin",
             environment["PATH"],
         )
         assertEquals("/tmp", environment["TMPDIR"])
@@ -34,6 +34,24 @@ class LocalRuntimeProcessLauncherTest {
         assertEquals("/android/proot-tmp", environment["PROOT_TMP_DIR"])
         assertEquals("/native/lib", environment["LD_LIBRARY_PATH"])
         assertTrue(environment["OPENCODE_DISABLE_AUTOUPDATE"] == "true")
+    }
+
+    @Test
+    fun `guest PATH includes Android system directories for am pm input access`() {
+        val environment =
+            localRuntimeEnvironment(
+                suiteEnvironment = emptyMap(),
+                prootTmp = File("/android/proot-tmp"),
+            )
+
+        val path = environment["PATH"]!!
+        val entries = path.split(":")
+        assertTrue("PATH must contain /system/bin", "/system/bin" in entries)
+        assertTrue("PATH must contain /system/xbin", "/system/xbin" in entries)
+        assertTrue(
+            "Alpine paths must precede Android system paths",
+            entries.indexOf("/usr/local/bin") < entries.indexOf("/system/bin"),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Append `/system/bin` and `/system/xbin` to the PRoot guest environment PATH so the AI agent can invoke Android platform commands directly from within the local runtime.

## What this unlocks

The PRoot environment already bind-mounts `/system` (`-b /system` in the launch command), but the guest PATH did not include Android system directories. With this change, the agent can now use:

- `am` — Activity Manager (start/stop activities, broadcast intents, force-stop apps)
- `pm` — Package Manager (list/install/clear packages)
- `input` — inject touch/key/text events (`input tap X Y`, `input text "hello"`)
- `dumpsys` — dump system service state
- `settings` — read/write system settings
- `content` — query content providers
- `cmd` — invoke system services

This is the first step toward giving the on-device agent capabilities comparable to a PC development environment. All major AI agent projects on Android (AppAgent, Mobile-Agent, DroidBot) rely on these commands as their primary interaction channel.

## Changes

- **`LocalRuntimeProcessLauncher.kt`**: Append `/system/bin:/system/xbin` to the guest PATH in `localRuntimeEnvironment()`. Alpine paths remain first to avoid shadowing Linux binaries.
- **`LocalRuntimeInstaller.kt`**: Align the `/etc/profile.d/opencode-android.sh` PATH with the process environment (also adds missing `/usr/local/sbin`, `/usr/sbin`, `/sbin`).
- **`LocalRuntimeProcessLauncherTest.kt`**: Update existing PATH assertion; add new test verifying Android system directories are present and ordered after Alpine paths.

## Testing

- `./gradlew :app:testDebugUnitTest` — all tests pass
- `./gradlew spotlessCheck` — formatting clean