### PR TITLE
fix: hide finished subagents and silence their completion notifications

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
@@ -240,7 +240,12 @@ class RuntimeActivityRepository(
                     )
                 }
                 appendLog("実行完了", null, event.sessionId)
-                onSessionIdle?.invoke(event.sessionId, sessionTitle(target, event.sessionId))
+                val isSubagent =
+                    runCatching { target.session(event.sessionId).parentId != null }
+                        .getOrDefault(false)
+                if (!isSubagent) {
+                    onSessionIdle?.invoke(event.sessionId, sessionTitle(target, event.sessionId))
+                }
             }
             is OpenCodeEvent.MessageUpdated -> {
                 mutableState.update { current ->

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -547,16 +547,12 @@ fun AndCodeApp(
         remember(activityState.sessions, chatState.sessionId, activityState.activeSessionIds) {
             val parentId = chatState.sessionId ?: return@remember emptyList()
             activityState.sessions
-                .filter { it.parentId == parentId }
+                .filter { it.parentId == parentId && it.id in activityState.activeSessionIds }
                 .map { session ->
                     SubagentInfo(
                         id = session.id,
                         name = session.title.ifBlank { session.slug ?: session.id.take(8) },
-                        status =
-                            when {
-                                session.id in activityState.activeSessionIds -> "running"
-                                else -> "idle"
-                            },
+                        status = "running",
                         providerId = "",
                     )
                 }

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
@@ -269,6 +269,59 @@ class RuntimeActivityRepositoryTest {
             assertEquals(listOf("q-1"), asked.map { it.id })
         }
 
+    @Test
+    fun `session idle raises the completion callback for top-level sessions`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            target.sessions = listOf(OpenCodeSession(id = "ses_1", title = "Main"))
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val completed = mutableListOf<String>()
+            RuntimeActivityRepository(
+                registry = registry,
+                scope = TestScope(dispatcher),
+                onSessionIdle = { sessionId, _ -> completed += sessionId },
+            )
+            advanceUntilIdle()
+
+            target.eventFlow.emit(OpenCodeEvent.SessionIdle("ses_1"))
+            advanceUntilIdle()
+
+            assertEquals(listOf("ses_1"), completed)
+        }
+
+    @Test
+    fun `session idle suppresses the completion callback for subagent sessions`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            target.sessions =
+                listOf(OpenCodeSession(id = "child_1", parentId = "ses_1", title = "Explore"))
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val completed = mutableListOf<String>()
+            RuntimeActivityRepository(
+                registry = registry,
+                scope = TestScope(dispatcher),
+                onSessionIdle = { sessionId, _ -> completed += sessionId },
+            )
+            advanceUntilIdle()
+
+            target.eventFlow.emit(OpenCodeEvent.SessionIdle("child_1"))
+            advanceUntilIdle()
+
+            assertTrue(completed.isEmpty())
+        }
+
     private class FakeUnreadStore(
         override var unreadSessionIds: Set<String>,
     ) : UnreadSessionStore
@@ -303,7 +356,9 @@ class RuntimeActivityRepositoryTest {
 
         override suspend fun health(): OpenCodeHealth = error("unused")
 
-        override suspend fun listSessions(directory: String?): List<OpenCodeSession> = emptyList()
+        var sessions: List<OpenCodeSession> = emptyList()
+
+        override suspend fun listSessions(directory: String?): List<OpenCodeSession> = sessions
 
         override suspend fun createSession(
             title: String?,


### PR DESCRIPTION
## What
- The subagent track above the composer listed every child session, so a finished subagent kept its pill pinned there permanently. It now shows only running children, so the track empties and disappears once the last subagent goes idle (same behaviour as the todo bar).
- A subagent going idle no longer fires the session-complete notification. That ping is noise for work the user did not ask to be told about; top-level sessions still notify as before.

## Why
Reported from the chat screen: a completed `@explore subagent` pill stayed visible above the todo bar, and a completion notification arrived for it.

## Tests
- Added `session idle raises the completion callback for top-level sessions` and `session idle suppresses the completion callback for subagent sessions` to `RuntimeActivityRepositoryTest`.
- Note: I could not run `./gradlew testDebugUnitTest lintDebug assembleDebug` in my environment (no JDK / Android SDK installed); please rely on CI for the build/lint/test gate.