### PR TITLE
fix: show AutoAccept chip for OpenCode runtimes

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/activity/ActivityViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/activity/ActivityViewModel.kt
@@ -111,11 +111,12 @@ class ActivityViewModel(
         actionError.value = null
         viewModelScope.launch {
             val targets = registry.targets.value
-            val results = coroutineScope {
-                targets.map { target ->
-                    async { runCatching { target.deleteSession(sessionId) } }
-                }.awaitAll()
-            }
+            val results =
+                coroutineScope {
+                    targets.map { target ->
+                        async { runCatching { target.deleteSession(sessionId) } }
+                    }.awaitAll()
+                }
             val deleted = results.any { it.getOrDefault(false) }
             val errors = results.mapNotNull { it.exceptionOrNull() }
             catalog.refresh()

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
@@ -21,8 +21,8 @@ import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.runtime.BackendKind
 import com.yugahashimoto.andcode.runtime.LocalAgent
 import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
-import com.yugahashimoto.andcode.runtime.RuntimeCapabilities
 import com.yugahashimoto.andcode.runtime.PermissionResponse
+import com.yugahashimoto.andcode.runtime.RuntimeCapabilities
 import com.yugahashimoto.andcode.runtime.RuntimeState
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
 import com.yugahashimoto.andcode.runtime.RuntimeType

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
@@ -21,6 +21,7 @@ import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.runtime.BackendKind
 import com.yugahashimoto.andcode.runtime.LocalAgent
 import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
+import com.yugahashimoto.andcode.runtime.RuntimeCapabilities
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.runtime.RuntimeState
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
@@ -48,6 +49,7 @@ class LocalRuntimeTarget(
     override val agent: LocalAgent = LocalAgent.OPEN_CODE
     override val type: RuntimeType = RuntimeType.LOCAL
     override val kind: BackendKind = BackendKind.LOCAL
+    override val capabilities = RuntimeCapabilities(permissions = true)
 
     private val mutableState = MutableStateFlow(mapStatus(runtimeManager.status()))
     override val state: StateFlow<RuntimeState> = mutableState.asStateFlow()

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
@@ -21,6 +21,7 @@ import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.core.util.safeMessage
 import com.yugahashimoto.andcode.data.connection.ConnectionProfile
 import com.yugahashimoto.andcode.runtime.BackendKind
+import com.yugahashimoto.andcode.runtime.RuntimeCapabilities
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.runtime.RuntimeState
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
@@ -41,6 +42,7 @@ class RemoteRuntimeTarget(
     override val displayName: String = profile.name
     override val type: RuntimeType = RuntimeType.REMOTE
     override val kind: BackendKind = BackendKind.REMOTE
+    override val capabilities = RuntimeCapabilities(permissions = true)
 
     private val mutableState = MutableStateFlow<RuntimeState>(RuntimeState.Disconnected)
     override val state: StateFlow<RuntimeState> = mutableState.asStateFlow()

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
@@ -21,8 +21,8 @@ import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.core.util.safeMessage
 import com.yugahashimoto.andcode.data.connection.ConnectionProfile
 import com.yugahashimoto.andcode.runtime.BackendKind
-import com.yugahashimoto.andcode.runtime.RuntimeCapabilities
 import com.yugahashimoto.andcode.runtime.PermissionResponse
+import com.yugahashimoto.andcode.runtime.RuntimeCapabilities
 import com.yugahashimoto.andcode.runtime.RuntimeState
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
 import com.yugahashimoto.andcode.runtime.RuntimeType


### PR DESCRIPTION
Cause: LocalRuntimeTarget and RemoteRuntimeTarget did not override capabilities, so the default RuntimeCapabilities() (permissions=false) was used, making supportsPermissions=false and hiding the AutoAcceptChip. Fix: Add capabilities = RuntimeCapabilities(permissions=true) override to both targets.