### PR TITLE
feat: show chat timestamps and AI response duration

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -20,6 +20,16 @@ sealed interface TimelineEntry {
     data class Activity(override val id: String, val parts: List<ChatPart>) : TimelineEntry
 
     data class Todo(override val id: String, val todos: List<TodoItem>) : TimelineEntry
+
+    /**
+     * Trailing meta row for a finished assistant turn: the clock time the reply landed plus how
+     * long the user waited for it, surfaced LINE-style beneath the answer.
+     */
+    data class Footer(
+        override val id: String,
+        val completedAt: Long,
+        val durationMs: Long,
+    ) : TimelineEntry
 }
 
 /** Broad buckets used to summarise a run of tool calls in one line. */
@@ -58,6 +68,10 @@ data class ActivitySummary(
 fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> {
     val entries = mutableListOf<TimelineEntry>()
     val pending = mutableListOf<ChatPart>()
+    var lastUserAt: Long? = null
+    var turnStartAt: Long? = null
+    var turnCompletedAt: Long? = null
+    var turnLastId: String? = null
 
     fun flush() {
         if (pending.isEmpty()) return
@@ -65,11 +79,33 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
         pending.clear()
     }
 
+    fun flushTurnFooter() {
+        val completed = turnCompletedAt ?: return
+        val lastId = turnLastId ?: return
+        val start = lastUserAt ?: turnStartAt ?: completed
+        entries +=
+            TimelineEntry.Footer(
+                id = "footer:$lastId",
+                completedAt = completed,
+                durationMs = (completed - start).coerceAtLeast(0L),
+            )
+        turnStartAt = null
+        turnCompletedAt = null
+        turnLastId = null
+    }
+
     messages.forEach { message ->
         if (message.isUser) {
             flush()
+            flushTurnFooter()
+            lastUserAt = message.timestamp
             entries += TimelineEntry.UserMessage(message)
             return@forEach
+        }
+        if (turnStartAt == null) turnStartAt = message.timestamp
+        turnLastId = message.id
+        message.completedAt?.let { completed ->
+            turnCompletedAt = maxOf(turnCompletedAt ?: 0L, completed)
         }
         message.parts.forEach { part ->
             when {
@@ -87,6 +123,7 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
         }
     }
     flush()
+    flushTurnFooter()
     return entries
 }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -354,6 +354,7 @@ fun ChatHomeScreen(
                                         is TimelineEntry.Body -> entry.messageId to entry.part.text
                                         is TimelineEntry.Activity -> null
                                         is TimelineEntry.Todo -> null
+                                        is TimelineEntry.Footer -> null
                                     }
                                 Box(
                                     modifier =

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -58,6 +58,9 @@ import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.ui.theme.AndCodeWarning
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 private val TOOL_CALL_ECHO_REGEX =
     Regex("""Called the [A-Za-z][A-Za-z ]*? tool with the following input: \{(?:[^{}]|\{[^{}]*\})*\}""")
@@ -71,43 +74,54 @@ fun MessageBubble(message: ChatMessage) {
         modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.CenterEnd,
     ) {
-        Surface(
-            modifier = Modifier.widthIn(max = 340.dp),
-            shape = RoundedCornerShape(20.dp, 20.dp, 5.dp, 20.dp),
-            color = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary,
+        Row(
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            Column(modifier = Modifier.padding(14.dp)) {
-                message.imagePreviews.forEach { preview ->
-                    Image(
-                        bitmap = preview.asImageBitmap(),
-                        contentDescription = stringResource(R.string.cd_image_preview),
-                        modifier =
-                            Modifier
-                                .widthIn(max = 280.dp)
-                                .heightIn(max = 220.dp)
-                                .padding(bottom = 8.dp),
-                        contentScale = ContentScale.Fit,
-                    )
-                }
-                message.attachments.forEach { attachment ->
-                    if (attachment.mime.startsWith("image/")) return@forEach
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        modifier = Modifier.padding(bottom = 8.dp),
-                    ) {
-                        Icon(Icons.Default.Description, contentDescription = stringResource(R.string.cd_attachment))
-                        Text(
-                            text = attachment.filename,
-                            style = MaterialTheme.typography.labelMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
+            Text(
+                text = formatClockTime(message.timestamp),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+            Surface(
+                modifier = Modifier.widthIn(max = 340.dp),
+                shape = RoundedCornerShape(20.dp, 20.dp, 5.dp, 20.dp),
+                color = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Column(modifier = Modifier.padding(14.dp)) {
+                    message.imagePreviews.forEach { preview ->
+                        Image(
+                            bitmap = preview.asImageBitmap(),
+                            contentDescription = stringResource(R.string.cd_image_preview),
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 280.dp)
+                                    .heightIn(max = 220.dp)
+                                    .padding(bottom = 8.dp),
+                            contentScale = ContentScale.Fit,
                         )
                     }
-                }
-                if (displayText.isNotBlank()) {
-                    Text(text = displayText)
+                    message.attachments.forEach { attachment ->
+                        if (attachment.mime.startsWith("image/")) return@forEach
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        ) {
+                            Icon(Icons.Default.Description, contentDescription = stringResource(R.string.cd_attachment))
+                            Text(
+                                text = attachment.filename,
+                                style = MaterialTheme.typography.labelMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                    if (displayText.isNotBlank()) {
+                        Text(text = displayText)
+                    }
                 }
             }
         }
@@ -128,6 +142,7 @@ fun TimelineEntryRow(
                 onClick = { onOpenActivity(entry.id) },
             )
         is TimelineEntry.Todo -> TodoTimelineCard(entry.todos)
+        is TimelineEntry.Footer -> MessageFooter(entry)
     }
 }
 
@@ -428,3 +443,38 @@ private fun renderInline(
             }
         }
     }
+
+private val clockTimeFormat = SimpleDateFormat("HH:mm", Locale.US)
+
+private fun formatClockTime(epochMs: Long): String = clockTimeFormat.format(Date(epochMs))
+
+@Composable
+private fun MessageFooter(entry: TimelineEntry.Footer) {
+    val minutes = entry.durationMs / 60_000L
+    val durationLabel =
+        when {
+            entry.durationMs <= 0L -> null
+            minutes < 1L -> stringResource(R.string.chat_response_duration_under_minute)
+            else -> stringResource(R.string.chat_response_duration, minutes)
+        }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.End),
+    ) {
+        if (durationLabel != null) {
+            Text(
+                text = durationLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (entry.completedAt > 0L) {
+            Text(
+                text = formatClockTime(entry.completedAt),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -75,6 +75,7 @@ data class ChatMessage(
     val attachments: List<PromptAttachment> = emptyList(),
     val imagePreviews: List<Bitmap> = emptyList(),
     val timestamp: Long = System.currentTimeMillis(),
+    val completedAt: Long? = null,
     val isStreaming: Boolean = false,
 ) {
     val text: String
@@ -1237,6 +1238,7 @@ class ChatViewModel(
             parts = parts,
             attachments = attachments,
             timestamp = message.info.time.created,
+            completedAt = message.info.time.completed,
             isStreaming = false,
         )
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -907,4 +907,6 @@
     <string name="setup_download_agents_description">تحضير بيئة Linux المشتركة والوكلاء الذين اخترتهم.</string>
     <string name="settings_agents_row">الوكلاء</string>
     <string name="settings_agents_section">الوكلاء</string>
+    <string name="chat_response_duration">%1$d min</string>
+    <string name="chat_response_duration_under_minute">&lt;1 min</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -907,4 +907,6 @@
     <string name="setup_download_agents_description">Prepara el entorno Linux compartido y los agentes que eligió.</string>
     <string name="settings_agents_row">Agentes</string>
     <string name="settings_agents_section">Agentes</string>
+    <string name="chat_response_duration">%1$d min</string>
+    <string name="chat_response_duration_under_minute">&lt;1 min</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -907,4 +907,6 @@
     <string name="setup_download_agents_description">Prépare l’environnement Linux partagé et les agents que vous avez choisis.</string>
     <string name="settings_agents_row">Agents</string>
     <string name="settings_agents_section">Agents</string>
+    <string name="chat_response_duration">%1$d min</string>
+    <string name="chat_response_duration_under_minute">&lt;1 min</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -921,4 +921,6 @@
     <string name="setup_download_agents_description">共有のLinux環境と、選んだエージェントを準備します。</string>
     <string name="settings_agents_row">エージェント</string>
     <string name="settings_agents_section">エージェント</string>
+    <string name="chat_response_duration">%1$d分</string>
+    <string name="chat_response_duration_under_minute">1分未満</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -907,4 +907,6 @@
     <string name="setup_download_agents_description">Prepara o ambiente Linux compartilhado e os agentes escolhidos.</string>
     <string name="settings_agents_row">Agentes</string>
     <string name="settings_agents_section">Agentes</string>
+    <string name="chat_response_duration">%1$d min</string>
+    <string name="chat_response_duration_under_minute">&lt;1 min</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -907,4 +907,6 @@
     <string name="setup_download_agents_description">Подготовка общей среды Linux и выбранных агентов.</string>
     <string name="settings_agents_row">Агенты</string>
     <string name="settings_agents_section">Агенты</string>
+    <string name="chat_response_duration">%1$d min</string>
+    <string name="chat_response_duration_under_minute">&lt;1 min</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -907,4 +907,6 @@
     <string name="setup_download_agents_description">准备共享的 Linux 环境以及你选择的智能体。</string>
     <string name="settings_agents_row">智能体</string>
     <string name="settings_agents_section">智能体</string>
+    <string name="chat_response_duration">%1$d min</string>
+    <string name="chat_response_duration_under_minute">&lt;1 min</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -921,4 +921,6 @@
     <string name="setup_download_agents_description">Prepare the shared Linux environment and the agents you picked.</string>
     <string name="settings_agents_row">Agents</string>
     <string name="settings_agents_section">Agents</string>
+    <string name="chat_response_duration">%1$d min</string>
+    <string name="chat_response_duration_under_minute">&lt;1 min</string>
 </resources>


### PR DESCRIPTION
Display the send time next to each user bubble and the completion time plus how long the user waited for the reply beneath each finished assistant turn (LINE-style).

- User bubble: `HH:mm` send time on the left of the bubble.
- Assistant turn footer: completion time + duration (e.g. `3 min 14:32`), right-aligned beneath the answer. Under 1 minute shows a localized "<1 min" label.
- Duration is measured from the user's prompt to the assistant's completed message; the footer only appears once a turn finishes (stays hidden while streaming).
- Adds a `completedAt` field to `ChatMessage` (sourced from `message.info.time.completed`) and a new `TimelineEntry.Footer` emitted at the end of each finished assistant turn by `groupConversationTimeline`.
- Response-duration strings added to all 8 locales to keep `lintVitalRelease` green.