### PR TITLE
fix: return to provider settings after OAuth completes and use atomic restart

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsViewModel.kt
@@ -89,6 +89,7 @@ class SettingsViewModel(
             clientId = com.yugahashimoto.andcode.BuildConfig.GITHUB_CLIENT_ID,
         )
     var onLocalRuntimeRestartNeeded: (() -> Unit)? = null
+    var onProviderAuthCompleted: (() -> Unit)? = null
 
     private data class CoreState(
         val runtime: RuntimeCatalogState,
@@ -411,7 +412,7 @@ class SettingsViewModel(
         val dialog = oauthState.value.dialog ?: return
         val methodIndex = dialog.methodIndex ?: return
         if (dialog.authorization?.method != "code" || code.isBlank()) return
-        val target = registry.selected.value ?: return
+        val target = providerTarget() ?: return
         if (providerAuthJob?.isActive == true) return
         providerAuthJob =
             viewModelScope.launch {
@@ -489,8 +490,11 @@ class SettingsViewModel(
             )
         }
         settingsTick.update { it + 1 }
-        if (notice == ProviderAuthNotice.CONNECTED && registry.selected.value?.kind == BackendKind.LOCAL) {
-            onLocalRuntimeRestartNeeded?.invoke()
+        if (notice == ProviderAuthNotice.CONNECTED) {
+            onProviderAuthCompleted?.invoke()
+            if (providerTarget()?.kind == BackendKind.LOCAL) {
+                onLocalRuntimeRestartNeeded?.invoke()
+            }
         }
         catalog.refreshProvidersOnly()
         catalog.refresh()

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
@@ -200,6 +200,8 @@ class WorkspaceViewModel(
 
     fun stopLocalRuntime() = localRuntimeController.stop()
 
+    fun restartLocalRuntime() = localRuntimeController.restart()
+
     fun reinstallLocalRuntime() = localRuntimeController.reinstall()
 
     fun installClaudeCode() = claudeCode?.install() ?: Unit

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
@@ -32,6 +32,7 @@ internal enum class LocalRuntimeServiceCommand {
     Rollback,
     Delete,
     Stop,
+    Restart,
     Restore,
     Ignore,
 }
@@ -45,6 +46,7 @@ internal fun localRuntimeServiceCommand(action: String?): LocalRuntimeServiceCom
         LocalRuntimeService.ACTION_ROLLBACK -> LocalRuntimeServiceCommand.Rollback
         LocalRuntimeService.ACTION_DELETE -> LocalRuntimeServiceCommand.Delete
         LocalRuntimeService.ACTION_STOP -> LocalRuntimeServiceCommand.Stop
+        LocalRuntimeService.ACTION_RESTART -> LocalRuntimeServiceCommand.Restart
         null -> LocalRuntimeServiceCommand.Restore
         else -> LocalRuntimeServiceCommand.Ignore
     }
@@ -126,6 +128,13 @@ class LocalRuntimeService : Service() {
                     manager.stop()
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     stopSelf()
+                }
+            }
+            LocalRuntimeServiceCommand.Restart -> {
+                autoRestartEnabled = true
+                launchOperation {
+                    manager.stop()
+                    manager.start()
                 }
             }
             LocalRuntimeServiceCommand.Restore -> {
@@ -272,6 +281,7 @@ class LocalRuntimeService : Service() {
         const val ACTION_INSTALL_AND_START = "com.yugahashimoto.andcode.local.INSTALL_AND_START"
         const val ACTION_START = "com.yugahashimoto.andcode.local.START"
         const val ACTION_STOP = "com.yugahashimoto.andcode.local.STOP"
+        const val ACTION_RESTART = "com.yugahashimoto.andcode.local.RESTART"
         const val ACTION_REINSTALL = "com.yugahashimoto.andcode.local.REINSTALL"
         const val ACTION_UPDATE = "com.yugahashimoto.andcode.local.UPDATE"
         const val ACTION_ROLLBACK = "com.yugahashimoto.andcode.local.ROLLBACK"
@@ -304,6 +314,8 @@ class LocalRuntimeServiceController(private val context: Context) {
     fun start() = LocalRuntimeService.send(context, LocalRuntimeService.ACTION_START)
 
     fun stop() = LocalRuntimeService.send(context, LocalRuntimeService.ACTION_STOP)
+
+    fun restart() = LocalRuntimeService.send(context, LocalRuntimeService.ACTION_RESTART)
 
     fun reinstall() = LocalRuntimeService.send(context, LocalRuntimeService.ACTION_REINSTALL)
 

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -90,6 +90,7 @@ import com.yugahashimoto.andcode.ui.navigation.ROUTE_CHAT
 import com.yugahashimoto.andcode.ui.navigation.ROUTE_ONBOARDING
 import com.yugahashimoto.andcode.ui.navigation.ROUTE_REMOTE_CONNECTION
 import com.yugahashimoto.andcode.ui.navigation.ROUTE_SCHEDULE
+import com.yugahashimoto.andcode.ui.navigation.ROUTE_SETTINGS_PROVIDERS
 import com.yugahashimoto.andcode.ui.navigation.SESSION_DETAIL_ROUTE
 import com.yugahashimoto.andcode.ui.navigation.settingsNavGraph
 import com.yugahashimoto.andcode.ui.navigation.workspaceNavGraph
@@ -100,7 +101,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -248,12 +248,13 @@ fun AndCodeApp(
 
     val speechManager = remember { SpeechRecognizerManager(context.applicationContext) }
     val voiceScope = rememberCoroutineScope()
-    settingsViewModel.onLocalRuntimeRestartNeeded = {
-        voiceScope.launch {
-            workspaceViewModel.stopLocalRuntime()
-            delay(2000)
-            workspaceViewModel.startLocalRuntime()
+    settingsViewModel.onProviderAuthCompleted = {
+        navController.navigate(ROUTE_SETTINGS_PROVIDERS) {
+            launchSingleTop = true
         }
+    }
+    settingsViewModel.onLocalRuntimeRestartNeeded = {
+        workspaceViewModel.restartLocalRuntime()
     }
     var voiceJob by remember { mutableStateOf<Job?>(null) }
     var startVoiceAfterPermission by remember { mutableStateOf(false) }

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeServiceCommandTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeServiceCommandTest.kt
@@ -35,6 +35,10 @@ class LocalRuntimeServiceCommandTest {
             LocalRuntimeServiceCommand.Stop,
             localRuntimeServiceCommand(LocalRuntimeService.ACTION_STOP),
         )
+        assertEquals(
+            LocalRuntimeServiceCommand.Restart,
+            localRuntimeServiceCommand(LocalRuntimeService.ACTION_RESTART),
+        )
         assertEquals(LocalRuntimeServiceCommand.Restore, localRuntimeServiceCommand(null))
     }
 


### PR DESCRIPTION
## Summary

OAuth完了後にチャット画面へ戻ってしまったりOpenCodeが停止したように見える問題を修正します。

### 変更内容

- OAuth 成功時は必ずプロバイダ設定画面へ遷移し「Provider connected.」を表示 ( コールバック追加)
- `completeProviderOAuth` が `registry.selected` ではなく `providerTarget()` を使うよう修正（認証コード完了処理が常に認証情報を所有するランタイムを対象にする）
- 別々の stop → delay → start を単一の `Restart` サービスコマンドに置換し、watchdog/サービスライフサイクルと競合しないアトミックな再起動に
- `LocalRuntimeServiceCommand.Restart` / `restart()` メソッド追加 + テスト追加