### PR TITLE
fix: preserve chat activity when switching agents

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
@@ -81,8 +81,12 @@ class RuntimeActivityRepository(
     init {
         scope.launch {
             registry.selected.collectLatest selected@{ target ->
-                mutableState.value =
-                    RuntimeActivityState(completedSessionIds = mutableState.value.completedSessionIds)
+                // A runtime switch does not cancel work already submitted to the previous target.
+                // Keep its active sessions visible until that target reports completion; clearing
+                // them here made an in-flight chat look idle/completed in the drawer.
+                mutableState.update { current ->
+                    current.copy(permissions = emptyList(), streamError = null)
+                }
                 if (target == null) return@selected
 
                 // The stream follows the selected runtime, not its connection state.

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -597,7 +597,6 @@ fun AndCodeApp(
                             if (agent.runtimeId != selectedRuntime?.id) {
                                 app.runtimeRegistry.select(agent.runtimeId)
                                 pendingSession = null
-                                chatViewModel.newSession()
                             }
                             navController.navigate(ROUTE_CHAT) { launchSingleTop = true }
                         },

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
@@ -175,6 +175,32 @@ class RuntimeActivityRepositoryTest {
         }
 
     @Test
+    fun `switching runtimes keeps an in-flight session active`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val current = FakeTarget(id = "opencode", requireConnected = false)
+            val next = FakeTarget(id = "claude", requireConnected = false)
+            current.state.value = RuntimeState.Connected("1.0")
+            next.state.value = RuntimeState.Connected("1.0")
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = current.id),
+                    localTarget = current,
+                    additionalTargets = listOf(next),
+                    remoteFactory = { error("unused") },
+                )
+            val repository = RuntimeActivityRepository(registry, TestScope(dispatcher))
+            advanceUntilIdle()
+
+            repository.markSessionRunning("session-in-flight")
+            registry.select(next.id)
+            runCurrent()
+
+            assertEquals(setOf("session-in-flight"), repository.state.value.activeSessionIds)
+            assertTrue(repository.state.value.completedSessionIds.isEmpty())
+        }
+
+    @Test
     fun `unread markers are restored from the store on startup`() =
         runTest {
             val dispatcher = StandardTestDispatcher(testScheduler)
@@ -337,9 +363,9 @@ class RuntimeActivityRepositoryTest {
     }
 
     private class FakeTarget(
+        override val id: String = "local-android",
         private val requireConnected: Boolean = true,
     ) : RuntimeTarget {
-        override val id: String = "local-android"
         override val displayName: String = "このAndroid端末"
         override val kind: BackendKind = BackendKind.LOCAL
         override val type: RuntimeType = RuntimeType.LOCAL

--- a/runtime_tools/termux_assets.lock.json
+++ b/runtime_tools/termux_assets.lock.json
@@ -7,10 +7,10 @@
             "libandroid-shmem",
             "libtalloc"
           ],
-          "filename": "pool/main/p/proot/proot_5.1.107.88_aarch64.deb",
+          "filename": "pool/main/p/proot/proot_5.1.107.89_aarch64.deb",
           "name": "proot",
-          "sha256": "f83bbf9029540f3f7c4ff1fa5624621f7d0a477fc910f7c8cca7daffb84f17ef",
-          "version": "5.1.107.88"
+          "sha256": "ec9fe38c50cfd49dd31fe360ffbcc3124a945dc1ea16293a8a769303dd724f46",
+          "version": "5.1.107.89"
         },
         {
           "depends": [],
@@ -36,10 +36,10 @@
             "libandroid-shmem",
             "libtalloc"
           ],
-          "filename": "pool/main/p/proot/proot_5.1.107.88_x86_64.deb",
+          "filename": "pool/main/p/proot/proot_5.1.107.89_x86_64.deb",
           "name": "proot",
-          "sha256": "ae0ee42e1ba20b5543442ca5e473722307a1f444eeecce7d7eabc472dfcc304a",
-          "version": "5.1.107.88"
+          "sha256": "0d76da0515f38dfb2217f647b0d79fcd61b38f80e25cbf2d39237697b02dd016",
+          "version": "5.1.107.89"
         },
         {
           "depends": [],


### PR DESCRIPTION
## Summary
- keep in-flight session activity visible when changing runtimes
- do not mark the previous chat complete while switching agents
- add a regression test for runtime switching during an active session

## Verification
- `./gradlew detekt spotlessCheck`
- Android unit tests could not run locally because the Android SDK is unavailable; CI runs `:app:testDebugUnitTest` and `:app:assembleDebug`.