### PR TITLE
feat: add AccessibilityService for ADB-free UI automation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,6 +90,19 @@
             android:exported="false"
             android:foregroundServiceType="microphone" />
 
+        <service
+            android:name=".accessibility.OpenCodeAccessibilityService"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
+
         <receiver
             android:name=".core.notification.PermissionActionReceiver"
             android:exported="false">

--- a/app/src/main/assets/scripts/android-ui.sh
+++ b/app/src/main/assets/scripts/android-ui.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Interact with the Android device via the OpenCode Accessibility Service.
+# This provides ADB-free UI automation through a local HTTP server.
+#
+# Usage:
+#   android-ui screen           # Get the current view hierarchy as JSON
+#   android-ui tap <x> <y>      # Tap at coordinates
+#   android-ui swipe <x1> <y1> <x2> <y2> [duration_ms]
+#   android-ui text "hello"     # Type text into the focused field
+#   android-ui key back|home|recents
+#   android-ui health           # Check if the service is connected
+#
+# Prerequisites: Enable the OpenCode Accessibility Service in
+# Settings > Accessibility.
+
+set -e
+HOST="http://127.0.0.1:4098"
+CMD="${1:-health}"
+shift 2>/dev/null || true
+
+case "$CMD" in
+    screen)
+        exec curl -s "$HOST/screen"
+        ;;
+    tap)
+        exec curl -s -X POST "$HOST/tap" -H 'Content-Type: application/json' -d "{\"x\":$1,\"y\":$2}"
+        ;;
+    swipe)
+        DUR="${5:-300}"
+        exec curl -s -X POST "$HOST/swipe" -H 'Content-Type: application/json' -d "{\"x1\":$1,\"y1\":$2,\"x2\":$3,\"y2\":$4,\"duration\":$DUR}"
+        ;;
+    text)
+        TEXT=$(printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+        exec curl -s -X POST "$HOST/text" -H 'Content-Type: application/json' -d "{\"text\":$TEXT}"
+        ;;
+    key)
+        exec curl -s -X POST "$HOST/key" -H 'Content-Type: application/json' -d "{\"key\":\"$1\"}"
+        ;;
+    health)
+        exec curl -s "$HOST/health"
+        ;;
+    *)
+        echo "Usage: android-ui [screen|tap|swipe|text|key|health] [args...]"
+        exit 1
+        ;;
+esac

--- a/app/src/main/java/com/opencode/android/OpenCodeApplication.kt
+++ b/app/src/main/java/com/opencode/android/OpenCodeApplication.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.startup.AppInitializer
+import com.opencode.android.accessibility.AccessibilityHttpServer
 import com.opencode.android.core.notification.RuntimeNotificationHelper
 import com.opencode.android.data.connection.SecureSettingsRepository
 import com.opencode.android.data.repository.ProviderCatalogCache
