### PR TITLE
fix: keep wake word toggle on while assistant setup completes

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -287,18 +287,21 @@ fun AndCodeApp(
                 startOrStopVoiceInput()
             } else if (granted && startWakeWordAfterPermission) {
                 startWakeWordAfterPermission = false
-                val started =
-                    com.yugahashimoto.andcode.feature.wakeword.WakeWordService.start(
-                        context,
-                        preferences.wakeWordModel,
-                    )
-                settingsViewModel.setWakeWordEnabled(started)
-                if (!started) {
-                    android.widget.Toast.makeText(
-                        context,
-                        R.string.wake_word_start_failed,
-                        android.widget.Toast.LENGTH_SHORT,
-                    ).show()
+                settingsViewModel.setWakeWordEnabled(true)
+                if (assistantActive) {
+                    val started =
+                        com.yugahashimoto.andcode.feature.wakeword.WakeWordService.start(
+                            context,
+                            preferences.wakeWordModel,
+                        )
+                    if (!started) {
+                        settingsViewModel.setWakeWordEnabled(false)
+                        android.widget.Toast.makeText(
+                            context,
+                            R.string.wake_word_start_failed,
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                    }
                 }
             } else if (!granted) {
                 startVoiceAfterPermission = false
@@ -378,13 +381,7 @@ fun AndCodeApp(
                     model = preferences.wakeWordModel,
                 )
             if (!started) settingsViewModel.setWakeWordEnabled(false)
-        } else if (preferences.wakeWordEnabled && !assistantActive) {
-            settingsViewModel.setWakeWordEnabled(false)
-            com.yugahashimoto.andcode.feature.wakeword.WakeWordService.stop(context)
-        } else if (preferences.wakeWordEnabled && !hasMicrophonePermission()) {
-            settingsViewModel.setWakeWordEnabled(false)
-            com.yugahashimoto.andcode.feature.wakeword.WakeWordService.stop(context)
-        } else if (!preferences.wakeWordEnabled) {
+        } else {
             com.yugahashimoto.andcode.feature.wakeword.WakeWordService.stop(context)
         }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -132,26 +132,29 @@ fun NavGraphBuilder.settingsNavGraph(
             onContinuousChange = settingsViewModel::setContinuousConversation,
             onWakeWordChange = { enabled ->
                 if (enabled) {
-                    if (!assistantActive()) {
-                        android.widget.Toast.makeText(
-                            context,
-                            com.yugahashimoto.andcode.R.string.wake_word_requires_assistant,
-                            android.widget.Toast.LENGTH_LONG,
-                        ).show()
-                        onOpenAssistantSettings()
-                    } else if (hasMicrophonePermission()) {
-                        val started =
-                            com.yugahashimoto.andcode.feature.wakeword.WakeWordService.start(
-                                context,
-                                settingsState.wakeWordModel,
-                            )
-                        settingsViewModel.setWakeWordEnabled(started)
-                        if (!started) {
+                    if (hasMicrophonePermission()) {
+                        settingsViewModel.setWakeWordEnabled(true)
+                        if (!assistantActive()) {
                             android.widget.Toast.makeText(
                                 context,
-                                com.yugahashimoto.andcode.R.string.wake_word_start_failed,
-                                android.widget.Toast.LENGTH_SHORT,
+                                com.yugahashimoto.andcode.R.string.wake_word_requires_assistant,
+                                android.widget.Toast.LENGTH_LONG,
                             ).show()
+                            onOpenAssistantSettings()
+                        } else {
+                            val started =
+                                com.yugahashimoto.andcode.feature.wakeword.WakeWordService.start(
+                                    context,
+                                    settingsState.wakeWordModel,
+                                )
+                            if (!started) {
+                                settingsViewModel.setWakeWordEnabled(false)
+                                android.widget.Toast.makeText(
+                                    context,
+                                    com.yugahashimoto.andcode.R.string.wake_word_start_failed,
+                                    android.widget.Toast.LENGTH_SHORT,
+                                ).show()
+                            }
                         }
                     } else {
                         onRequestWakeWordPermission()


### PR DESCRIPTION
## Problem
Tapping the wake word switch on the voice settings screen did not turn it on. When AndCode was not yet set as the system digital assistant, the change handler never persisted the enabled flag (it only saved the result of `WakeWordService.start`, which returns false without an active assistant), and the sync `LaunchedEffect` immediately reset the preference to false whenever the assistant was inactive or the mic permission was missing. The toggle snapped back to off every time.

## Fix
- Persist `wakeWordEnabled = true` as soon as the user flips the switch (and right after the microphone permission is granted), instead of gating it on a successful service start.
- When the assistant is not yet active, show the existing guidance toast and open the system assistant settings, but leave the preference on.
- Simplify the sync effect so it starts the service once the assistant becomes active (and the mic is granted), and otherwise just stops any running service without clearing the preference. The service therefore comes up automatically after the user finishes assistant setup.

## Verification
- `./gradlew detekt spotlessCheck` passes locally.
- Compile/lint/unit tests run in CI (no Android SDK in this environment).