### PR TITLE
docs: require worktree cleanup after a PR is merged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@ At the start of every new session, ALWAYS create a git worktree before making an
 3. Work exclusively within the worktree directory.
 4. Never modify the main working tree directly.
 5. After creating the worktree, ALL subsequent tool calls (read, edit, grep, glob, bash) MUST use the worktree absolute path as their base directory. The default working directory (`/workspace/and-code`) is the main tree and must NEVER be used for file operations after worktree creation. Verify by running `pwd` or checking paths before the first edit.
+6. Once the branch's pull request is merged, clean up immediately: remove the worktree (`git worktree remove <path>`) and delete the local branch (`git branch -D <branch-name>`). Never leave a merged worktree or its branch behind.


### PR DESCRIPTION
Adds a sixth rule to the Worktree section of AGENTS.md: once a branch's PR is merged, remove the worktree and delete the local branch so merged worktrees are never left behind.

Documentation-only change.