### PR TITLE
feat: persist ADB wireless-debugging link and surface local runtime settings

### DIFF
--- a/app/src/main/assets/scripts/android-app.sh
+++ b/app/src/main/assets/scripts/android-app.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Manage Android apps on the connected device via ADB (install, launch, stop, logs).
+# Usage:
+#   android-app install <apk_path>          Install or replace an APK
+#   android-app launch <package>            Launch an app's launcher activity
+#   android-app stop <package>              Force-stop an app
+#   android-app clear <package>             Clear an app's data
+#   android-app logcat <package> [lines]    Show recent logcat for a package (default 200)
+#   android-app list                        List installed third-party packages
+# Requires: adb connected (see ADB setup in Local runtime settings)
+set -e
+adb get-state >/dev/null 2>&1 || {
+    echo "android: adb has no connected device. Enable wireless debugging and connect via AndCode -> Settings -> Local runtime -> ADB." >&2
+    exit 1
+}
+CMD="${1:-}"
+[ -n "$CMD" ] && shift
+case "$CMD" in
+    install)
+        [ -n "${1:-}" ] || { echo "usage: android-app install <apk_path>" >&2; exit 2; }
+        adb install -r "$1"
+        ;;
+    launch)
+        [ -n "${1:-}" ] || { echo "usage: android-app launch <package>" >&2; exit 2; }
+        adb shell monkey -p "$1" -c android.intent.category.LAUNCHER 1
+        ;;
+    stop)
+        [ -n "${1:-}" ] || { echo "usage: android-app stop <package>" >&2; exit 2; }
+        adb shell am force-stop "$1"
+        ;;
+    clear)
+        [ -n "${1:-}" ] || { echo "usage: android-app clear <package>" >&2; exit 2; }
+        adb shell pm clear "$1"
+        ;;
+    logcat)
+        PKG="${1:-}"
+        LINES="${2:-200}"
+        [ -n "$PKG" ] || { echo "usage: android-app logcat <package> [lines]" >&2; exit 2; }
+        PID="$(adb shell pidof "$PKG" 2>/dev/null | tr -d '\r' || true)"
+        if [ -n "$PID" ]; then
+            adb logcat -d -t "$LINES" --pid="$PID"
+        else
+            adb logcat -d -t "$LINES" | grep -F "$PKG" || true
+        fi
+        ;;
+    list)
+        adb shell pm list packages -3 | sed 's/^package://'
+        ;;
+    *)
+        echo "usage: android-app {install|launch|stop|clear|logcat|list} ..." >&2
+        exit 2
+        ;;
+esac

--- a/app/src/main/assets/scripts/android-instrument.sh
+++ b/app/src/main/assets/scripts/android-instrument.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Run an Android instrumentation test package on the connected device via ADB.
+# Usage: android-instrument <test_package>/<runner_class> [extra am instrument args...]
+# Example: android-instrument com.example.app.test/androidx.test.runner.AndroidJUnitRunner
+# The test APK must already be installed (build it externally, then `android-app install`).
+# Requires: adb connected (see ADB setup in Local runtime settings)
+set -e
+adb get-state >/dev/null 2>&1 || {
+    echo "android: adb has no connected device. Enable wireless debugging and connect via AndCode -> Settings -> Local runtime -> ADB." >&2
+    exit 1
+}
+COMPONENT="${1:-}"
+if [ -z "$COMPONENT" ]; then
+    echo "usage: android-instrument <test_package>/<runner_class> [extra am instrument args...]" >&2
+    exit 2
+fi
+shift
+exec adb shell am instrument -w -r "$COMPONENT" "$@"

--- a/app/src/main/assets/scripts/android-screenshot.sh
+++ b/app/src/main/assets/scripts/android-screenshot.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 # Capture a screenshot from the connected Android device via ADB.
 # Usage: android-screenshot [output_path]
-# Requires: adb connected (see ADB setup in Local OpenCode settings)
+# Requires: adb connected (see ADB setup in Local runtime settings)
 set -e
+adb get-state >/dev/null 2>&1 || {
+    echo "android: adb has no connected device. Enable wireless debugging and connect via AndCode -> Settings -> Local runtime -> ADB." >&2
+    exit 1
+}
 OUTPUT="${1:-/tmp/screenshot.png}"
 adb shell screencap -p /sdcard/_oc_screenshot.png
 adb pull /sdcard/_oc_screenshot.png "$OUTPUT" >/dev/null 2>&1

--- a/app/src/main/assets/scripts/android-vision.sh
+++ b/app/src/main/assets/scripts/android-vision.sh
@@ -2,8 +2,12 @@
 # Capture an annotated screenshot with numbered UI element labels.
 # Outputs a JSON array of elements and saves an annotated PNG.
 # Usage: android-vision [output_dir]
-# Requires: adb connected, python3, py3-pillow
+# Requires: adb connected (see ADB setup in Local runtime settings), python3, py3-pillow
 set -e
