### PR TITLE
feat: add android-vision screenshot annotation for agent visual feedback

### DIFF
--- a/app/src/main/assets/scripts/android-screenshot.sh
+++ b/app/src/main/assets/scripts/android-screenshot.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Capture a screenshot from the connected Android device via ADB.
+# Usage: android-screenshot [output_path]
+# Requires: adb connected (see ADB setup in Local OpenCode settings)
+set -e
+OUTPUT="${1:-/tmp/screenshot.png}"
+adb shell screencap -p /sdcard/_oc_screenshot.png
+adb pull /sdcard/_oc_screenshot.png "$OUTPUT" >/dev/null 2>&1
+adb shell rm /sdcard/_oc_screenshot.png >/dev/null 2>&1
+echo "$OUTPUT"

--- a/app/src/main/assets/scripts/android-vision.sh
+++ b/app/src/main/assets/scripts/android-vision.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Capture an annotated screenshot with numbered UI element labels.
+# Outputs a JSON array of elements and saves an annotated PNG.
+# Usage: android-vision [output_dir]
+# Requires: adb connected, python3, py3-pillow
+set -e
+OUTDIR="${1:-/tmp/android-vision}"
+mkdir -p "$OUTDIR"
+SHOT="$OUTDIR/screenshot.png"
+XML="$OUTDIR/ui.xml"
+ANNOTATED="$OUTDIR/annotated.png"
+
+# Capture screenshot and UI hierarchy
+adb shell screencap -p /sdcard/_oc_shot.png 2>/dev/null
+adb pull /sdcard/_oc_shot.png "$SHOT" >/dev/null 2>&1
+adb shell rm /sdcard/_oc_shot.png >/dev/null 2>&1
+
+adb shell uiautomator dump /sdcard/_oc_ui.xml 2>/dev/null
+adb pull /sdcard/_oc_ui.xml "$XML" >/dev/null 2>&1
+adb shell rm /sdcard/_oc_ui.xml >/dev/null 2>&1
+
+# Annotate and output element descriptions as JSON
+exec python3 - "$SHOT" "$XML" "$ANNOTATED" <<'PYEOF'
+import sys, json, re, xml.etree.ElementTree as ET
+from PIL import Image, ImageDraw, ImageFont
+
+shot_path, xml_path, annotated_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+img = Image.open(shot_path)
+draw = ImageDraw.Draw(img)
+W, H = img.size
+try:
+    font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", max(14, W // 40))
+except Exception:
+    font = ImageFont.load_default()
+
+elements = []
+for node in ET.parse(xml_path).iter("node"):
+    bounds_str = node.get("bounds", "")
+    clickable = node.get("clickable", "false") == "true"
+    focusable = node.get("focusable", "false") == "true"
+    scrollable = node.get("scrollable", "false") == "true"
+    if not (clickable or focusable or scrollable):
+        continue
+    m = re.match(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", bounds_str)
+    if not m:
+        continue
+    x1, y1, x2, y2 = map(int, m.groups())
+    cx, cy = (x1 + x2) // 2, (y1 + y2) // 2
+    if x2 <= x1 or y2 <= y1 or x1 < 0 or y1 < 0 or x2 > W or y2 > H:
+        continue
+    idx = len(elements) + 1
+    elements.append({
+        "label": idx,
+        "bounds": [x1, y1, x2, y2],
+        "center": [cx, cy],
+        "class": node.get("class", ""),
+        "text": node.get("text", ""),
+        "resource_id": node.get("resource-id", ""),
+        "content_desc": node.get("content-desc", ""),
+        "clickable": clickable,
+        "focusable": focusable,
+        "scrollable": scrollable,
+    })
+    draw.rectangle([x1, y1, x2, y2], outline="red", width=max(2, W // 400))
+    label = str(idx)
+    bbox = draw.textbbox((cx, cy), label, font=font)
+    lw, lh = bbox[2] - bbox[0] + 8, bbox[3] - bbox[1] + 4
+    draw.rectangle([cx - lw//2, cy - lh//2, cx + lw//2, cy + lh//2], fill="red")
+    draw.text((cx - lw//2 + 4, cy - lh//2 + 2), label, fill="white", font=font)
+
+img.save(annotated_path)
+print(json.dumps({"screenshot": shot_path, "annotated": annotated_path, "elements": elements, "width": W, "height": H}, indent=2))
+PYEOF

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeDiagnostics.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeDiagnostics.kt
@@ -162,6 +162,7 @@ class LocalRuntimeDiagnosticsCollector(
                 LocalRuntimeToolDefinition("adb", "ADB", "adb version | head -n 1"),
                 LocalRuntimeToolDefinition("java", "Java", "java -version 2>&1 | head -n 1"),
                 LocalRuntimeToolDefinition("gradle", "Gradle", "gradle --version 2>&1 | head -n 1"),
+                LocalRuntimeToolDefinition("python3", "Python", "python3 --version"),
             )
     }
 }

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
@@ -215,7 +215,7 @@ class LocalRuntimeInstaller(
                 "/root",
                 "/bin/sh",
                 "-lc",
-                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /sbin/apk add --no-cache bash git curl openssh-client ripgrep ca-certificates libstdc++ github-cli android-tools openjdk17 gradle && /usr/sbin/update-ca-certificates",
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /sbin/apk add --no-cache bash git curl openssh-client ripgrep ca-certificates libstdc++ github-cli android-tools openjdk17 gradle python3 py3-pillow && /usr/sbin/update-ca-certificates",
             )
         val installLog =
             File(runtimeDirectory, "logs/tool-install.log").apply {
@@ -269,7 +269,20 @@ class LocalRuntimeInstaller(
         }
         File(rootfs, "root/.config/opencode").mkdirs()
         File(rootfs, "root/.local/share/opencode").mkdirs()
+        installAndroidHelperScripts(rootfs)
         require(suite.proot.isFile) { "PRoot launcher is unavailable" }
+    }
+
+    private fun installAndroidHelperScripts(rootfs: File) {
+        val binDir = File(rootfs, "usr/local/bin").apply { mkdirs() }
+        listOf("android-vision.sh" to "android-vision", "android-screenshot.sh" to "android-screenshot").forEach {
+                (assetName, scriptName) ->
+            val scriptFile = File(binDir, scriptName)
+            context.assets.open("scripts/$assetName").use { input ->
+                scriptFile.outputStream().use { output -> input.copyTo(output) }
+            }
+            scriptFile.setExecutable(true, false)
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Install `python3` and `py3-pillow` in the PRoot environment and deploy helper scripts that let the agent capture and understand the Android screen — the same visual grounding pattern used by AppAgent and Mobile-Agent.

## What this unlocks

The agent can now **see the screen** and **understand UI elements**:

```bash
# Capture raw screenshot
android-screenshot /tmp/shot.png

# Capture annotated screenshot with numbered UI elements
android-vision /tmp/vision
# → Outputs JSON: { elements: [{ label: 1, bounds: [x1,y1,x2,y2], center: [cx,cy], class, text, resource_id, ... }], annotated: /tmp/vision/annotated.png }
# → The annotated PNG has red bounding boxes with white numbers over each interactive element
```

The LLM can then tap element #5 with: `adb shell input tap <cx> <cy>`

## Scripts installed

| Script | Purpose |
|---|---|
| `android-screenshot` | Raw screenshot capture via `adb shell screencap` |
| `android-vision` | Annotated screenshot + UI hierarchy JSON (like AppAgent's `draw_bbox_multi`) |

## Changes

- **`LocalRuntimeInstaller.kt`**: Add `python3 py3-pillow` to apk install; copy scripts from `assets/scripts/` during `configureRootfs()`
- **`LocalRuntimeDiagnostics.kt`**: Add `python3` to `REQUIRED_TOOLS`
- **`assets/scripts/android-screenshot.sh`**: Screenshot capture script
- **`assets/scripts/android-vision.sh`**: Annotated screenshot + JSON element description script (parses uiautomator XML, annotates with PIL)

## Testing

- `./gradlew :app:testDebugUnitTest` — all tests pass
- `./gradlew spotlessCheck` — formatting clean