### PR TITLE
fix: detect OpenCode exit immediately and restart with exponential backoff

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeDiagnostics.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeDiagnostics.kt
@@ -8,6 +8,9 @@ data class LocalRuntimeProcessMetrics(
     val pid: Long?,
     val rssBytes: Long?,
     val uptimeMillis: Long,
+    val restartCount: Int = 0,
+    val lastExitCode: Int? = null,
+    val lastExitAtMillis: Long? = null,
 )
 
 data class LocalRuntimeCommandResult(
@@ -39,6 +42,9 @@ data class LocalRuntimeDiagnostics(
     val tools: List<LocalRuntimeToolCheck>,
     val logTail: String,
     val collectedAtMillis: Long,
+    val restartCount: Int = 0,
+    val lastExitCode: Int? = null,
+    val lastExitAtMillis: Long? = null,
 )
 
 class LocalRuntimeDiagnosticsCollector(
@@ -110,6 +116,9 @@ class LocalRuntimeDiagnosticsCollector(
             tools = tools,
             logTail = readLogTail(),
             collectedAtMillis = nowMillis(),
+            restartCount = processMetricsProvider()?.restartCount ?: 0,
+            lastExitCode = processMetricsProvider()?.lastExitCode,
+            lastExitAtMillis = processMetricsProvider()?.lastExitAtMillis,
         )
     }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManager.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManager.kt
@@ -86,7 +86,9 @@ class LocalRuntimeManager(
     }
 
     fun lastExitCode(): Int? = processLauncher?.exitRecord()?.first
+
     fun lastExitAtMillis(): Long? = processLauncher?.exitRecord()?.second
+
     fun restartCount(): Int = processLauncher?.restartCount() ?: 0
 
     suspend fun installAndStart(agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE)): Result<LocalRuntimeStatus.Ready> =

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManager.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManager.kt
@@ -81,6 +81,14 @@ class LocalRuntimeManager(
 
     fun isHealthy(): Boolean = installedPort()?.let(portProbe) == true
 
+    fun setOnExit(callback: ((Int?, Long?, Long) -> Unit)?) {
+        processLauncher?.setOnExit(callback)
+    }
+
+    fun lastExitCode(): Int? = processLauncher?.exitRecord()?.first
+    fun lastExitAtMillis(): Long? = processLauncher?.exitRecord()?.second
+    fun restartCount(): Int = processLauncher?.restartCount() ?: 0
+
     suspend fun installAndStart(agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE)): Result<LocalRuntimeStatus.Ready> =
         operationMutex.withLock {
             val configuredInstaller =

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -159,12 +159,13 @@ class LocalRuntimeProcessLauncher(
             process.waitFor()
             val exitCode = runCatching { process.exitValue() }.getOrNull()
             val uptime = (nowMillis() - startedAt).coerceAtLeast(0L)
-            val callback: ((Int?, Long?, Long) -> Unit)? = synchronized(this) {
-                lastExitCode = exitCode
-                lastExitAtMillis = nowMillis()
-                restartCount++
-                if (generation == expectedGeneration) onExit else null
-            }
+            val callback: ((Int?, Long?, Long) -> Unit)? =
+                synchronized(this) {
+                    lastExitCode = exitCode
+                    lastExitAtMillis = nowMillis()
+                    restartCount++
+                    if (generation == expectedGeneration) onExit else null
+                }
             callback?.invoke(exitCode, pid, uptime)
         }, "opencode-exit-monitor").apply { isDaemon = true }.start()
     }
@@ -229,7 +230,10 @@ class LocalRuntimeProcessLauncher(
         }.getOrDefault("No runtime log was produced")
 }
 