+adb get-state >/dev/null 2>&1 || {
+    echo "android: adb has no connected device. Enable wireless debugging and connect via AndCode -> Settings -> Local runtime -> ADB." >&2
+    exit 1
+}
 OUTDIR="${1:-/tmp/android-vision}"
 mkdir -p "$OUTDIR"
 SHOT="$OUTDIR/screenshot.png"

--- a/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
@@ -1,6 +1,8 @@
 package com.yugahashimoto.andcode
 
 import android.app.Application
+import android.content.Context
+import android.net.nsd.NsdManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -17,6 +19,7 @@ import com.yugahashimoto.andcode.feature.support.GitHubStarCoordinator
 import com.yugahashimoto.andcode.feature.support.GitHubStarService
 import com.yugahashimoto.andcode.runtime.RuntimeRegistry
 import com.yugahashimoto.andcode.runtime.local.AdbConnectionManager
+import com.yugahashimoto.andcode.runtime.local.AdbShellRunner
 import com.yugahashimoto.andcode.runtime.local.AndroidClaudeMessages
 import com.yugahashimoto.andcode.runtime.local.AndroidLocalRuntimeMessages
 import com.yugahashimoto.andcode.runtime.local.AntigravityController
@@ -239,7 +242,16 @@ class AndCodeApplication : Application() {
                 commandExecutor = commandRunner::run,
             )
         localRuntimeController = LocalRuntimeServiceController(this)
