### PR TITLE
fix: add navigationBarsPadding to screens without Scaffold

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/McpScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/McpScreen.kt
@@ -109,7 +109,13 @@ fun McpScreen(
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = padding.calculateTopPadding() + 8.dp, bottom = 88.dp),
+                contentPadding =
+                    PaddingValues(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = padding.calculateTopPadding() + 8.dp,
+                        bottom = padding.calculateBottomPadding() + 88.dp,
+                    ),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 items(state.servers, key = { it.name }) { server ->

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -282,7 +283,7 @@ fun SettingsScreenV2(
         if (isTablet) {
             Row(modifier = Modifier.fillMaxSize()) {
                 LazyColumn(
-                    modifier = Modifier.width(320.dp),
+                    modifier = Modifier.width(320.dp).navigationBarsPadding(),
                     contentPadding = PaddingValues(start = 20.dp, end = 20.dp, top = 6.dp, bottom = 28.dp),
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                 ) {
@@ -295,7 +296,7 @@ fun SettingsScreenV2(
             }
         } else {
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize().navigationBarsPadding(),
                 contentPadding = PaddingValues(start = 20.dp, end = 20.dp, top = 6.dp, bottom = 28.dp),
                 verticalArrangement = Arrangement.spacedBy(20.dp),
             ) {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -107,7 +108,7 @@ fun VoiceSettingsScreen(
         )
 
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().navigationBarsPadding(),
             contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/TerminalScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/TerminalScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -57,6 +58,7 @@ fun TerminalScreen(
             Modifier
                 .fillMaxSize()
                 .background(TerminalBackground)
+                .navigationBarsPadding()
                 .imePadding(),
     ) {
         Row(

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceExplorerScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceExplorerScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -112,7 +113,7 @@ fun WorkspaceExplorerScreen(
             stringResource(R.string.tab_pr),
         )
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         if (workspaceDeck.size > 1) {
             WorkspaceDeckRow(workspaceDeck, state.workspace.name)
         }


### PR DESCRIPTION
設定画面などScaffoldを使わない画面でコンテンツがAndroidのナビゲーションバーの下に描画される問題を修正。

## Changes
- SettingsScreenV2: LazyColumnに navigationBarsPadding() 追加（タブレット/スマホ両方）
- VoiceSettingsScreen: LazyColumnに navigationBarsPadding() 追加
- TerminalScreen: 外側Columnに navigationBarsPadding() 追加
- WorkspaceExplorerScreen: 外側Columnに navigationBarsPadding() 追加
- McpScreen: bottom contentPaddingにScaffoldの calculateBottomPadding() を加算

Scaffold使用画面はScaffoldのinnerPaddingで既に対応済み。