### PR TITLE
fix: make chat URLs clickable and consistent

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
@@ -121,7 +122,10 @@ fun MessageBubble(message: ChatMessage) {
                         }
                     }
                     if (displayText.isNotBlank()) {
-                        Text(text = displayText)
+                        LinkedText(
+                            text = displayText,
+                            linkColor = MaterialTheme.colorScheme.onPrimary,
+                        )
                     }
                 }
             }
@@ -246,6 +250,52 @@ private fun InlineText(
             onTextLayout = { layoutResult = it },
         )
     }
+}
+
+@Composable
+private fun LinkedText(
+    text: String,
+    linkColor: Color,
+) {
+    val context = LocalContext.current
+    val style = LocalTextStyle.current
+    val inlines = remember(text) { MarkdownLite.parseInline(text) }
+    val annotated =
+        remember(inlines, linkColor) {
+            buildAnnotatedString {
+                inlines.forEach { inline ->
+                    if (inline is MarkdownInline.Link) {
+                        val start = length
+                        withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+                            append(inline.text)
+                        }
+                        addStringAnnotation("link", inline.url, start, length)
+                    } else {
+                        append(inline.text)
+                    }
+                }
+            }
+        }
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    Text(
+        text = annotated,
+        style = style,
+        modifier =
+            Modifier.pointerInput(annotated) {
+                detectTapGestures { offset ->
+                    layoutResult?.let { layout ->
+                        val position = layout.getOffsetForPosition(offset)
+                        annotated.getStringAnnotations("link", position, position)
+                            .firstOrNull()?.let { ann ->
+                                runCatching {
+                                    context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(ann.item)))
+                                }
+                            }
+                    }
+                }
+            },
+        onTextLayout = { layoutResult = it },
+    )
 }
 
 @Composable
@@ -460,15 +510,24 @@ private fun annotateFilePaths(
     source: AnnotatedString,
     linkColor: Color,
 ): AnnotatedString {
+    val excludeRanges =
+        source.getStringAnnotations("link", 0, source.text.length) +
+            source.getStringAnnotations("code", 0, source.text.length)
     return buildAnnotatedString {
         append(source)
         FILE_PATH_REGEX.findAll(source.text).forEach { match ->
-            addStyle(
-                SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
-                match.range.first,
-                match.range.last + 1,
-            )
-            addStringAnnotation("filepath", match.value, match.range.first, match.range.last + 1)
+            val overlapsProtected =
+                excludeRanges.any { ann ->
+                    match.range.first < ann.end && match.range.last + 1 > ann.start
+                }
+            if (!overlapsProtected) {
+                addStyle(
+                    SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
+                    match.range.first,
+                    match.range.last + 1,
+                )
+                addStringAnnotation("filepath", match.value, match.range.first, match.range.last + 1)
+            }
         }
     }
 }