-        adbConnectionManager = AdbConnectionManager(this, commandRunner)
+        adbConnectionManager =
+            AdbConnectionManager(
+                shellRunner = AdbShellRunner { command, timeoutSeconds -> commandRunner.runShell(command, timeoutSeconds) },
+                connectionStore = settings,
+                nsdManagerProvider = { getSystemService(Context.NSD_SERVICE) as? NsdManager },
+            )
+        // Keep the persisted wireless-debugging link alive for the whole process lifetime. The
+        // loop is a cheap no-op until the user has connected once, and it self-heals the link
+        // whenever the adb server inside the Linux runtime is restarted.
+        adbConnectionManager.startAutoReconnect(applicationScope)
         runtimeRegistry =
             RuntimeRegistry(
                 store = settings,

--- a/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
@@ -6,8 +6,9 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.yugahashimoto.andcode.data.repository.UnreadSessionStore
 import com.yugahashimoto.andcode.runtime.RuntimeConnectionStore
+import com.yugahashimoto.andcode.runtime.local.AdbConnectionStore
 
-class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, UnreadSessionStore {
+class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, UnreadSessionStore, AdbConnectionStore {
     private val masterKey =
         MasterKey.Builder(context)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -53,6 +54,24 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
         }
 
     fun selectedConnection(): ConnectionProfile? = selectedConnectionId?.let { selected -> connections().firstOrNull { it.id == selected } }
+
+    @Synchronized
+    override fun saveConnectedPort(port: Int) {
+        preferences.edit().putInt(KEY_ADB_CONNECTION_PORT, port).apply()
+    }
+
+    @Synchronized
+    override fun loadConnectedPort(): Int? =
+        if (preferences.contains(KEY_ADB_CONNECTION_PORT)) {
+            preferences.getInt(KEY_ADB_CONNECTION_PORT, 0)
+        } else {
+            null
+        }
+
+    @Synchronized
+    override fun clearConnectedPort() {
+        preferences.edit().remove(KEY_ADB_CONNECTION_PORT).apply()
+    }
 
     var ttsEnabled: Boolean
         get() = preferences.getBoolean(KEY_TTS_ENABLED, true)
@@ -332,6 +351,7 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
         private const val PREFS_NAME = "opencode_android_secure_settings"
         private const val KEY_CONNECTIONS = "connections"
         private const val KEY_SELECTED_CONNECTION = "selected_connection"
+        private const val KEY_ADB_CONNECTION_PORT = "adb_connection_port"
         private const val KEY_TTS_ENABLED = "tts_enabled"
         private const val KEY_TTS_PROVIDER = "tts_provider"
         private const val KEY_TTS_ANDROID_ENGINE = "tts_android_engine"

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Router
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.HorizontalDivider
@@ -235,6 +236,12 @@ fun SettingsScreenV2(
                     icon = Icons.Default.Build,
                     title = stringResource(R.string.server_info_settings_row),
                     onClick = onOpenServerInfo,
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Default.Terminal,
+                    title = stringResource(R.string.settings_local_runtime_row),
+                    onClick = onOpenLocalRuntime,
                 )
                 SettingsDivider()
                 SettingsRow(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AdbConnectionManager.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AdbConnectionManager.kt
@@ -1,15 +1,27 @@
 package com.yugahashimoto.andcode.runtime.local
 
-import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+/** Narrow seam over [LocalRuntimeCommandRunner] so the manager stays unit-testable without proot. */
+fun interface AdbShellRunner {
+    fun runShell(
+        command: String,
+        timeoutSeconds: Long,
+    ): LocalRuntimeCommandResult
+}
 
 sealed interface AdbConnectionState {
     data object Disconnected : AdbConnectionState
@@ -33,11 +45,9 @@ sealed interface AdbConnectionState {
 }
 
 class AdbConnectionManager(
-    private val context: Context,
-    private val commandRunner: LocalRuntimeCommandRunner,
-    private val nsdManagerProvider: () -> NsdManager? = {
-        context.getSystemService(Context.NSD_SERVICE) as? NsdManager
-    },
+    private val shellRunner: AdbShellRunner,
+    private val connectionStore: AdbConnectionStore = InMemoryAdbConnectionStore(),
+    private val nsdManagerProvider: () -> NsdManager?,
 ) {
     private val mutableState = MutableStateFlow<AdbConnectionState>(AdbConnectionState.Disconnected)
     val state: StateFlow<AdbConnectionState> = mutableState.asStateFlow()
@@ -47,6 +57,9 @@ class AdbConnectionManager(
 
     @Volatile
     private var discoveredPort: Int? = null
+
+    @Volatile
+    private var autoReconnectJob: Job? = null
 
     fun startDiscovery() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
@@ -129,7 +142,7 @@ class AdbConnectionManager(
         withContext(Dispatchers.IO) {
             mutableState.value = AdbConnectionState.Pairing(pairingPort)
             val result =
-                commandRunner.runShell(
+                shellRunner.runShell(
                     "echo '${pairingCode.replace("'", "'\\''")}' | adb pair localhost:$pairingPort",
                     timeoutSeconds = 30L,
                 )
@@ -144,11 +157,12 @@ class AdbConnectionManager(
     suspend fun connect(port: Int): Result<Unit> =
         withContext(Dispatchers.IO) {
             val result =
-                commandRunner.runShell(
+                shellRunner.runShell(
                     "adb connect localhost:$port",
-                    timeoutSeconds = 30L,
+                    timeoutSeconds = CONNECT_TIMEOUT_SECONDS,
                 )
-            if (result.exitCode == 0 && result.output.contains("connected", ignoreCase = true)) {
+            if (isConnectedOutput(result)) {
+                connectionStore.saveConnectedPort(port)
                 mutableState.value = AdbConnectionState.Connected(port)
                 Result.success(Unit)
             } else {
@@ -159,19 +173,23 @@ class AdbConnectionManager(
 
     suspend fun disconnect(): Result<Unit> =
         withContext(Dispatchers.IO) {
-            val result = commandRunner.runShell("adb disconnect", timeoutSeconds = 10L)
+            val result = shellRunner.runShell("adb disconnect", timeoutSeconds = 10L)
+            connectionStore.clearConnectedPort()
             mutableState.value = AdbConnectionState.Disconnected
             if (result.exitCode == 0) Result.success(Unit) else Result.failure(RuntimeException(result.output))
         }
 
     suspend fun checkConnection(): Boolean =
         withContext(Dispatchers.IO) {
-            val result = commandRunner.runShell("adb get-state", timeoutSeconds = 10L)
+            val result = shellRunner.runShell("adb get-state", timeoutSeconds = 10L)
             val connected = result.exitCode == 0 && result.output.trim() == "device"
             if (connected) {
                 mutableState.update { current ->
                     if (current !is AdbConnectionState.Connected) {
-                        val port = (current as? AdbConnectionState.Discovered)?.port ?: discoveredPort
+                        val port =
+                            (current as? AdbConnectionState.Discovered)?.port
+                                ?: discoveredPort
+                                ?: connectionStore.loadConnectedPort()
                         if (port != null) AdbConnectionState.Connected(port) else current
                     } else {
                         current
@@ -181,11 +199,74 @@ class AdbConnectionManager(
             connected
         }
 
+    /**
+     * Re-connects to the last persisted wireless-debugging port, if any. Called when the Linux
+     * runtime becomes ready: the adb server lives inside proot, so it is reborn with the runtime
+     * and any earlier `adb connect` is lost on every restart.
+     */
+    suspend fun restoreAndReconnect(): Boolean {
+        val port = connectionStore.loadConnectedPort() ?: return false
+        return reconnectQuietly(port)
+    }
+
+    /**
+     * Periodically verifies the persisted ADB link and restores it when it drops. The loop is a
+     * cheap no-op until a port has been saved, so devices that never set up wireless debugging pay
+     * only a preferences read per tick.
+     */
+    fun startAutoReconnect(
+        scope: CoroutineScope,
+        intervalMs: Long = DEFAULT_HEALTH_INTERVAL_MS,
+    ) {
+        stopAutoReconnect()
+        autoReconnectJob =
+            scope.launch {
+                while (isActive) {
+                    delay(intervalMs)
+                    ensureConnection()
+                }
+            }
+    }
+
+    fun stopAutoReconnect() {
+        autoReconnectJob?.cancel()
+        autoReconnectJob = null
+    }
+
+    private suspend fun ensureConnection() {
+        val port = connectionStore.loadConnectedPort() ?: return
+        if (checkConnection()) return
+        reconnectQuietly(port)
+    }
+
+    /** Reconnects without surfacing an [AdbConnectionState.Error], so background retries never flap the UI. */
+    private suspend fun reconnectQuietly(port: Int): Boolean =
+        withContext(Dispatchers.IO) {
+            val result =
+                shellRunner.runShell(
+                    "adb connect localhost:$port",
+                    timeoutSeconds = CONNECT_TIMEOUT_SECONDS,
+                )
+            if (isConnectedOutput(result)) {
+                connectionStore.saveConnectedPort(port)
+                mutableState.value = AdbConnectionState.Connected(port)
+                true
+            } else {
+                false
+            }
+        }
+
+    private fun isConnectedOutput(result: LocalRuntimeCommandResult): Boolean =
+        result.exitCode == 0 && result.output.contains("connected", ignoreCase = true)
+
     fun destroy() {
         stopDiscovery()
+        stopAutoReconnect()
     }
 
     companion object {
         private const val SERVICE_TYPE = "_adb-tls-connect._tcp"
+        private const val CONNECT_TIMEOUT_SECONDS = 30L
+        private const val DEFAULT_HEALTH_INTERVAL_MS = 30_000L
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AdbConnectionStore.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AdbConnectionStore.kt
@@ -1,0 +1,31 @@
+package com.yugahashimoto.andcode.runtime.local
+
+/**
+ * Remembers the wireless-debugging port the user last connected to, so the ADB link can be
+ * restored automatically after the app or the Linux runtime restarts. The pairing keys already
+ * survive restarts inside the rootfs (`/root/.android` is carried over on reinstall), so only the
+ * port has to be persisted — a saved port can be re-connected without pairing again.
+ */
+interface AdbConnectionStore {
+    fun saveConnectedPort(port: Int)
+
+    fun loadConnectedPort(): Int?
+
+    fun clearConnectedPort()
+}
+
+/** Volatile in-memory store used as a safe default and by unit tests. */
+class InMemoryAdbConnectionStore : AdbConnectionStore {
+    @Volatile
+    private var port: Int? = null
+
+    override fun saveConnectedPort(port: Int) {
+        this.port = port
+    }
+
+    override fun loadConnectedPort(): Int? = port
+
+    override fun clearConnectedPort() {
+        port = null
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
@@ -417,6 +417,8 @@ class LocalRuntimeInstaller(
         listOf(
             "android-vision.sh" to "android-vision",
             "android-screenshot.sh" to "android-screenshot",
+            "android-instrument.sh" to "android-instrument",
+            "android-app.sh" to "android-app",
         ).forEach {
                 (assetName, scriptName) ->
             val scriptFile = File(binDir, scriptName)

--- a/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartInitializer.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartInitializer.kt
@@ -5,6 +5,7 @@ import androidx.startup.Initializer
 import com.yugahashimoto.andcode.AndCodeApplication
 import com.yugahashimoto.andcode.hasUsableRuntimeSetup
 import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
+import com.yugahashimoto.andcode.runtime.local.AdbConnectionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -45,6 +46,13 @@ class RuntimeAutoStartInitializer : Initializer<RuntimeAutoStartInitializer.Resu
                     // while the local runtime is still coming up, and Ready is re-emitted on every
                     // watchdog tick — selecting on each one would pull them back to the phone.
                     app.runtimeRegistry.selectIfUnset(LOCAL_RUNTIME_ID)
+                    // The adb server is reborn with the Linux runtime, so restore the persisted
+                    // wireless-debugging link as soon as it is reachable. Guarded by the current
+                    // state because Ready re-emits on every watchdog tick and a redundant
+                    // `adb connect` would spawn a proot process each time.
+                    if (app.adbConnectionManager.state.value !is AdbConnectionState.Connected) {
+                        scope.launch { app.adbConnectionManager.restoreAndReconnect() }
+                    }
                     if (app.runtimeRegistry.selected.value?.id != LOCAL_RUNTIME_ID) return@collect
                     warmupJob?.cancel()
                     warmupJob =

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -191,16 +191,16 @@
     <string name="loading_changes">変更を取得しています</string>
     <string name="no_uncommitted_changes">未コミットの変更はありません</string>
 
-    <string name="local_runtime_screen_title">ローカルOpenCode</string>
+    <string name="local_runtime_screen_title">ローカルランタイム</string>
     <string name="refresh_diagnostics_description">診断と更新情報を再取得</string>
     <string name="operation_failed_title">操作に失敗しました</string>
     <string name="update_confirm_title">OpenCode %1$sへ更新しますか？</string>
-    <string name="update_confirm_body1">更新中はローカルOpenCodeを停止し、検証後に再起動します。</string>
+    <string name="update_confirm_body1">更新中はローカルランタイムを停止し、検証後に再起動します。</string>
     <string name="update_confirm_body2">失敗した場合は現在のOpenCode %1$sへ自動復旧します。</string>
     <string name="required_free_space">必要な空き容量: %1$s</string>
     <string name="update_confirm_button">更新する</string>
     <string name="rollback_confirm_title">OpenCode %1$sへ戻しますか？</string>
-    <string name="rollback_confirm_body">現在のローカルOpenCodeを停止し、保存されている直前バージョンへ切り替えて再起動します。起動できない場合は現在のバージョンへ復旧します。</string>
+    <string name="rollback_confirm_body">現在のローカルランタイムを停止し、保存されている直前バージョンへ切り替えて再起動します。起動できない場合は現在のバージョンへ復旧します。</string>
     <string name="rollback_button">ロールバック</string>
     <string name="delete_runtime_confirm_title">ローカルランタイムを削除しますか？</string>
     <string name="delete_runtime_confirm_body">導入済みのエージェント、Linux環境、キャッシュ、ログ、アプリ内のローカル作業フォルダが削除されます。PC接続設定は保持されます。</string>
@@ -341,15 +341,15 @@
     <string name="speech_error_start">開始エラー: %1$s</string>
 
     <string name="notification_runtime_not_installed">ローカルランタイムは未導入です</string>
-    <string name="notification_runtime_setting_up">ローカルOpenCodeをセットアップ中</string>
-    <string name="notification_runtime_starting">ローカルOpenCodeを起動中</string>
-    <string name="notification_runtime_updating">ローカルOpenCodeを更新中</string>
-    <string name="notification_runtime_stopped">ローカルOpenCodeは停止中</string>
-    <string name="notification_runtime_ready">ローカルOpenCodeが稼働中</string>
+    <string name="notification_runtime_setting_up">ローカルランタイムをセットアップ中</string>
+    <string name="notification_runtime_starting">ローカルランタイムを起動中</string>
+    <string name="notification_runtime_updating">ローカルランタイムを更新中</string>
+    <string name="notification_runtime_stopped">ローカルランタイムは停止中</string>
+    <string name="notification_runtime_ready">ローカルランタイムが稼働中</string>
     <string name="notification_runtime_ready_detail">OpenCode %1$s · 127.0.0.1:%2$d</string>
-    <string name="notification_runtime_broken">ローカルOpenCodeで問題が発生</string>
+    <string name="notification_runtime_broken">ローカルランタイムで問題が発生</string>
     <string name="notification_runtime_unsupported_device">この端末では利用できません</string>
-    <string name="notification_channel_local_runtime_description">Android端末内で実行するOpenCodeの状態</string>
+    <string name="notification_channel_local_runtime_description">Android端末内で実行するローカルランタイムの状態</string>
 
     <string name="install_step_preparing_command_env">Androidコマンド環境を準備しています</string>
     <string name="install_step_downloading_alpine">Alpine Linuxをダウンロードしています</string>
@@ -358,7 +358,7 @@
     <string name="install_step_extracting_opencode">OpenCodeを展開しています</string>
     <string name="install_step_installing_dev_tools">Gitと開発ツールを導入しています</string>
     <string name="install_step_activating_runtime">ランタイムを有効化しています</string>
-    <string name="install_step_done">ローカルOpenCodeを導入しました</string>
+    <string name="install_step_done">ローカルランタイムを導入しました</string>
 
     <!-- Redesign: drawer -->
     <string name="menu_description">メニュー</string>
@@ -768,8 +768,8 @@
     <string name="agent_antigravity_name">Antigravity</string>
     <string name="runtime_error_install_failed">ローカルランタイムの導入に失敗しました</string>
     <string name="runtime_error_reinstall_failed">ローカルランタイムの再導入に失敗しました</string>
-    <string name="runtime_error_start_failed">ローカルOpenCodeを起動できません</string>
-    <string name="runtime_error_stop_failed">ローカルOpenCodeを停止できません</string>
+    <string name="runtime_error_start_failed">ローカルランタイムを起動できません</string>
+    <string name="runtime_error_stop_failed">ローカルランタイムを停止できません</string>
     <string name="runtime_error_delete_failed">ローカルランタイムを削除できません</string>
     <string name="runtime_error_delete_incomplete">ローカルランタイムを完全に削除できませんでした</string>
     <string name="runtime_error_missing_files">ローカルランタイムのファイルが不足しています</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,16 +191,16 @@
     <string name="loading_changes">Loading changes</string>
     <string name="no_uncommitted_changes">No uncommitted changes</string>
 
-    <string name="local_runtime_screen_title">Local OpenCode</string>
+    <string name="local_runtime_screen_title">Local runtime</string>
     <string name="refresh_diagnostics_description">Refresh diagnostics and update info</string>
     <string name="operation_failed_title">Operation failed</string>
     <string name="update_confirm_title">Update to OpenCode %1$s?</string>
-    <string name="update_confirm_body1">Local OpenCode will stop during the update and restart after verification.</string>
+    <string name="update_confirm_body1">Local runtime will stop during the update and restart after verification.</string>
     <string name="update_confirm_body2">If it fails, it automatically reverts to the current OpenCode %1$s.</string>
     <string name="required_free_space">Free space needed: %1$s</string>
     <string name="update_confirm_button">Update</string>
     <string name="rollback_confirm_title">Revert to OpenCode %1$s?</string>
-    <string name="rollback_confirm_body">Local OpenCode will stop and switch to the saved previous version, then restart. If it can\'t start, it reverts to the current version.</string>
+    <string name="rollback_confirm_body">Local runtime will stop and switch to the saved previous version, then restart. If it can\'t start, it reverts to the current version.</string>
     <string name="rollback_button">Rollback</string>
     <string name="delete_runtime_confirm_title">Delete the local runtime?</string>
     <string name="delete_runtime_confirm_body">The installed agents, the Linux environment, cache, logs, and the in-app local workspace will be deleted. PC connection settings are kept.</string>
@@ -341,15 +341,15 @@
     <string name="speech_error_start">Start error: %1$s</string>
 
     <string name="notification_runtime_not_installed">Local runtime is not installed</string>
-    <string name="notification_runtime_setting_up">Setting up local OpenCode</string>
-    <string name="notification_runtime_starting">Starting local OpenCode</string>
-    <string name="notification_runtime_updating">Updating local OpenCode</string>
-    <string name="notification_runtime_stopped">Local OpenCode is stopped</string>
-    <string name="notification_runtime_ready">Local OpenCode is running</string>
+    <string name="notification_runtime_setting_up">Setting up local runtime</string>
+    <string name="notification_runtime_starting">Starting local runtime</string>
+    <string name="notification_runtime_updating">Updating local runtime</string>
+    <string name="notification_runtime_stopped">Local runtime is stopped</string>
+    <string name="notification_runtime_ready">Local runtime is running</string>
     <string name="notification_runtime_ready_detail">OpenCode %1$s · 127.0.0.1:%2$d</string>
-    <string name="notification_runtime_broken">Local OpenCode has a problem</string>
+    <string name="notification_runtime_broken">Local runtime has a problem</string>
     <string name="notification_runtime_unsupported_device">Not available on this device</string>
-    <string name="notification_channel_local_runtime_description">Status of OpenCode running on this Android device</string>
+    <string name="notification_channel_local_runtime_description">Status of the local runtime on this Android device</string>
 
     <string name="install_step_preparing_command_env">Preparing the Android command environment</string>
     <string name="install_step_downloading_alpine">Downloading Alpine Linux</string>
@@ -358,7 +358,7 @@
     <string name="install_step_extracting_opencode">Extracting OpenCode</string>
     <string name="install_step_installing_dev_tools">Installing Git and development tools</string>
     <string name="install_step_activating_runtime">Activating the runtime</string>
-    <string name="install_step_done">Local OpenCode installed</string>
+    <string name="install_step_done">Local runtime installed</string>
 
     <!-- Redesign: drawer -->
     <string name="menu_description">Menu</string>
@@ -768,8 +768,8 @@
     <string name="agent_antigravity_name">Antigravity</string>
     <string name="runtime_error_install_failed">Could not install the local runtime</string>
     <string name="runtime_error_reinstall_failed">Could not reinstall the local runtime</string>
-    <string name="runtime_error_start_failed">Could not start local OpenCode</string>
-    <string name="runtime_error_stop_failed">Could not stop local OpenCode</string>
+    <string name="runtime_error_start_failed">Could not start local runtime</string>
+    <string name="runtime_error_stop_failed">Could not stop local runtime</string>
     <string name="runtime_error_delete_failed">Could not delete the local runtime</string>
     <string name="runtime_error_delete_incomplete">The local runtime could not be fully deleted</string>
     <string name="runtime_error_missing_files">Local runtime files are missing</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AdbConnectionManagerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AdbConnectionManagerTest.kt
@@ -1,6 +1,16 @@
 package com.yugahashimoto.andcode.runtime.local
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -26,5 +36,143 @@ class AdbConnectionManagerTest {
         assertEquals(37123, (pairing as AdbConnectionState.Pairing).pairingPort)
         assertEquals(5555, (connected as AdbConnectionState.Connected).port)
         assertEquals("failed", (error as AdbConnectionState.Error).message)
+    }
+
+    @Test
+    fun `connect persists port and sets connected state`() =
+        runTest {
+            val store = InMemoryAdbConnectionStore()
+            val runner = FakeShellRunner()
+            val manager = AdbConnectionManager(runner, store, nsdManagerProvider = { null })
+
+            val result = manager.connect(5555)
+
+            assertTrue(result.isSuccess)
+            assertEquals(5555, store.loadConnectedPort())
+            assertEquals(AdbConnectionState.Connected(5555), manager.state.value)
+            assertTrue(runner.commands.any { it.contains("adb connect localhost:5555") })
+        }
+
+    @Test
+    fun `connect failure sets error and does not persist`() =
+        runTest {
+            val store = InMemoryAdbConnectionStore()
+            val runner = FakeShellRunner().apply { connectOk = false }
+            val manager = AdbConnectionManager(runner, store, nsdManagerProvider = { null })
+
+            val result = manager.connect(5555)
+
+            assertTrue(result.isFailure)
+            assertNull(store.loadConnectedPort())
+            assertTrue(manager.state.value is AdbConnectionState.Error)
+        }
+
+    @Test
+    fun `disconnect clears persisted port`() =
+        runTest {
+            val store = InMemoryAdbConnectionStore().apply { saveConnectedPort(5555) }
+            val runner = FakeShellRunner()
+            val manager = AdbConnectionManager(runner, store, nsdManagerProvider = { null })
+
+            manager.disconnect()
+
+            assertNull(store.loadConnectedPort())
+            assertEquals(AdbConnectionState.Disconnected, manager.state.value)
+        }
+
+    @Test
+    fun `restoreAndReconnect reconnects to persisted port`() =
+        runTest {
+            val store = InMemoryAdbConnectionStore().apply { saveConnectedPort(5555) }
+            val runner = FakeShellRunner()
+            val manager = AdbConnectionManager(runner, store, nsdManagerProvider = { null })
+
+            val restored = manager.restoreAndReconnect()
+
+            assertTrue(restored)
+            assertEquals(AdbConnectionState.Connected(5555), manager.state.value)
+        }
+
+    @Test
+    fun `restoreAndReconnect returns false when no port saved`() =
+        runTest {
+            val store = InMemoryAdbConnectionStore()
+            val runner = FakeShellRunner()
+            val manager = AdbConnectionManager(runner, store, nsdManagerProvider = { null })
+
+            val restored = manager.restoreAndReconnect()
+
+            assertFalse(restored)
+            assertEquals(AdbConnectionState.Disconnected, manager.state.value)
+        }
+
+    @Test
+    fun `checkConnection sets connected state from persisted port`() =
+        runTest {
+            val store = InMemoryAdbConnectionStore().apply { saveConnectedPort(5555) }
+            val runner = FakeShellRunner()
+            val manager = AdbConnectionManager(runner, store, nsdManagerProvider = { null })
+
+            val connected = manager.checkConnection()
+
+            assertTrue(connected)
+            assertEquals(AdbConnectionState.Connected(5555), manager.state.value)
+        }
+
+    @Test
+    fun `auto reconnect restores a dropped connection`() =
+        runBlocking {
+            val store = InMemoryAdbConnectionStore().apply { saveConnectedPort(5555) }
+            val runner =
+                FakeShellRunner().apply {
+                    deviceConnected = false
+                    connectOk = true
+                }
+            val manager = AdbConnectionManager(runner, store, nsdManagerProvider = { null })
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            try {
+                manager.startAutoReconnect(scope, intervalMs = 10)
+                withTimeout(3000) {
+                    while (manager.state.value !is AdbConnectionState.Connected) delay(5)
+                }
+                assertEquals(AdbConnectionState.Connected(5555), manager.state.value)
+                assertTrue(runner.commands.any { it.contains("adb connect localhost:5555") })
+            } finally {
+                scope.cancel()
+            }
+        }
+}
+
+private class FakeShellRunner : AdbShellRunner {
+    val commands = java.util.Collections.synchronizedList(mutableListOf<String>())
+
+    @Volatile
+    var deviceConnected: Boolean = true
+
+    @Volatile
+    var connectOk: Boolean = true
+
+    override fun runShell(
+        command: String,
+        timeoutSeconds: Long,
+    ): LocalRuntimeCommandResult {
+        commands.add(command)
+        return when {
+            command.contains("adb get-state") ->
+                if (deviceConnected) {
+                    LocalRuntimeCommandResult(0, "device")
+                } else {
+                    LocalRuntimeCommandResult(1, "unknown")
+                }
+            command.contains("adb connect") ->
+                if (connectOk) {
+                    LocalRuntimeCommandResult(0, "connected to localhost:5555")
+                } else {
+                    LocalRuntimeCommandResult(1, "failed to connect")
+                }
+            command.contains("adb disconnect") -> LocalRuntimeCommandResult(0, "disconnected")
+            command.contains("adb pair") -> LocalRuntimeCommandResult(0, "Successfully paired")
+            else -> LocalRuntimeCommandResult(0, "")
+        }
     }
 }

--- a/docs/LOCAL_RUNTIME.md
+++ b/docs/LOCAL_RUNTIME.md
@@ -167,6 +167,32 @@ OpenCodeがOAuthの `auto` 方式を返した場合、Androidはブラウザを�
 
 接続または切断が成功すると、プロバイダーとモデルのカタログを自動的に再取得する。
 
+## ADB連携（無線デバッグ）
+
+ランタイム内の `adb` から、この端末自身へ無線デバッグ接続できる。接続すると、ランタイム内のツールが端末の画面キャプチャ・UI自動操作・アプリインストール・Instrumentation Testを実行できる。ADB接続は特定のエージェントではなく、OpenCode・Claude Code・Antigravityが共有するランタイム全体の設定である。
+
+### セットアップ
+
+1. 端末の開発者オプションで「無線デバッグ」を有効にする。
+2. 設定 →「ローカルランタイム」→「Android Debug Bridge (ADB)」カードを開く。
+3. 「ペアリング」で、無線デバッグ画面のペアリングポートと6桁コードを入力する。
+4. 「接続」をタップする。
+
+### 再接続の自動化
+
+- 接続済みポートは暗号化設定へ永続化される。ペアリング鍵はrootfsの `/root/.android` に保存され、再インストール時も引き継がれるため、再ペアリングは不要である。
+- アプリ起動時とランタイムReady時に、永続化済みポートへ自動で `adb connect` を再実行する。adbサーバーはPRoot内でランタイムと共に再起動するため、再接続は毎回必要である。
+- 30秒ごとのヘルスチェックが接続断を検知し、永続化済みポートがあれば自動再接続する。ポート未設定の場合は何もしない。
+
+### ヘルパースクリプト
+
+ランタイムの `/usr/local/bin` に次が配置される（Alpine・Debian両rootfs）。
+
+- `android-screenshot` — 画面キャプチャ
+- `android-vision` — UI要素ラベル付きアノテーション画像とJSON
+- `android-app` — 他アプリの install / launch / stop / clear / logcat / list
+- `android-instrument` — `am instrument` によるInstrumentation Test実行
+
 ## Android上の制約
 
 Androidローカル実行はPCの完全な代替ではない。
@@ -184,7 +210,9 @@ Androidローカル実行はPCの完全な代替ではない。
 - Docker
 - Android Emulatorの内側から別のAndroid Emulatorを動かすこと
 - iOSビルド
-- 大規模なGradle・Flutterビルド
+- Gradle・Kotlin/Javaコンパイル・JVM単体テスト（規模を問わない）
 - 長時間の高負荷処理
+
+PRootはptraceでsyscallをエミュレートするため、JVMが初期化に要求する実行可能メモリページ（`mprotect(PROT_EXEC)`）を確保できない。このためランタイム内ではJVMを使う処理が一切動作しない。AndroidアプリのビルドとInstrumentation Testは、PC等でビルドしたAPKを `android-app install` で端末へ入れ、`android-instrument` で実行する。
 
 重い作業はPCリモート実行へ切り替える。


### PR DESCRIPTION
## 動機

ローカルランタイムは OpenCode / Claude Code / Antigravity が共有する Alpine/PRoot サンドボックスだが、ADB無線デバッグ接続は次の問題があった。

- 接続状態がメモリ上にしかなく、アプリやランタイムの再起動で毎回消失（adb server は proot 内でランタイムと共に再起動する）
- 設定UIが「Local OpenCode」としてエージェント配下に埋もれ、共有ランタイムの設定であることが分かりにくい

## 変更内容

### ADB接続の永続化＋自動再接続
- 接続済みポートを暗号化設定へ永続化（ペアリング鍵は rootfs `/root/.android` に保存済みで引き継がれるため再ペアリング不要）
- アプリ起動時・ランタイムReady時・30秒ヘルスチェックで自動 `adb connect` 再接続
- テスト容易性のため `AdbConnectionManager` から `Context` 依存を切り離し（`AdbShellRunner` seam）、単体テスト7件追加

### UI再配置
- トップレベル設定に「ローカルランタイム」行を追加（未結線だった `onOpenLocalRuntime` を結線）
- 画面名「Local OpenCode」→「Local runtime」/「ローカルランタイム」へ統一改名（通知・インストール等含む。OpenCode バージョン参照は維持）

### テストヘルパー・ドキュメント
- `android-instrument`（`am instrument` 実行）、`android-app`（install/launch/stop/clear/logcat/list）追加
- 全 adb スクリプトに未接続時の設定画面誘導ガード
- `docs/LOCAL_RUNTIME.md` に ADB連携セクションと JVM-in-proot 制約（`mprotect(PROT_EXEC)` 不可）を明文化

## 検証

- `./gradlew spotlessCheck` 通過（ktlintクリーン）
- 新規シェルヘルパーは `sh -n` 通過
- 単体テスト: `./gradlew :app:testDebugUnitTest --tests "*AdbConnectionManagerTest*""
- フルチェック: `./gradlew testDebugUnitTest lintDebug assembleDebug`