### PR TITLE
fix: render image parts returned by the assistant

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -17,6 +17,10 @@ sealed interface TimelineEntry {
         override val id: String get() = "body:${part.id}"
     }
 
+    data class Image(val messageId: String, val part: ChatPart.Image) : TimelineEntry {
+        override val id: String get() = "image:${part.id}"
+    }
+
     data class Activity(override val id: String, val parts: List<ChatPart>) : TimelineEntry
 
     data class Todo(override val id: String, val todos: List<TodoItem>) : TimelineEntry
@@ -113,6 +117,10 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
                     flush()
                     entries += TimelineEntry.Todo("todo:${part.id}", part.todos)
                 }
+                part is ChatPart.Image -> {
+                    flush()
+                    entries += TimelineEntry.Image(message.id, part)
+                }
                 part !is ChatPart.Text -> pending += part
                 part.text.isNotBlank() -> {
                     flush()
@@ -162,6 +170,7 @@ fun summarizeActivity(parts: List<ChatPart>): ActivitySummary {
                 }
             }
             is ChatPart.Text -> Unit
+            is ChatPart.Image -> Unit
         }
     }
     return ActivitySummary(counts = counts, reasoningCount = reasoning, running = running, hasError = hasError)

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
@@ -179,6 +179,7 @@ fun AssistantActivitySheet(
                     is ChatPart.Tool -> ToolCard(part)
                     is ChatPart.Patch -> PatchCard(part)
                     is ChatPart.Text -> Unit
+                    is ChatPart.Image -> Unit
                 }
             }
             item { Column(modifier = Modifier.padding(bottom = 32.dp)) {} }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -359,6 +359,7 @@ fun ChatHomeScreen(
                                     when (entry) {
                                         is TimelineEntry.UserMessage -> entry.message.id to entry.message.text
                                         is TimelineEntry.Body -> entry.messageId to entry.part.text
+                                        is TimelineEntry.Image -> null
                                         is TimelineEntry.Activity -> null
                                         is TimelineEntry.Todo -> null
                                         is TimelineEntry.Footer -> null

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Image as ImageIcon
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -441,7 +442,7 @@ private fun ImagePartView(part: ChatPart.Image) {
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 modifier = Modifier.padding(10.dp),
             ) {
-                Icon(androidx.compose.material.icons.filled.Image, contentDescription = null)
+                Icon(Icons.Default.ImageIcon, contentDescription = null)
                 Text(
                     text = part.filename ?: part.mime,
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -136,6 +136,7 @@ fun TimelineEntryRow(
     when (entry) {
         is TimelineEntry.UserMessage -> MessageBubble(entry.message)
         is TimelineEntry.Body -> MarkdownText(entry.part.text)
+        is TimelineEntry.Image -> ImagePartView(entry.part)
         is TimelineEntry.Activity ->
             AssistantActivityRow(
                 parts = entry.parts,
@@ -390,6 +391,63 @@ private fun MarkdownText(
                     HorizontalDivider(
                         color = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f),
                     )
+            }
+        }
+    }
+}
+
+internal data class DataImage(val mime: String, val base64: String)
+
+internal fun parseDataImageUri(url: String): DataImage? {
+    if (!url.startsWith("data:")) return null
+    val payload = url.removePrefix("data:")
+    val comma = payload.indexOf(',')
+    if (comma < 0) return null
+    val meta = payload.substring(0, comma)
+    if (!meta.endsWith(";base64")) return null
+    val mime = meta.removeSuffix(";base64")
+    if (!mime.startsWith("image/")) return null
+    return DataImage(mime, payload.substring(comma + 1))
+}
+
+private fun decodeDataImage(url: String): android.graphics.Bitmap? {
+    val data = parseDataImageUri(url) ?: return null
+    return runCatching {
+        val bytes = android.util.Base64.decode(data.base64, android.util.Base64.DEFAULT)
+        android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    }.getOrNull()
+}
+
+@Composable
+private fun ImagePartView(part: ChatPart.Image) {
+    val bitmap = remember(part.url) { decodeDataImage(part.url) }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = part.filename ?: stringResource(R.string.cd_image_preview),
+            modifier =
+                Modifier
+                    .widthIn(max = 320.dp)
+                    .heightIn(max = 320.dp),
+            contentScale = ContentScale.Fit,
+        )
+    } else {
+        Surface(
+            shape = RoundedCornerShape(10.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.padding(10.dp),
+            ) {
+                Icon(androidx.compose.material.icons.filled.Image, contentDescription = null)
+                Text(
+                    text = part.filename ?: part.mime,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Description
-import androidx.compose.material.icons.filled.Image as ImageIcon
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -62,6 +61,7 @@ import com.yugahashimoto.andcode.ui.theme.AndCodeWarning
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import androidx.compose.material.icons.filled.Image as ImageIcon
 
 private val TOOL_CALL_ECHO_REGEX =
     Regex("""Called the [A-Za-z][A-Za-z ]*? tool with the following input: \{(?:[^{}]|\{[^{}]*\})*\}""")

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -67,6 +67,13 @@ sealed interface ChatPart {
     ) : ChatPart
 
     data class Patch(override val id: String, val files: List<String>) : ChatPart
+
+    data class Image(
+        override val id: String,
+        val mime: String,
+        val url: String,
+        val filename: String? = null,
+    ) : ChatPart
 }
 
 data class ChatMessage(
@@ -116,12 +123,21 @@ private const val TRANSIENT_RECOVERY_DELAY_MS = 5000L
 private const val HEALTH_CHECK_ATTEMPTS = 15
 private const val HEALTH_CHECK_DELAY_MS = 2000L
 
-private fun OpenCodePart.toChatPart(): ChatPart? {
+internal fun OpenCodePart.toChatPart(): ChatPart? {
     val partId = id ?: return null
     val stateMap = state.orEmpty()
     return when (type) {
         "text" -> ChatPart.Text(partId, text.orEmpty())
         "reasoning" -> ChatPart.Reasoning(partId, text.orEmpty())
+        "file" -> {
+            val partMime = mime.orEmpty()
+            val partUrl = url.orEmpty()
+            if (partMime.startsWith("image/") && partUrl.isNotBlank()) {
+                ChatPart.Image(id = partId, mime = partMime, url = partUrl, filename = filename)
+            } else {
+                null
+            }
+        }
         "tool" -> {
             val inputText = formatToolInput(stateMap["input"])
             val rawOutput = stateMap["output"]?.jsonPrimitiveOrNull()

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
@@ -271,4 +271,26 @@ class AssistantActivityGroupTest {
         assertEquals(1, entries.size)
         assertTrue(entries.single() is TimelineEntry.Activity)
     }
+
+    @Test
+    fun `image parts get their own entry and split the surrounding run`() {
+        val entries =
+            groupConversationTimeline(
+                listOf(
+                    assistant(
+                        "m1",
+                        tool("t1", "read"),
+                        ChatPart.Image("i1", "image/png", "data:image/png;base64,abc"),
+                        ChatPart.Text("x1", "see above"),
+                    ),
+                ),
+            )
+
+        assertEquals(3, entries.size)
+        assertEquals(listOf("t1"), (entries[0] as TimelineEntry.Activity).parts.map { it.id })
+        val image = entries[1] as TimelineEntry.Image
+        assertEquals("i1", image.part.id)
+        assertEquals("image:i1", image.id)
+        assertEquals("see above", (entries[2] as TimelineEntry.Body).part.text)
+    }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
@@ -1,0 +1,83 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import com.yugahashimoto.andcode.core.api.OpenCodePart
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChatImagePartTest {
+    @Test
+    fun `parses a base64 png data uri`() {
+        val parsed = parseDataImageUri("data:image/png;base64,iVBORw0KGgo=")
+
+        assertEquals("image/png", parsed?.mime)
+        assertEquals("iVBORw0KGgo=", parsed?.base64)
+    }
+
+    @Test
+    fun `parses a base64 jpeg data uri`() {
+        val parsed = parseDataImageUri("data:image/jpeg;base64,/9j/4AAQ")
+
+        assertEquals("image/jpeg", parsed?.mime)
+        assertEquals("/9j/4AAQ", parsed?.base64)
+    }
+
+    @Test
+    fun `rejects a non image mime`() {
+        assertNull(parseDataImageUri("data:text/plain;base64,abc"))
+    }
+
+    @Test
+    fun `rejects a non data uri`() {
+        assertNull(parseDataImageUri("https://example.com/shot.png"))
+    }
+
+    @Test
+    fun `rejects a data uri without base64 suffix`() {
+        assertNull(parseDataImageUri("data:image/png,abc"))
+    }
+
+    @Test
+    fun `rejects a data uri without a comma`() {
+        assertNull(parseDataImageUri("data:image/png;base64"))
+    }
+
+    @Test
+    fun `maps an image file part to a chat image part`() {
+        val part =
+            OpenCodePart(
+                id = "p1",
+                type = "file",
+                mime = "image/png",
+                url = "data:image/png;base64,abc",
+                filename = "shot.png",
+            )
+
+        val chat = part.toChatPart() as ChatPart.Image
+        assertEquals("p1", chat.id)
+        assertEquals("image/png", chat.mime)
+        assertEquals("data:image/png;base64,abc", chat.url)
+        assertEquals("shot.png", chat.filename)
+    }
+
+    @Test
+    fun `drops an image file part that has no url`() {
+        val part = OpenCodePart(id = "p2", type = "file", mime = "image/png", url = null)
+
+        assertNull(part.toChatPart())
+    }
+
+    @Test
+    fun `drops a non image file part`() {
+        val part =
+            OpenCodePart(
+                id = "p3",
+                type = "file",
+                mime = "text/plain",
+                url = "data:text/plain;base64,abc",
+                filename = "log.txt",
+            )
+
+        assertNull(part.toChatPart())
+    }
+}


### PR DESCRIPTION
## What
Images that OpenCode returns as `file` parts with an `image/*` mime (e.g. a screenshot the `read` tool pulled in) were silently dropped: `toChatPart()` mapped only text/reasoning/tool/patch and returned `null` for everything else, and the timeline grouper would have folded any surviving image into the collapsed tool run anyway.

## Changes
- New `ChatPart.Image` + `TimelineEntry.Image`; image file parts now map through `toChatPart()` and get their own timeline row in narrative order.
- `ImagePartView` decodes base64 `data:` URIs inline; non-data URLs fall back to a filename/mime placeholder.
- Exhaustiveness updated in `ChatHomeScreen`, `AssistantActivityRow`, and `summarizeActivity`.
- Unit tests for the part mapping, the data-URI parser, and the timeline grouping.

## Note
This sandbox has no Android SDK and the JVM cannot start (grsecurity/PaX), so I could not run `./gradlew` locally. Verification is deferred to CI; please merge only once the checks are green.