@@ -488,10 +547,13 @@ private fun renderInline(
                     withStyle(
                         SpanStyle(textDecoration = TextDecoration.LineThrough),
                     ) { append(inline.text) }
-                is MarkdownInline.Code ->
+                is MarkdownInline.Code -> {
+                    val start = length
                     withStyle(
                         SpanStyle(fontFamily = FontFamily.Monospace, background = codeBackground),
                     ) { append(inline.text) }
+                    addStringAnnotation("code", inline.text, start, length)
+                }
                 is MarkdownInline.Link -> {
                     val start = length
                     withStyle(

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/MarkdownLite.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/MarkdownLite.kt
@@ -1,17 +1,19 @@
 package com.yugahashimoto.andcode.feature.chat
 
 sealed interface MarkdownInline {
-    data class Plain(val text: String) : MarkdownInline
+    val text: String
 
-    data class Bold(val text: String) : MarkdownInline
+    data class Plain(override val text: String) : MarkdownInline
 
-    data class Italic(val text: String) : MarkdownInline
+    data class Bold(override val text: String) : MarkdownInline
 
-    data class Strikethrough(val text: String) : MarkdownInline
+    data class Italic(override val text: String) : MarkdownInline
 
-    data class Code(val text: String) : MarkdownInline
+    data class Strikethrough(override val text: String) : MarkdownInline
 
-    data class Link(val text: String, val url: String) : MarkdownInline
+    data class Code(override val text: String) : MarkdownInline
+
+    data class Link(override val text: String, val url: String) : MarkdownInline
 }
 
 sealed interface MarkdownBlock {
@@ -140,7 +142,7 @@ object MarkdownLite {
             .split("|")
             .map { it.trim() }
 
-    private fun parseInline(text: String): List<MarkdownInline> {
+    internal fun parseInline(text: String): List<MarkdownInline> {
         val result = mutableListOf<MarkdownInline>()
         var lastIndex = 0
         for (match in inlineRegex.findAll(text)) {
@@ -161,7 +163,7 @@ object MarkdownLite {
                 linkText != null && linkUrl != null -> result += MarkdownInline.Link(linkText, linkUrl)
                 italic != null -> result += MarkdownInline.Italic(italic)
                 bareUrl != null -> {
-                    val url = bareUrl.trimEnd('.', ',', '!', '?', ':', ';', ')', ']', '}')
+                    val url = trimUrlTail(bareUrl)
                     result += MarkdownInline.Link(url, url)
                     if (url.length < bareUrl.length) {
                         result += MarkdownInline.Plain(bareUrl.substring(url.length))
@@ -177,5 +179,17 @@ object MarkdownLite {
             result += MarkdownInline.Plain(text)
         }
         return result
+    }
+
+    private fun trimUrlTail(raw: String): String {
+        var s = raw
+        while (s.isNotEmpty()) {
+            when {
+                s.last() in ".,!?;:]}" -> s = s.dropLast(1)
+                s.last() == ')' && s.count { it == '(' } < s.count { it == ')' } -> s = s.dropLast(1)
+                else -> break
+            }
+        }
+        return s
     }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/MarkdownLiteTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/MarkdownLiteTest.kt
@@ -122,4 +122,85 @@ class MarkdownLiteTest {
         assertTrue(blocks[3] is MarkdownBlock.CodeBlock)
         assertTrue(blocks[4] is MarkdownBlock.Paragraph)
     }
+
+    @Test
+    fun `bare url with balanced parentheses is preserved`() {
+        val paragraph =
+            MarkdownLite.parse("See https://en.wikipedia.org/wiki/Foo_(bar) for details")
+                .single() as MarkdownBlock.Paragraph
+        assertEquals(
+            listOf(
+                MarkdownInline.Plain("See "),
+                MarkdownInline.Link(
+                    "https://en.wikipedia.org/wiki/Foo_(bar)",
+                    "https://en.wikipedia.org/wiki/Foo_(bar)",
+                ),
+                MarkdownInline.Plain(" for details"),
+            ),
+            paragraph.inlines,
+        )
+    }
+
+    @Test
+    fun `bare url wrapped in parentheses trims closing paren`() {
+        val paragraph =
+            MarkdownLite.parse("(https://example.com)")
+                .single() as MarkdownBlock.Paragraph
+        assertEquals(
+            listOf(
+                MarkdownInline.Plain("("),
+                MarkdownInline.Link("https://example.com", "https://example.com"),
+                MarkdownInline.Plain(")"),
+            ),
+            paragraph.inlines,
+        )
+    }
+
+    @Test
+    fun `bare url with trailing comma is trimmed`() {
+        val paragraph =
+            MarkdownLite.parse("Visit https://example.com, then continue")
+                .single() as MarkdownBlock.Paragraph
+        assertEquals(
+            listOf(
+                MarkdownInline.Plain("Visit "),
+                MarkdownInline.Link("https://example.com", "https://example.com"),
+                MarkdownInline.Plain(","),
+                MarkdownInline.Plain(" then continue"),
+            ),
+            paragraph.inlines,
+        )
+    }
+
+    @Test
+    fun `markdown link is parsed`() {
+        val paragraph =
+            MarkdownLite.parse("See [docs](https://example.com/docs) for info")
+                .single() as MarkdownBlock.Paragraph
+        assertEquals(
+            listOf(
+                MarkdownInline.Plain("See "),
+                MarkdownInline.Link("docs", "https://example.com/docs"),
+                MarkdownInline.Plain(" for info"),
+            ),
+            paragraph.inlines,
+        )
+    }
+
+    @Test
+    fun `multiple bare urls are all linked`() {
+        val paragraph =
+            MarkdownLite.parse("Go to https://a.com and https://b.com today")
+                .single() as MarkdownBlock.Paragraph
+        assertEquals(
+            listOf(
+                MarkdownInline.Plain("Go to "),
+                MarkdownInline.Link("https://a.com", "https://a.com"),
+                MarkdownInline.Plain(" and "),
+                MarkdownInline.Link("https://b.com", "https://b.com"),
+                MarkdownInline.Plain(" today"),
+            ),
+            paragraph.inlines,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes cases where URLs in chat did not render as proper clickable links.

### Changes

1. **User messages**: URLs were rendered as plain text. Added a `LinkedText` composable that reuses `MarkdownLite.parseInline` to detect and make URLs tappable (`ChatMessageComponents.kt`).
2. **Bare URL punctuation**: replaced the fixed `trimEnd` set with `trimUrlTail`, which respects balanced parentheses so URLs like `https://en.wikipedia.org/wiki/Foo_(bar)` keep their `)` while `(https://example.com)` trims it (`MarkdownLite.kt`).
3. **File-path/URL overlap**: `FILE_PATH_REGEX` was matching domains inside URLs (e.g. `//example.com`) and inline-code spans, producing half-highlighted fake links. `annotateFilePaths` now skips ranges that overlap existing `link` or `code` annotations, and inline code is tagged with a `code` annotation.

### Tests

Added unit tests for balanced-paren URLs, wrapped URLs, trailing comma, markdown links, and multiple bare URLs.