### PR TITLE
fix: remove premature bitmap recycle causing crash on image send

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -197,7 +197,6 @@ fun ChatHomeScreen(
     val attachedImages = remember { mutableStateListOf<Bitmap>() }
     DisposableEffect(Unit) {
         onDispose {
-            attachedImages.forEach { if (!it.isRecycled) it.recycle() }
             attachedImages.clear()
         }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -686,7 +686,6 @@ class ChatViewModel(
                     .onSuccess { title ->
                         if (title.isNotBlank()) _uiState.update { it.copy(sessionTitle = title) }
                     }
-                _uiState.value.imagePreviews.forEach { bmp -> if (!bmp.isRecycled) bmp.recycle() }
                 _uiState.update { it.copy(attachments = emptyList(), imagePreviews = emptyList()) }
                 clearDraft(targetSessionId)
                 var sessionCompleted = false


### PR DESCRIPTION
v0.5.0 added explicit bitmap.recycle() calls that recycle objects still referenced by ChatMessage.imagePreviews in the message list. When the UI renders the sent message, asImageBitmap() is called on a recycled bitmap, crashing the app.

- Remove recycle in sendMessage() after clearing state: the same Bitmap objects are stored in the user message and rendered by ChatMessageComponents.
- Remove recycle in DisposableEffect: the ViewModel holds the same references and onCleared() is the correct lifecycle boundary.

Bitmaps are still cleaned up in onCleared() and removeAttachment().