### PR TITLE
fix: post a notification when the agent asks a question

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
@@ -266,6 +266,7 @@ class AndCodeApplication : Application() {
                     githubStarCoordinator.onSessionCompleted()
                 },
                 onSessionError = notifications::notifySessionError,
+                onQuestionAsked = notifications::notifyQuestion,
                 unreadStore = settings,
             )
         githubStarCoordinator.refresh()

--- a/app/src/main/java/com/yugahashimoto/andcode/core/notification/RuntimeNotificationHelper.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/notification/RuntimeNotificationHelper.kt
@@ -16,6 +16,7 @@ import androidx.core.content.ContextCompat
 import com.yugahashimoto.andcode.MainActivity
 import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.PermissionRequest
+import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 
 class RuntimeNotificationHelper(private val context: Context) {
@@ -77,6 +78,48 @@ class RuntimeNotificationHelper(private val context: Context) {
         safeNotify(permissionNotificationId(request.id), notification)
     }
 
+    fun notifyQuestion(
+        request: QuestionRequest,
+        chatTitle: String?,
+    ) {
+        if (!canPostNotifications()) return
+        val openIntent =
+            pendingActivityIntent(
+                requestCode = request.id.hashCode(),
+                extras =
+                    mapOf(
+                        EXTRA_OPEN_CHAT to true,
+                        EXTRA_TARGET_SESSION_ID to request.sessionId,
+                    ),
+            )
+        val prompt = request.questions.firstOrNull()?.question?.takeIf(String::isNotBlank)
+        val notification =
+            NotificationCompat.Builder(context, CHANNEL_APPROVALS)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(
+                    context.getString(R.string.notification_question_title) + " · " +
+                        (chatTitle?.takeIf(String::isNotBlank) ?: context.getString(R.string.new_chat)),
+                )
+                .setContentText(prompt ?: context.getString(R.string.notification_question_body))
+                .setStyle(
+                    NotificationCompat.BigTextStyle().bigText(
+                        buildString {
+                            append(chatTitle?.takeIf(String::isNotBlank) ?: context.getString(R.string.new_chat))
+                            if (prompt != null) {
+                                append('\n')
+                                append(prompt)
+                            }
+                        },
+                    ),
+                )
+                .setContentIntent(openIntent)
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .build()
+
+        safeNotify(questionNotificationId(request.id), notification)
+    }
+
     fun notifySessionComplete(
         sessionId: String,
         chatTitle: String?,
@@ -134,6 +177,10 @@ class RuntimeNotificationHelper(private val context: Context) {
 
     fun cancelPermission(permissionId: String) {
         manager.cancel(permissionNotificationId(permissionId))
+    }
+
+    fun cancelQuestion(questionId: String) {
+        manager.cancel(questionNotificationId(questionId))
     }
 
     private fun canPostNotifications(): Boolean {
@@ -220,6 +267,8 @@ class RuntimeNotificationHelper(private val context: Context) {
     }
 
     private fun permissionNotificationId(permissionId: String): Int = 20_000 + (permissionId.hashCode() and 0x0FFF)
+
+    private fun questionNotificationId(questionId: String): Int = 25_000 + (questionId.hashCode() and 0x0FFF)
 
     private fun statusNotificationId(
         sessionId: String,

--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
@@ -2,6 +2,7 @@ package com.yugahashimoto.andcode.data.repository
 
 import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import com.yugahashimoto.andcode.core.api.PermissionRequest
+import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.runtime.RuntimeRegistry
 import com.yugahashimoto.andcode.runtime.RuntimeState
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
@@ -50,6 +51,7 @@ class RuntimeActivityRepository(
     private val onPermissionResolved: ((String) -> Unit)? = null,
     private val onSessionIdle: ((String, String?) -> Unit)? = null,
     private val onSessionError: ((String?, String?) -> Unit)? = null,
+    private val onQuestionAsked: ((QuestionRequest, String?) -> Unit)? = null,
     private val unreadStore: UnreadSessionStore? = null,
 ) {
     init {
@@ -284,6 +286,10 @@ class RuntimeActivityRepository(
                     current.copy(activeSessionIds = current.activeSessionIds + event.request.sessionId)
                 }
                 appendLog("質問", event.request.questions.firstOrNull()?.question, event.request.sessionId)
+                onQuestionAsked?.invoke(
+                    event.request,
+                    sessionTitle(target, event.request.sessionId),
+                )
             }
             is OpenCodeEvent.Unknown -> appendLog("未対応イベント", event.type)
         }

--- a/app/src/main/java/com/yugahashimoto/andcode/di/AppModule.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/di/AppModule.kt
@@ -163,6 +163,7 @@ val appModule =
                 },
                 onSessionIdle = notifications::notifySessionComplete,
                 onSessionError = notifications::notifySessionError,
+                onQuestionAsked = notifications::notifyQuestion,
             )
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">الموافقات</string>
     <string name="notification_channel_status">حالة المهمة</string>
     <string name="notification_approval_title">مطلوب موافقة</string>
+    <string name="notification_question_title">مطلوب إجابة</string>
+    <string name="notification_question_body">الوكيل يطرح سؤالاً</string>
     <string name="notification_complete_title">انتهى التنفيذ</string>
     <string name="notification_complete_body">المحادثة %1$s خاملة</string>
     <string name="permission_chat_confirmation">تنتظر هذه المحادثة موافقتك. اختر ما يُسمح للوكيل بفعله:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">Aprobaciones</string>
     <string name="notification_channel_status">Estado de la tarea</string>
     <string name="notification_approval_title">Se necesita aprobación</string>
+    <string name="notification_question_title">Se necesita respuesta</string>
+    <string name="notification_question_body">El agente está haciendo una pregunta</string>
     <string name="notification_complete_title">Ejecución finalizada</string>
     <string name="notification_complete_body">El chat %1$s está inactivo</string>
     <string name="permission_chat_confirmation">Este chat espera su aprobación. Elija qué puede hacer el agente:</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">Approbations</string>
     <string name="notification_channel_status">État de la tâche</string>
     <string name="notification_approval_title">Approbation requise</string>
+    <string name="notification_question_title">Réponse requise</string>
+    <string name="notification_question_body">L’agent pose une question</string>
     <string name="notification_complete_title">Exécution terminée</string>
     <string name="notification_complete_body">Le chat %1$s est inactif</string>
     <string name="permission_chat_confirmation">Cette conversation attend votre approbation. Choisissez ce que l’agent peut faire :</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">承認</string>
     <string name="notification_channel_status">タスク状態</string>
     <string name="notification_approval_title">承認が必要です</string>
+    <string name="notification_question_title">回答が必要です</string>
+    <string name="notification_question_body">エージェントが質問しています</string>
     <string name="notification_complete_title">実行が完了しました</string>
     <string name="notification_complete_body">チャット「%1$s」が待機中です</string>
     <string name="permission_chat_confirmation">このチャットは承認待ちです。エージェントに許可する操作を選んでください:</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">Aprovações</string>
     <string name="notification_channel_status">Status da tarefa</string>
     <string name="notification_approval_title">Aprovação necessária</string>
+    <string name="notification_question_title">Resposta necessária</string>
+    <string name="notification_question_body">O agente está fazendo uma pergunta</string>
     <string name="notification_complete_title">Execução concluída</string>
     <string name="notification_complete_body">O chat %1$s está ocioso</string>
     <string name="permission_chat_confirmation">Este chat aguarda sua aprovação. Escolha o que o agente pode fazer:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">Одобрения</string>
     <string name="notification_channel_status">Статус задачи</string>
     <string name="notification_approval_title">Требуется подтверждение</string>
+    <string name="notification_question_title">Требуется ответ</string>
+    <string name="notification_question_body">Агент задаёт вопрос</string>
     <string name="notification_complete_title">Выполнение завершено</string>
     <string name="notification_complete_body">Чат %1$s бездействует</string>
     <string name="permission_chat_confirmation">Этот чат ожидает вашего подтверждения. Выберите, что разрешено агенту:</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">批准</string>
     <string name="notification_channel_status">任务状态</string>
     <string name="notification_approval_title">需要批准</string>
+    <string name="notification_question_title">需要回答</string>
+    <string name="notification_question_body">智能体正在提问</string>
     <string name="notification_complete_title">运行已完成</string>
     <string name="notification_complete_body">聊天 %1$s 处于空闲状态</string>
     <string name="permission_chat_confirmation">此对话正在等待你的批准。请选择允许该智能体执行的操作：</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,8 @@
     <string name="notification_channel_approvals">Approvals</string>
     <string name="notification_channel_status">Task status</string>
     <string name="notification_approval_title">Approval needed</string>
+    <string name="notification_question_title">Answer needed</string>
+    <string name="notification_question_body">The agent is asking a question</string>
     <string name="notification_complete_title">Run finished</string>
     <string name="notification_complete_body">Chat %1$s is idle</string>
     <string name="permission_chat_confirmation">This chat is waiting for your approval. Choose what the agent may do:</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
@@ -7,6 +7,8 @@ import com.yugahashimoto.andcode.core.api.OpenCodeMessage
 import com.yugahashimoto.andcode.core.api.OpenCodeSession
 import com.yugahashimoto.andcode.core.api.PromptRequest
 import com.yugahashimoto.andcode.core.api.ProviderCatalog
+import com.yugahashimoto.andcode.core.api.QuestionPrompt
+import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.data.connection.ConnectionProfile
 import com.yugahashimoto.andcode.runtime.BackendKind
 import com.yugahashimoto.andcode.runtime.PermissionResponse
@@ -232,6 +234,39 @@ class RuntimeActivityRepositoryTest {
             assertEquals("notification cancel callback", listOf("perm-1"), cancelled)
             assertEquals("resolvedPermissions subscribers", listOf("perm-1"), observed)
             collector.cancel()
+        }
+
+    @Test
+    fun `a question event raises the notification callback`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val asked = mutableListOf<QuestionRequest>()
+            RuntimeActivityRepository(
+                registry = registry,
+                scope = TestScope(dispatcher),
+                onQuestionAsked = { request, _ -> asked += request },
+            )
+            advanceUntilIdle()
+
+            target.eventFlow.emit(
+                OpenCodeEvent.QuestionAsked(
+                    QuestionRequest(
+                        id = "q-1",
+                        sessionId = "ses_1",
+                        questions = listOf(QuestionPrompt(question = "Which framework?")),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf("q-1"), asked.map { it.id })
         }
 
     private class FakeUnreadStore(


### PR DESCRIPTION
## Problem
When the agent asked a question via the question tool, nothing appeared in the Android notification bar. The `QuestionAsked` event only updated activity state and appended a log entry — unlike `PermissionAsked`, `SessionIdle` and `SessionError`, it never invoked a notification callback, so a turn waiting for an answer was invisible while the app was backgrounded.

## Fix
- Add `RuntimeNotificationHelper.notifyQuestion` (high-priority, opens the chat; mirrors `notifyPermission`) plus `cancelQuestion`.
- Add an `onQuestionAsked` callback to `RuntimeActivityRepository` and invoke it in the `QuestionAsked` branch.
- Wire the callback in both `AppModule` and `AndCodeApplication`.
- Add `notification_question_title`/`notification_question_body` strings across all 8 locales.
- Add a unit test asserting the callback fires on a `QuestionAsked` event.

## Verification
- `./gradlew detekt spotlessCheck` passes locally.
- Full `lintDebug`/`testDebugUnitTest`/`assembleDebug` run on CI (local sandbox cannot run the x86_64 aapt2).