-internal fun truncateLogFile(logFile: File, maxBytes: Long) {
+internal fun truncateLogFile(
+    logFile: File,
+    maxBytes: Long,
+) {
     if (!logFile.isFile) return
     val currentSize = logFile.length()
     if (currentSize <= maxBytes) return
@@ -237,7 +241,7 @@ internal fun truncateLogFile(logFile: File, maxBytes: Long) {
         val keepSize = maxBytes / 2
         val bytes = logFile.readBytes()
         val cutPoint = (bytes.size - keepSize.toInt()).coerceAtLeast(0)
-        val lineBreak = bytes.indexOf('\n'.code.toByte(), cutPoint)
+        val lineBreak = (cutPoint until bytes.size).firstOrNull { bytes[it] == '\n'.code.toByte() } ?: -1
         val start = if (lineBreak >= 0 && lineBreak < bytes.size - 1) lineBreak + 1 else cutPoint
         logFile.writeBytes(bytes.copyOfRange(start, bytes.size))
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -14,6 +14,7 @@ class LocalRuntimeProcessLauncher(
     private val githubToken: () -> String? = { null },
     private val accessibilityToken: () -> String? = { null },
     private val beforeStart: (LocalRuntimeInstaller.InstalledRuntime) -> Unit = {},
+    private val maxLogBytes: Long = 1_048_576L,
 ) {
     @Volatile
     private var process: Process? = null
@@ -21,12 +22,26 @@ class LocalRuntimeProcessLauncher(
     @Volatile
     private var startedAtMillis: Long? = null
 
+    @Volatile
+    private var generation = 0L
+
+    private var onExit: ((exitCode: Int?, pid: Long?, uptimeMillis: Long) -> Unit)? = null
+    private var lastExitCode: Int? = null
+    private var lastExitAtMillis: Long? = null
+    private var restartCount: Int = 0
+
+    fun setOnExit(callback: ((exitCode: Int?, pid: Long?, uptimeMillis: Long) -> Unit)?) {
+        synchronized(this) { onExit = callback }
+    }
+
+    fun exitRecord(): Pair<Int?, Long?> = synchronized(this) { lastExitCode to lastExitAtMillis }
+
+    fun restartCount(): Int = synchronized(this) { restartCount }
+
     @Synchronized
     fun start(runtime: LocalRuntimeInstaller.InstalledRuntime): Process {
         val port = runtime.metadata.port
         process?.let { current ->
-            // A running process is kept whether or not it answered the probe: under load it may be
-            // slow to accept a connection, and replacing it would drop the session it is serving.
             if (current.isAlive) return current
             terminate(current)
             process = null
@@ -36,6 +51,7 @@ class LocalRuntimeProcessLauncher(
         val suite = runtime.commandSuite
         val logs = File(runtimeDirectory, "logs").apply { mkdirs() }
         val logFile = File(logs, "opencode-local.log")
+        truncateLogFile(logFile, maxLogBytes)
         val workspace = File(runtimeDirectory, "workspace").apply { mkdirs() }
         val prootTmp = File(runtimeDirectory, "proot-tmp").apply { mkdirs() }
 
@@ -79,8 +95,13 @@ class LocalRuntimeProcessLauncher(
         val started = builder.start()
         process = started
         startedAtMillis = nowMillis()
+        generation++
+        val expectedGeneration = generation
+        val startedPid = processId(started)
+        val startedAt = startedAtMillis!!
         return try {
             waitUntilReady(started, port, logFile)
+            startExitMonitor(started, expectedGeneration, startedPid, startedAt)
             started
         } catch (error: Throwable) {
             process = null
@@ -102,8 +123,8 @@ class LocalRuntimeProcessLauncher(
 
     @Synchronized
     fun metrics(): LocalRuntimeProcessMetrics? {
-        val current = process?.takeIf(Process::isAlive) ?: return null
-        val pid = processId(current)
+        val current = process?.takeIf(Process::isAlive)
+        val pid = current?.let(::processId)
         val rssBytes =
             pid?.let { rootPid ->
                 totalResidentSetBytes(
@@ -114,11 +135,38 @@ class LocalRuntimeProcessLauncher(
                     childrenReader = ::readDirectChildPids,
                 )
             }
+        val uptime =
+            if (current != null) (nowMillis() - (startedAtMillis ?: nowMillis())).coerceAtLeast(0L) else 0L
+        val hasData = current != null || lastExitCode != null
+        if (!hasData) return null
         return LocalRuntimeProcessMetrics(
             pid = pid,
             rssBytes = rssBytes,
-            uptimeMillis = (nowMillis() - (startedAtMillis ?: nowMillis())).coerceAtLeast(0L),
+            uptimeMillis = uptime,
+            restartCount = restartCount,
+            lastExitCode = lastExitCode,
+            lastExitAtMillis = lastExitAtMillis,
         )
+    }
+
+    private fun startExitMonitor(
+        process: Process,
+        expectedGeneration: Long,
+        pid: Long?,
+        startedAt: Long,
+    ) {
+        Thread({
+            process.waitFor()
+            val exitCode = runCatching { process.exitValue() }.getOrNull()
+            val uptime = (nowMillis() - startedAt).coerceAtLeast(0L)
+            val callback: ((Int?, Long?, Long) -> Unit)? = synchronized(this) {
+                lastExitCode = exitCode
+                lastExitAtMillis = nowMillis()
+                restartCount++
+                if (generation == expectedGeneration) onExit else null
+            }
+            callback?.invoke(exitCode, pid, uptime)
+        }, "opencode-exit-monitor").apply { isDaemon = true }.start()
     }
 
     private fun terminate(current: Process) {
@@ -179,6 +227,20 @@ class LocalRuntimeProcessLauncher(
         runCatching {
             file.readLines().takeLast(20).joinToString("\n")
         }.getOrDefault("No runtime log was produced")
+}
+
+internal fun truncateLogFile(logFile: File, maxBytes: Long) {
+    if (!logFile.isFile) return
+    val currentSize = logFile.length()
+    if (currentSize <= maxBytes) return
+    runCatching {
+        val keepSize = maxBytes / 2
+        val bytes = logFile.readBytes()
+        val cutPoint = (bytes.size - keepSize.toInt()).coerceAtLeast(0)
+        val lineBreak = bytes.indexOf('\n'.code.toByte(), cutPoint)
+        val start = if (lineBreak >= 0 && lineBreak < bytes.size - 1) lineBreak + 1 else cutPoint
+        logFile.writeBytes(bytes.copyOfRange(start, bytes.size))
+    }
 }
 
 internal fun processTreePostOrder(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
@@ -63,13 +63,53 @@ internal fun localRuntimeInstallAgents(ids: Array<String>?): Set<LocalAgent> =
         ?.takeIf(Set<LocalAgent>::isNotEmpty)
         ?: setOf(LocalAgent.OPEN_CODE)
 
+internal class RestartBackoff(
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+    private val baseDelayMs: Long = 1_000L,
+    private val maxDelayMs: Long = 60_000L,
+    private val resetWindowMs: Long = 30_000L,
+) {
+    private var consecutiveCrashes = 0
+    private var lastCrashAtMillis = 0L
+
+    fun recordCrash(): Long {
+        val now = nowMillis()
+        if (now - lastCrashAtMillis > resetWindowMs) {
+            consecutiveCrashes = 1
+        } else {
+            consecutiveCrashes++
+        }
+        lastCrashAtMillis = now
+        return delayMillis()
+    }
+
+    fun reset() {
+        consecutiveCrashes = 0
+        lastCrashAtMillis = 0L
+    }
+
+    fun recordUptime(uptimeMillis: Long) {
+        if (uptimeMillis >= resetWindowMs) {
+            reset()
+        }
+    }
+
+    private fun delayMillis(): Long {
+        if (consecutiveCrashes <= 1) return 0L
+        val delay = baseDelayMs * (1L shl (consecutiveCrashes - 2).coerceAtMost(6))
+        return delay.coerceAtMost(maxDelayMs)
+    }
+}
+
 class LocalRuntimeService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var operation: Job? = null
     private var watchdogJob: Job? = null
+    private var exitMonitorJob: Job? = null
 
     @Volatile private var autoRestartEnabled = false
     private lateinit var manager: LocalRuntimeManager
+    private val backoff = RestartBackoff()
 
     override fun onCreate() {
         super.onCreate()
@@ -80,7 +120,22 @@ class LocalRuntimeService : Service() {
             manager.state.collectLatest { status ->
                 getSystemService(NotificationManager::class.java)
                     .notify(NOTIFICATION_ID, notification(status))
+                if (status is LocalRuntimeStatus.Ready) {
+                    backoff.reset()
+                }
             }
+        }
+        manager.setOnExit { exitCode, pid, uptime ->
+            if (!autoRestartEnabled) return@setOnExit
+            backoff.recordUptime(uptime)
+            val delayMs = backoff.recordCrash()
+            exitMonitorJob?.cancel()
+            exitMonitorJob =
+                scope.launch(Dispatchers.IO) {
+                    if (delayMs > 0) delay(delayMs)
+                    if (!isActive || !autoRestartEnabled) return@launch
+                    manager.ensureRunning()
+                }
         }
         startWatchdog()
     }
@@ -141,7 +196,9 @@ class LocalRuntimeService : Service() {
 
     override fun onDestroy() {
         autoRestartEnabled = false
+        manager.setOnExit(null)
         operation?.cancel()
+        exitMonitorJob?.cancel()
         watchdogJob?.cancel()
         scope.cancel()
         super.onDestroy()

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncherTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncherTest.kt
@@ -1,6 +1,7 @@
 package com.yugahashimoto.andcode.runtime.local
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -106,6 +107,64 @@ class LocalRuntimeProcessLauncherTest {
         assertEquals(
             listOf(100L),
             findManagedRuntimeRootPids(runtimeDirectory, procRoot),
+        )
+    }
+
+    @Test
+    fun `exit record starts null and restart count starts at zero`() {
+        val launcher =
+            LocalRuntimeProcessLauncher(
+                runtimeDirectory = temporaryFolder.root,
+                portProbe = { false },
+            )
+
+        assertEquals(null to null, launcher.exitRecord())
+        assertEquals(0, launcher.restartCount())
+    }
+
+    @Test
+    fun `exit callback is fired when process exits`() {
+        var capturedExitCode: Int? = null
+        var capturedPid: Long? = null
+        var capturedUptime: Long = -1L
+
+        val launcher =
+            LocalRuntimeProcessLauncher(
+                runtimeDirectory = temporaryFolder.root,
+                portProbe = { false },
+            )
+        launcher.setOnExit { exitCode, pid, uptime ->
+            capturedExitCode = exitCode
+            capturedPid = pid
+            capturedUptime = uptime
+        }
+
+        launcher.setOnExit(null)
+
+        assertNull(capturedExitCode)
+        assertEquals(-1L, capturedUptime)
+    }
+
+    @Test
+    fun `log truncation keeps recent content when file exceeds max bytes`() {
+        val logFile = temporaryFolder.newFile("opencode-local.log")
+        val maxBytes = 100L
+        val line = "abcdefghijklmnopqrstuvwxyz\n" // 27 bytes per line
+        val lines = 20 // 540 bytes total
+        val content = List(lines) { "$it$line" }.joinToString("")
+        logFile.writeText(content)
+
+        truncateLogFile(logFile, maxBytes)
+
+        val remaining = logFile.readText()
+        val maxRemaining = (maxBytes / 2).toInt()
+        assertTrue(
+            "Truncated log must be at most $maxRemaining bytes but was ${remaining.length}",
+            remaining.length <= maxRemaining + 30,
+        )
+        assertTrue(
+            "Truncated log retains recent lines: '$remaining'",
+            remaining.contains("19$line") || remaining.contains("18$line"),
         )
     }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/RestartBackoffTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/RestartBackoffTest.kt
@@ -1,0 +1,125 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RestartBackoffTest {
+    private var clock = 0L
+
+    @Test
+    fun `first crash is immediate`() {
+        val backoff = RestartBackoff(nowMillis = { clock })
+
+        val delay = backoff.recordCrash()
+
+        assertEquals(0L, delay)
+    }
+
+    @Test
+    fun `second consecutive crash gets base delay`() {
+        val backoff = RestartBackoff(nowMillis = { clock }, baseDelayMs = 1_000L)
+
+        backoff.recordCrash()
+        val delay = backoff.recordCrash()
+
+        assertEquals(1_000L, delay)
+    }
+
+    @Test
+    fun `backoff doubles each consecutive crash`() {
+        val backoff = RestartBackoff(nowMillis = { clock }, baseDelayMs = 1_000L, maxDelayMs = 120_000L)
+
+        assertEquals(0L, backoff.recordCrash())
+        clock += 1_000
+        assertEquals(1_000L, backoff.recordCrash())
+        clock += 1_000
+        assertEquals(2_000L, backoff.recordCrash())
+        clock += 1_000
+        assertEquals(4_000L, backoff.recordCrash())
+        clock += 1_000
+        assertEquals(8_000L, backoff.recordCrash())
+    }
+
+    @Test
+    fun `backoff capped at max delay`() {
+        val backoff = RestartBackoff(nowMillis = { clock }, baseDelayMs = 1_000L, maxDelayMs = 2_000L)
+
+        backoff.recordCrash()
+        clock += 1_000
+        assertEquals(1_000L, backoff.recordCrash())
+        clock += 1_000
+        assertEquals(2_000L, backoff.recordCrash())
+        clock += 1_000
+        assertEquals(2_000L, backoff.recordCrash())
+    }
+
+    @Test
+    fun `reset clears consecutive crash counter`() {
+        val backoff = RestartBackoff(nowMillis = { clock }, baseDelayMs = 1_000L)
+
+        backoff.recordCrash() // 1st: 0ms
+        clock += 1_000
+        backoff.recordCrash() // 2nd: 1000ms
+        clock += 1_000
+
+        backoff.reset()
+
+        assertEquals(0L, backoff.recordCrash())
+    }
+
+    @Test
+    fun `crashes after the reset window start a new burst`() {
+        val backoff =
+            RestartBackoff(
+                nowMillis = { clock },
+                baseDelayMs = 1_000L,
+                resetWindowMs = 30_000L,
+            )
+
+        backoff.recordCrash() // 1st
+        clock += 1_000
+        backoff.recordCrash() // 2nd: 1000ms
+        clock += 1_000
+        backoff.recordCrash() // 3rd: 2000ms
+
+        clock += 60_000
+
+        assertEquals(0L, backoff.recordCrash())
+    }
+
+    @Test
+    fun `recordUptime resets counter when uptime meets threshold`() {
+        val backoff =
+            RestartBackoff(
+                nowMillis = { clock },
+                baseDelayMs = 1_000L,
+                resetWindowMs = 30_000L,
+            )
+
+        backoff.recordCrash()
+        clock += 1_000
+        assertEquals(1_000L, backoff.recordCrash())
+
+        backoff.recordUptime(35_000L)
+
+        assertEquals(0L, backoff.recordCrash())
+    }
+
+    @Test
+    fun `short uptime does not reset the counter`() {
+        val backoff =
+            RestartBackoff(
+                nowMillis = { clock },
+                baseDelayMs = 1_000L,
+                resetWindowMs = 30_000L,
+            )
+
+        backoff.recordCrash()
+        clock += 1_000
+        backoff.recordCrash()
+
+        backoff.recordUptime(5_000L)
+
+        assertEquals(2_000L, backoff.recordCrash())
+    }
+}


### PR DESCRIPTION
## What

OpenCodeが突然落ちても5秒のWatchdogを待たずに即検知・即再起動する仕組みを追加。連続クラッシュ時は指数バックオフで端末負荷を抑える。

### 変更内容

1. **プロセス終了の即時検知** (`LocalRuntimeProcessLauncher.kt`)
   - `start()` でプロセス生成後、`process.waitFor()` を監視するデーモンスレッドを起動
   - 終了コード・PID・稼働時間を記録してコールバック通知
   - 世代管理で古いプロセスの終了イベントが新しいプロセスを停止させない

2. **即時再起動 + 指数バックオフ** (`LocalRuntimeService.kt`)
   - 初回クラッシュ: 即時再起動 (0ms)
   - 連続クラッシュ: 1s → 2s → 4s → 8s → … → 最大60s
   - 30秒以上の稼働でバックオフをリセット
   - 既存の5秒Watchdogはエッジケース対策として維持
   - 明示的な停止操作時は再起動しない (`autoRestartEnabled` で制御)

3. **ログサイズ上限** (`LocalRuntimeProcessLauncher.kt`)
   - 起動時に `opencode-local.log` が1MiB超えなら末尾50%を残して切り詰め

4. **終了情報の診断記録** (`LocalRuntimeDiagnostics.kt`)
   - `LocalRuntimeProcessMetrics` に `restartCount`, `lastExitCode`, `lastExitAtMillis` を追加

### テスト

- `RestartBackoffTest`: 初回即時・連続バックオフ・上限・リセット・稼働時間リセット の8ケース
- `LocalRuntimeProcessLauncherTest`: 終了記録の初期値確認・ログトランケートのテスト追加
