### PR TITLE
feat: add official Antigravity local runtime and multi-agent drawer integration

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/activity/ActivityViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/activity/ActivityViewModel.kt
@@ -105,14 +105,20 @@ class ActivityViewModel(
     }
 
     fun deleteSession(sessionId: String) {
-        val backend = registry.selected.value ?: return
         actionError.value = null
         viewModelScope.launch {
-            runCatching { backend.deleteSession(sessionId) }
-                .onSuccess { catalog.refresh() }
-                .onFailure { error ->
-                    actionError.value = error.message ?: "Failed to delete session"
-                }
+            val targets = registry.targets.value
+            var deleted = false
+            var lastError: Throwable? = null
+            for (target in targets) {
+                runCatching { target.deleteSession(sessionId) }
+                    .onSuccess { if (it) deleted = true }
+                    .onFailure { lastError = it }
+            }
+            catalog.refresh()
+            if (!deleted && lastError != null) {
+                actionError.value = lastError?.message ?: "Failed to delete session"
+            }
         }
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/activity/ActivityViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/activity/ActivityViewModel.kt
@@ -9,6 +9,9 @@ import com.yugahashimoto.andcode.data.repository.RuntimeCatalogRepository
 import com.yugahashimoto.andcode.data.repository.RuntimeEventLog
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.runtime.RuntimeRegistry
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -108,16 +111,18 @@ class ActivityViewModel(
         actionError.value = null
         viewModelScope.launch {
             val targets = registry.targets.value
-            var deleted = false
-            var lastError: Throwable? = null
-            for (target in targets) {
-                runCatching { target.deleteSession(sessionId) }
-                    .onSuccess { if (it) deleted = true }
-                    .onFailure { lastError = it }
+            val results = coroutineScope {
+                targets.map { target ->
+                    async { runCatching { target.deleteSession(sessionId) } }
+                }.awaitAll()
             }
+            val deleted = results.any { it.getOrDefault(false) }
+            val errors = results.mapNotNull { it.exceptionOrNull() }
             catalog.refresh()
-            if (!deleted && lastError != null) {
-                actionError.value = lastError?.message ?: "Failed to delete session"
+            if (!deleted && errors.isNotEmpty()) {
+                actionError.value =
+                    errors.mapNotNull { it.message }.distinct().joinToString("; ")
+                        .ifBlank { "Failed to delete session" }
             }
         }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
@@ -270,11 +270,12 @@ class AntigravityRuntime(
 
     fun listMessages(sessionId: String): List<OpenCodeMessage> = messages[sessionId].orEmpty().toList()
 
-    fun remove(sessionId: String) {
+    fun remove(sessionId: String): Boolean {
         abort(sessionId)
-        records.remove(sessionId)
+        val removed = records.remove(sessionId) != null
         messages.remove(sessionId)
         persist()
+        return removed
     }
 
     fun create(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
@@ -190,8 +190,7 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
     }
 
     override suspend fun deleteSession(sessionId: String): Boolean {
-        runtime.remove(sessionId)
-        return true
+        return runtime.remove(sessionId)
     }
 
     override suspend fun respondToPermission(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
@@ -281,10 +281,12 @@ class ClaudeCodeTarget(
     }
 
     override suspend fun deleteSession(sessionId: String): Boolean {
-        if (records.remove(sessionId) == null) return false
-        persist()
+        val removed = records.remove(sessionId) != null
+        if (removed) {
+            persist()
+        }
         withContext(Dispatchers.IO) { runtime.deleteSessionData(sessionId) }
-        return true
+        return removed
     }
 
     /**

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -97,6 +97,9 @@ import com.yugahashimoto.andcode.ui.theme.AndCodeTheme
 import com.yugahashimoto.andcode.ui.theme.AppTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -624,36 +627,48 @@ fun AndCodeApp(
                         },
                         onDeleteSession = { sessionId ->
                             voiceScope.launch {
-                                app.runtimeRegistry.targets.value.forEach { target ->
-                                    runCatching { target.deleteSession(sessionId) }
+                                val targets = app.runtimeRegistry.targets.value
+                                coroutineScope {
+                                    targets.map { target ->
+                                        async { runCatching { target.deleteSession(sessionId) } }
+                                    }.awaitAll()
                                 }
                                 app.catalogRepository.refreshSessionsOnly()
                             }
                         },
                         onArchiveSession = { sessionId ->
                             voiceScope.launch {
-                                app.runtimeRegistry.targets.value.forEach { target ->
-                                    runCatching { target.archiveSession(sessionId) }
+                                val targets = app.runtimeRegistry.targets.value
+                                coroutineScope {
+                                    targets.map { target ->
+                                        async { runCatching { target.archiveSession(sessionId) } }
+                                    }.awaitAll()
                                 }
                                 app.catalogRepository.refreshSessionsOnly()
                             }
                         },
                         onBatchDelete = { sessionIds ->
                             voiceScope.launch {
-                                sessionIds.forEach { id ->
-                                    app.runtimeRegistry.targets.value.forEach { target ->
-                                        runCatching { target.deleteSession(id) }
-                                    }
+                                val targets = app.runtimeRegistry.targets.value
+                                coroutineScope {
+                                    sessionIds.flatMap { id ->
+                                        targets.map { target ->
+                                            async { runCatching { target.deleteSession(id) } }
+                                        }
+                                    }.awaitAll()
                                 }
                                 app.catalogRepository.refreshSessionsOnly()
                             }
                         },
                         onBatchArchive = { sessionIds ->
                             voiceScope.launch {
-                                sessionIds.forEach { id ->
-                                    app.runtimeRegistry.targets.value.forEach { target ->
-                                        runCatching { target.archiveSession(id) }
-                                    }
+                                val targets = app.runtimeRegistry.targets.value
+                                coroutineScope {
+                                    sessionIds.flatMap { id ->
+                                        targets.map { target ->
+                                            async { runCatching { target.archiveSession(id) } }
+                                        }
+                                    }.awaitAll()
                                 }
                                 app.catalogRepository.refreshSessionsOnly()
                             }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -624,20 +624,26 @@ fun AndCodeApp(
                         },
                         onDeleteSession = { sessionId ->
                             voiceScope.launch {
-                                runCatching { selectedRuntime?.deleteSession(sessionId) }
+                                app.runtimeRegistry.targets.value.forEach { target ->
+                                    runCatching { target.deleteSession(sessionId) }
+                                }
                                 app.catalogRepository.refreshSessionsOnly()
                             }
                         },
                         onArchiveSession = { sessionId ->
                             voiceScope.launch {
-                                runCatching { selectedRuntime?.archiveSession(sessionId) }
+                                app.runtimeRegistry.targets.value.forEach { target ->
+                                    runCatching { target.archiveSession(sessionId) }
+                                }
                                 app.catalogRepository.refreshSessionsOnly()
                             }
                         },
                         onBatchDelete = { sessionIds ->
                             voiceScope.launch {
                                 sessionIds.forEach { id ->
-                                    runCatching { selectedRuntime?.deleteSession(id) }
+                                    app.runtimeRegistry.targets.value.forEach { target ->
+                                        runCatching { target.deleteSession(id) }
+                                    }
                                 }
                                 app.catalogRepository.refreshSessionsOnly()
                             }
@@ -645,7 +651,9 @@ fun AndCodeApp(
                         onBatchArchive = { sessionIds ->
                             voiceScope.launch {
                                 sessionIds.forEach { id ->
-                                    runCatching { selectedRuntime?.archiveSession(id) }
+                                    app.runtimeRegistry.targets.value.forEach { target ->
+                                        runCatching { target.archiveSession(id) }
+                                    }
                                 }
                                 app.catalogRepository.refreshSessionsOnly()
                             }


### PR DESCRIPTION
### Summary

This PR adds full support for the official **Antigravity** local runtime to AndCode, bringing it to feature parity with Claude Code and OpenCode, alongside multi-agent UX enhancements.

### Key Changes
- **Antigravity Local Runtime & Agent Support**:
  - Implemented `AntigravityRuntime`, `AntigravityTarget`, `AntigravityAuthCoordinator`, `AntigravityController`, `AntigravityInstaller`, `AntigravityMcp`, and related components.
  - Added support for official Google Antigravity OAuth sign-in flow on Android with URL extraction and transcript buffering.
  - Added Antigravity model catalogue, settings, permission modes, and process tree handling.
  - Pre-installed `git` and `gh` dev tools in Debian rootfs sandbox for Antigravity runtime execution.

- **Multi-Agent Drawer & Unified Chat History**:
  - Unified chat history (`RuntimeCatalogRepository`) across all installed runtimes (`OpenCode`, `Claude Code`, `Antigravity`), preserving agent icons and target associations.
  - Added an agent switcher in the drawer navigation to quickly filter or switch active agents.
  - Fixed session deletion and archiving to route across all registered targets in multi-agent views.
  - Improved model fallback logic when re-opening existing chats or switching active runtimes.

- **Onboarding & Localizations**:
  - Refined setup guide order, install attribution, and error diagnostics.
  - Localized strings for GitHub auth and setup guidance across 8 supported locales.