@@ -102,6 +103,8 @@ class OpenCodeApplication : Application() {
 
     lateinit var runtimeMessages: LocalRuntimeMessages
         private set
+
+    val accessibilityHttpServer = AccessibilityHttpServer()
 
     lateinit var githubStarCoordinator: GitHubStarCoordinator
         private set
@@ -224,6 +227,7 @@ class OpenCodeApplication : Application() {
             )
         localRuntimeController = LocalRuntimeServiceController(this)
         adbConnectionManager = AdbConnectionManager(this, commandRunner)
+        accessibilityHttpServer.start()
         runtimeRegistry =
             RuntimeRegistry(
                 store = settings,

--- a/app/src/main/java/com/opencode/android/accessibility/AccessibilityHttpServer.kt
+++ b/app/src/main/java/com/opencode/android/accessibility/AccessibilityHttpServer.kt
@@ -1,0 +1,169 @@
+package com.opencode.android.accessibility
+
+import android.util.Log
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.util.concurrent.Executors
+
+class AccessibilityHttpServer(
+    private val port: Int = DEFAULT_PORT,
+) {
+    @Volatile
+    private var serverSocket: ServerSocket? = null
+
+    @Volatile
+    private var isRunning: Boolean = false
+        private set
+
+    private val executor = Executors.newSingleThreadExecutor()
+
+    fun start() {
+        if (isRunning) return
+        val socket = ServerSocket()
+        socket.bind(InetSocketAddress("127.0.0.1", port))
+        serverSocket = socket
+        isRunning = true
+        executor.execute {
+            while (isRunning) {
+                runCatching {
+                    val client = socket.accept()
+                    handleClient(client.getInputStream(), client.getOutputStream())
+                    client.close()
+                }.onFailure { e ->
+                    if (isRunning) Log.w(TAG, "Connection error", e)
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        isRunning = false
+        serverSocket?.close()
+        serverSocket = null
+    }
+
+    private fun handleClient(
+        input: java.io.InputStream,
+        output: OutputStream,
+    ) {
+        val reader = BufferedReader(InputStreamReader(input, Charsets.UTF_8))
+        val requestLine = reader.readLine() ?: return
+        val parts = requestLine.split(" ")
+        if (parts.size < 2) return
+        val method = parts[0]
+        val path = parts[1].substringBefore("?")
+
+        val headers = mutableMapOf<String, String>()
+        while (true) {
+            val headerLine = reader.readLine() ?: break
+            if (headerLine.isEmpty()) break
+            val colonIndex = headerLine.indexOf(":")
+            if (colonIndex > 0) {
+                headers[headerLine.substring(0, colonIndex).trim().lowercase()] =
+                    headerLine.substring(colonIndex + 1).trim()
+            }
+        }
+
+        val contentLength = headers["content-length"]?.toIntOrNull() ?: 0
+        val body = if (contentLength > 0) reader.readChars(contentLength) else ""
+        val bodyJson = if (body.isNotBlank()) runCatching { JSONObject(body) }.getOrNull() ?: JSONObject() else JSONObject()
+
+        val (code, response) = route(method, path, bodyJson)
+        val bytes = response.toByteArray(Charsets.UTF_8)
+        output.write(
+            (
+                "HTTP/1.1 $code ${statusText(code)}\r\n" +
+                    "Content-Type: application/json; charset=utf-8\r\n" +
+                    "Content-Length: ${bytes.size}\r\n" +
+                    "Connection: close\r\n\r\n"
+            ).toByteArray(Charsets.UTF_8),
+        )
+        output.write(bytes)
+        output.flush()
+    }
+
+    private fun route(
+        method: String,
+        path: String,
+        body: JSONObject,
+    ): Pair<Int, String> {
+        val service = OpenCodeAccessibilityService.instance
+        if (service == null && path != "/health") {
+            return 503 to """{"error":"Accessibility service not connected"}"""
+        }
+        return when (path) {
+            "/health" -> {
+                if (service != null) {
+                    200 to """{"status":"connected"}"""
+                } else {
+                    503 to """{"status":"disconnected"}"""
+                }
+            }
+            "/screen" -> 200 to (service?.captureViewTree() ?: """{"error":"unavailable"}""")
+            "/tap" -> {
+                val x = body.optDouble("x", -1.0).toFloat()
+                val y = body.optDouble("y", -1.0).toFloat()
+                if (x < 0 || y < 0) return 400 to """{"error":"Missing x or y"}"""
+                val ok = service!!.performTap(x, y)
+                200 to """{"success":$ok}"""
+            }
+            "/swipe" -> {
+                val x1 = body.optDouble("x1", -1.0).toFloat()
+                val y1 = body.optDouble("y1", -1.0).toFloat()
+                val x2 = body.optDouble("x2", -1.0).toFloat()
+                val y2 = body.optDouble("y2", -1.0).toFloat()
+                val duration = body.optLong("duration", 300)
+                if (x1 < 0 || y1 < 0 || x2 < 0 || y2 < 0) return 400 to """{"error":"Missing coordinates"}"""
+                val ok = service!!.performSwipe(x1, y1, x2, y2, duration)
+                200 to """{"success":$ok}"""
+            }
+            "/text" -> {
+                val text = body.optString("text", "")
+                if (text.isEmpty()) return 400 to """{"error":"Missing text"}"""
+                val ok = service!!.typeText(text)
+                200 to """{"success":$ok}"""
+            }
+            "/key" -> {
+                val key = body.optString("key", "")
+                val ok =
+                    when (key) {
+                        "back" -> service!!.performBack()
+                        "home" -> service!!.performHome()
+                        "recents" -> service!!.performRecents()
+                        else -> false
+                    }
+                200 to """{"success":$ok,"key":"$key"}"""
+            }
+            else -> 404 to """{"error":"Not found"}"""
+        }
+    }
+
+    private fun statusText(code: Int): String =
+        when (code) {
+            200 -> "OK"
+            400 -> "Bad Request"
+            404 -> "Not Found"
+            503 -> "Service Unavailable"
+            else -> "Unknown"
+        }
+
+    private fun BufferedReader.readChars(count: Int): String {
+        val chars = CharArray(count)
+        var read = 0
+        while (read < count) {
+            val n = read(chars, read, count - read)
+            if (n < 0) break
+            read += n
+        }
+        return String(chars, 0, read)
+    }
+
+    companion object {
+        const val DEFAULT_PORT = 4098
+        private const val TAG = "AccessibilityHttpServer"
+    }
+}

--- a/app/src/main/java/com/opencode/android/accessibility/OpenCodeAccessibilityService.kt
+++ b/app/src/main/java/com/opencode/android/accessibility/OpenCodeAccessibilityService.kt
@@ -1,0 +1,111 @@
+package com.opencode.android.accessibility
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.GestureDescription
+import android.graphics.Path
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import org.json.JSONArray
+import org.json.JSONObject
+
+class OpenCodeAccessibilityService : AccessibilityService() {
+    @Volatile
+    private var lastRoot: AccessibilityNodeInfo? = null
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent) {
+        lastRoot = rootInActiveWindow
+    }
+
+    override fun onInterrupt() {}
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        instance = this
+    }
+
+    override fun onUnbind(intent: android.content.Intent?): Boolean {
+        instance = null
+        return super.onUnbind(intent)
+    }
+
+    fun captureViewTree(): String {
+        val root = lastRoot ?: rootInActiveWindow ?: return JSONObject().put("error", "No window content").toString()
+        val tree = nodeToJson(root)
+        recycleTree(root)
+        return tree.toString(2)
+    }
+
+    fun performTap(
+        x: Float,
+        y: Float,
+    ): Boolean {
+        val path = Path().apply { moveTo(x, y) }
+        val stroke = GestureDescription.StrokeDescription(path, 0, 50)
+        val gesture = GestureDescription.Builder().addStroke(stroke).build()
+        return dispatchGesture(gesture, null, null)
+    }
+
+    fun performSwipe(
+        x1: Float,
+        y1: Float,
+        x2: Float,
+        y2: Float,
+        durationMs: Long = 300,
+    ): Boolean {
+        val path =
+            Path().apply {
+                moveTo(x1, y1)
+                lineTo(x2, y2)
+            }
+        val stroke = GestureDescription.StrokeDescription(path, 0, durationMs)
+        val gesture = GestureDescription.Builder().addStroke(stroke).build()
+        return dispatchGesture(gesture, null, null)
+    }
+
+    fun performBack(): Boolean = performGlobalAction(GLOBAL_ACTION_BACK)
+
+    fun performHome(): Boolean = performGlobalAction(GLOBAL_ACTION_HOME)
+
+    fun performRecents(): Boolean = performGlobalAction(GLOBAL_ACTION_RECENTS)
+
+    fun typeText(text: String): Boolean {
+        val focused = findFocus(AccessibilityNodeInfo.FOCUS_INPUT) ?: return false
+        val args = android.os.Bundle()
+        args.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
+        return focused.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+    }
+
+    private fun nodeToJson(node: AccessibilityNodeInfo): JSONObject =
+        JSONObject().apply {
+            put("class", node.className?.toString() ?: "")
+            put("text", node.text?.toString() ?: "")
+            put("resource_id", node.viewIdResourceName ?: "")
+            put("content_desc", node.contentDescription?.toString() ?: "")
+            put("clickable", node.isClickable)
+            put("focusable", node.isFocusable)
+            put("scrollable", node.isScrollable)
+            put("editable", node.isEditable)
+            put("enabled", node.isEnabled)
+            val rect = android.graphics.Rect()
+            node.getBoundsInScreen(rect)
+            put("bounds", JSONArray().put(rect.left).put(rect.top).put(rect.right).put(rect.bottom))
+            val children = JSONArray()
+            for (i in 0 until node.childCount) {
+                node.getChild(i)?.let { child ->
+                    children.put(nodeToJson(child))
+                }
+            }
+            if (children.length() > 0) put("children", children)
+        }
+
+    private fun recycleTree(node: AccessibilityNodeInfo) {
+        for (i in 0 until node.childCount) {
+            node.getChild(i)?.let(::recycleTree)
+        }
+    }
+
+    companion object {
+        @Volatile
+        var instance: OpenCodeAccessibilityService? = null
+    }
+}

--- a/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/opencode/android/runtime/local/LocalRuntimeInstaller.kt
@@ -360,7 +360,11 @@ class LocalRuntimeInstaller(
 
     private fun installAndroidHelperScripts(rootfs: File) {
         val binDir = File(rootfs, "usr/local/bin").apply { mkdirs() }
-        listOf("android-vision.sh" to "android-vision", "android-screenshot.sh" to "android-screenshot").forEach {
+        listOf(
+            "android-vision.sh" to "android-vision",
+            "android-screenshot.sh" to "android-screenshot",
+            "android-ui.sh" to "android-ui",
+        ).forEach {
                 (assetName, scriptName) ->
             val scriptFile = File(binDir, scriptName)
             context.assets.open("scripts/$assetName").use { input ->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">جارٍ الإقران…</string>
     <string name="adb_connecting_in_progress">جارٍ الاتصال…</string>
     <string name="adb_requires_android_11">يتطلب Android 11 أو أحدث</string>
+    <string name="accessibility_service_description">يتيح لوكيل OpenCode قراءة الشاشة والنقر والتمرير وإدخال النص بدون ADB. يوفر خادم HTTP محلي على المنفذ 4098.</string>
+    <string name="accessibility_setup_title">خدمة إمكانية الوصول</string>
+    <string name="accessibility_setup_description">تفعيل قراءة الشاشة والتحكم بالإيماءات بدون ADB. يمكن للوكيل استخدام curl للتفاعل مع الجهاز.</string>
+    <string name="accessibility_status_disconnected">غير مفعّل</string>
+    <string name="accessibility_status_connected">نشط (المنفذ %1$d)</string>
+    <string name="accessibility_enable_button">تفعيل في الإعدادات</string>
     <string name="runtime_status_not_installed">غير مثبت</string>
     <string name="runtime_status_setting_up">جارٍ الإعداد</string>
     <string name="runtime_status_starting">جارٍ البدء</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">Vinculando…</string>
     <string name="adb_connecting_in_progress">Conectando…</string>
     <string name="adb_requires_android_11">Requiere Android 11 o posterior</string>
+    <string name="accessibility_service_description">Permite al agente OpenCode leer la pantalla, tocar, deslizar y escribir texto sin ADB. Expone una API HTTP local en el puerto 4098.</string>
+    <string name="accessibility_setup_title">Servicio de accesibilidad</string>
+    <string name="accessibility_setup_description">Habilita la lectura de pantalla y el control por gestos sin ADB. El agente puede usar curl para interactuar con el dispositivo.</string>
+    <string name="accessibility_status_disconnected">No habilitado</string>
+    <string name="accessibility_status_connected">Activo (puerto %1$d)</string>
+    <string name="accessibility_enable_button">Habilitar en Ajustes</string>
     <string name="runtime_status_not_installed">No instalado</string>
     <string name="runtime_status_setting_up">Configurando</string>
     <string name="runtime_status_starting">Iniciando</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">Association en cours…</string>
     <string name="adb_connecting_in_progress">Connexion en cours…</string>
     <string name="adb_requires_android_11">Nécessite Android 11 ou version ultérieure</string>
+    <string name="accessibility_service_description">Permet à l\'agent OpenCode de lire l\'écran, taper, glisser et saisir du texte sans ADB. Expose une API HTTP locale sur le port 4098.</string>
+    <string name="accessibility_setup_title">Service d\'accessibilité</string>
+    <string name="accessibility_setup_description">Active la lecture d\'écran et le contrôle par gestes sans ADB. L\'agent peut utiliser curl pour interagir avec l\'appareil.</string>
+    <string name="accessibility_status_disconnected">Non activé</string>
+    <string name="accessibility_status_connected">Actif (port %1$d)</string>
+    <string name="accessibility_enable_button">Activer dans les paramètres</string>
     <string name="runtime_status_not_installed">Non installé</string>
     <string name="runtime_status_setting_up">Configuration en cours</string>
     <string name="runtime_status_starting">Démarrage</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">ペアリング中…</string>
     <string name="adb_connecting_in_progress">接続中…</string>
     <string name="adb_requires_android_11">Android 11以降が必要です</string>
+    <string name="accessibility_service_description">OpenCodeエージェントがADBなしで画面読み取り、タップ、スワイプ、テキスト入力を行えるようにします。ローカルHTTPサーバー（ポート4098）を提供します。</string>
+    <string name="accessibility_setup_title">アクセシビリティサービス</string>
+    <string name="accessibility_setup_description">ADBなしで画面読み取りとジェスチャー制御を有効にします。エージェントはcurl経由でデバイスを操作できます。</string>
+    <string name="accessibility_status_disconnected">無効</string>
+    <string name="accessibility_status_connected">アクティブ（ポート %1$d）</string>
+    <string name="accessibility_enable_button">設定で有効にする</string>
     <string name="runtime_status_not_installed">未インストール</string>
     <string name="runtime_status_setting_up">セットアップ中</string>
     <string name="runtime_status_starting">起動中</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">Pareando…</string>
     <string name="adb_connecting_in_progress">Conectando…</string>
     <string name="adb_requires_android_11">Requer Android 11 ou posterior</string>
+    <string name="accessibility_service_description">Permite que o agente OpenCode leia a tela, toque, deslize e digite texto sem ADB. Expõe uma API HTTP local na porta 4098.</string>
+    <string name="accessibility_setup_title">Serviço de acessibilidade</string>
+    <string name="accessibility_setup_description">Ativa leitura de tela e controle por gestos sem ADB. O agente pode usar curl para interagir com o dispositivo.</string>
+    <string name="accessibility_status_disconnected">Não ativado</string>
+    <string name="accessibility_status_connected">Ativo (porta %1$d)</string>
+    <string name="accessibility_enable_button">Ativar nas Configurações</string>
     <string name="runtime_status_not_installed">Não instalado</string>
     <string name="runtime_status_setting_up">Configurando</string>
     <string name="runtime_status_starting">Iniciando</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">Сопряжение…</string>
     <string name="adb_connecting_in_progress">Подключение…</string>
     <string name="adb_requires_android_11">Требуется Android 11 или новее</string>
+    <string name="accessibility_service_description">Позволяет агенту OpenCode читать экран, нажимать, свайпать и вводить текст без ADB. Предоставляет локальный HTTP-сервер на порту 4098.</string>
+    <string name="accessibility_setup_title">Служба специальных возможностей</string>
+    <string name="accessibility_setup_description">Включает чтение экрана и управление жестами без ADB. Агент может использовать curl для взаимодействия с устройством.</string>
+    <string name="accessibility_status_disconnected">Не включено</string>
+    <string name="accessibility_status_connected">Активно (порт %1$d)</string>
+    <string name="accessibility_enable_button">Включить в настройках</string>
     <string name="runtime_status_not_installed">Не установлено</string>
     <string name="runtime_status_setting_up">Настройка</string>
     <string name="runtime_status_starting">Запуск</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">配对中…</string>
     <string name="adb_connecting_in_progress">连接中…</string>
     <string name="adb_requires_android_11">需要 Android 11 或更高版本</string>
+    <string name="accessibility_service_description">允许 OpenCode 代理在无需 ADB 的情况下读取屏幕、点击、滑动和输入文本。在端口 4098 上提供本地 HTTP API。</string>
+    <string name="accessibility_setup_title">无障碍服务</string>
+    <string name="accessibility_setup_description">无需 ADB 即可启用屏幕阅读和手势控制。代理可以通过 curl 与设备交互。</string>
+    <string name="accessibility_status_disconnected">未启用</string>
+    <string name="accessibility_status_connected">活跃（端口 %1$d）</string>
+    <string name="accessibility_enable_button">在设置中启用</string>
     <string name="runtime_status_not_installed">未安装</string>
     <string name="runtime_status_setting_up">正在设置</string>
     <string name="runtime_status_starting">正在启动</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,6 +286,12 @@
     <string name="adb_pairing_in_progress">Pairing…</string>
     <string name="adb_connecting_in_progress">Connecting…</string>
     <string name="adb_requires_android_11">Requires Android 11 or later</string>
+    <string name="accessibility_service_description">Allows the OpenCode agent to read the screen, tap, swipe, and type text without ADB. Exposes a local HTTP API on port 4098.</string>
+    <string name="accessibility_setup_title">Accessibility Service</string>
+    <string name="accessibility_setup_description">Enable screen reading and gesture control without ADB. The agent can use curl to interact with the device through a local HTTP server.</string>
+    <string name="accessibility_status_disconnected">Not enabled</string>
+    <string name="accessibility_status_connected">Active (port %1$d)</string>
+    <string name="accessibility_enable_button">Enable in Settings</string>
     <string name="runtime_status_not_installed">Not installed</string>
     <string name="runtime_status_setting_up">Setting up</string>
     <string name="runtime_status_starting">Starting</string>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged|typeViewClicked|typeViewScrolled"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault|flagIncludeNotImportantViews|flagReportViewIds|flagRetrieveInteractiveWindows"
+    android:canPerformGestures="true"
+    android:canRetrieveWindowContent="true"
+    android:description="@string/accessibility_service_description"
+    android:notificationTimeout="100"
+    android:packageNames="" />


### PR DESCRIPTION
## Summary

Add an  that provides screen reading, gesture injection, and text input **without requiring ADB or wireless debugging**. A built-in HTTP server (127.0.0.1:4098) exposes these capabilities to the PRoot agent via .

This is the final phase of the agent empowerment initiative. Combined with the previous phases, the agent now has:

| Phase | Capability | Channel |
|---|---|---|
| 1 | , , ,  | PATH |
| 2 |  | Wireless ADB |
| 3 | 使用方法: javac <options> <source files>
使用可能なオプションには次のものがあります。
  @<filename>                  ファイルからの読取りオプションおよびファイル名
  -Akey[=value]                注釈プロセッサに渡されるオプション
  --add-modules <module>(,<module>)*
        初期モジュールに加えて解決するルート・モジュール、または<module>が
                ALL-MODULE-PATHである場合はモジュール・パスのすべてのモジュール。
  --boot-class-path <path>, -bootclasspath <path>
        ブートストラップ・クラス・パスの位置をオーバーライドする
  --class-path <path>, -classpath <path>, -cp <path>
        ユーザー・クラス・ファイルおよび注釈プロセッサを検索する位置を指定する
  -d <directory>               生成されたクラス・ファイルを格納する位置を指定する
  -deprecation                 推奨されないAPIが使用されているソースの位置を出力する
  --enable-preview             プレビュー言語機能を有効にします。-sourceまたは--releaseとともに使用されます。
  -encoding <encoding>         ソース・ファイルが使用する文字エンコーディングを指定する
  -endorseddirs <dirs>         推奨規格パスの位置をオーバーライドする
  -extdirs <dirs>              インストール済み拡張機能の位置をオーバーライドする
  -g                           すべてのデバッグ情報を生成する
  -g:{lines,vars,source}       いくつかのデバッグ情報のみを生成する
  -g:none                      デバッグ情報を生成しない
  -h <directory>               生成されたネイティブ・ヘッダー・ファイルを格納する場所を指定する
  --help, -help, -?            このヘルプ・メッセージを出力します
  --help-extra, -X             追加オプションのヘルプを出力します
  -implicit:{none,class}       暗黙的に参照されるファイルについてクラス・ファイルを生成するかどうかを指定する
  -J<flag>                     <flag>を実行システムに直接渡す
  --limit-modules <module>(,<module>)*
        参照可能なモジュールの領域を制限します
  --module <module>(,<module>)*, -m <module>(,<module>)*
        指定したモジュールのみコンパイルし、タイムスタンプを確認する
  --module-path <path>, -p <path>
        アプリケーション・モジュールを検索する位置を指定する
  --module-source-path <module-source-path>
        複数モジュールの入力ソース・ファイルを検索する位置を指定する
  --module-version <バージョン>     コンパイルするモジュールのバージョンを指定します
  -nowarn                      警告を発生させない
  -parameters                  メソッド・パラメータにリフレクション用のメタデータを生成します
  -proc:{none,only,full}       注釈処理やコンパイルを実行するかどうかを制御します。
  -processor <class1>[,<class2>,<class3>...]
        実行する注釈プロセッサの名前。デフォルトの検出処理をバイパス
  --processor-module-path <path>
        注釈プロセッサを検索するモジュール・パスを指定する
  --processor-path <path>, -processorpath <path>
        注釈プロセッサを検索する位置を指定する
  -profile <profile>
        使用されているAPIが、指定したプロファイルで使用可能かどうかを確認します。
        このオプションは非推奨であり、今後のリリースで削除される可能性があります。
  --release <release>
        指定されたJava SEリリースに対してコンパイルします。サポートされているリリース: 
            8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
  -s <directory>               生成されたソース・ファイルを格納する場所を指定する
  --source <release>, -source <release>
        指定されたJava SEリリースとソースの互換性を保持します。サポートされているリリース: 
            8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
  --source-path <path>, -sourcepath <path>
        入力ソース・ファイルを検索する位置を指定する
  --system <jdk>|none          システム・モジュールの位置をオーバーライドする
  --target <release>, -target <release>
        指定されたJava SEリリースに適したクラス・ファイルを生成します。サポートされているリリース: 
            8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
  --upgrade-module-path <path>
        アップグレード可能なモジュールの位置をオーバーライドする
  -verbose                     コンパイラの動作についてメッセージを出力する
  --version, -version          バージョン情報
  -Werror                      警告が発生した場合にコンパイルを終了する, ,  | JDK + Gradle |
| 4 | Annotated screenshots, UI tree JSON | Python + PIL |
| **5** | **Screen reading, gestures, text input** | **AccessibilityService HTTP** |

## Endpoints

| Endpoint | Method | Description |
|---|---|---|
|  | GET | Check if service is connected |
|  | GET | View hierarchy as JSON |
|  | POST |  — tap at coordinates |
|  | POST |  |
|  | POST |  — type into focused field |
|  | POST |  |

## Usage from PRoot

```bash
android-ui screen           # view hierarchy
android-ui tap 500 800      # tap
android-ui swipe 500 1500 500 500  # swipe up
android-ui text "hello"   # type text
android-ui key back         # press back
```

## Changes

- **`OpenCodeAccessibilityService.kt`**: Reads view tree ( → JSON), dispatches gestures (), performs global actions, types text ()
- **`AccessibilityHttpServer.kt`**: Minimal -based HTTP server (no external dependency) on port 4098
- **`accessibility_service_config.xml`**: Service configuration with , 
- **`AndroidManifest.xml`**: Register AccessibilityService with  permission
- **`OpenCodeApplication.kt`**: Start HTTP server on app launch
- **`assets/scripts/android-ui.sh`**: curl wrapper for all endpoints
- **`LocalRuntimeInstaller.kt`**: Install android-ui script during setup
- **Strings**: 8 locales (en/ja/ar/es/fr/pt/ru/zh)

## Key advantage over ADB

- No wireless debugging setup needed
- No pairing code
- Survives device reboots (once enabled in Settings)
- User controls access via Android's Accessibility settings

## Testing

- `./gradlew :app:testDebugUnitTest` — all tests pass
- `./gradlew spotlessCheck` — formatting clean