### PR TITLE
feat: add setting for whether Enter sends chat message

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
@@ -327,6 +327,10 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
         get() = preferences.getString(KEY_SEND_BEHAVIOR, "interrupt") ?: "interrupt"
         set(value) = preferences.edit().putString(KEY_SEND_BEHAVIOR, value).apply()
 
+    var enterToSend: Boolean
+        get() = preferences.getBoolean(KEY_ENTER_TO_SEND, false)
+        set(value) = preferences.edit().putBoolean(KEY_ENTER_TO_SEND, value).apply()
+
     var sidebarGrouping: String
         get() = preferences.getString(KEY_SIDEBAR_GROUPING, "project") ?: "project"
         set(value) = preferences.edit().putString(KEY_SIDEBAR_GROUPING, value).apply()
@@ -398,6 +402,7 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
         private const val KEY_TOOL_CALL_DETAIL_LEVEL = "tool_call_detail_level"
         private const val KEY_AUTO_EXPAND_REASONING = "auto_expand_reasoning"
         private const val KEY_SEND_BEHAVIOR = "send_behavior"
+        private const val KEY_ENTER_TO_SEND = "enter_to_send"
         private const val KEY_SIDEBAR_GROUPING = "sidebar_grouping"
         private const val KEY_WORKSPACE_TITLE_SOURCE = "workspace_title_source"
         private const val KEY_LANGUAGE = "language"

--- a/app/src/main/java/com/yugahashimoto/andcode/data/settings/AppPreferencesRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/settings/AppPreferencesRepository.kt
@@ -35,6 +35,7 @@ data class AppPreferences(
     val toolCallDetailLevel: String = "detailed",
     val autoExpandReasoning: Boolean = false,
     val sendBehavior: String = "interrupt",
+    val enterToSend: Boolean = false,
     val sidebarGrouping: String = "project",
     val workspaceTitleSource: String = "title",
     val language: String = "system",
@@ -73,6 +74,7 @@ class AppPreferencesRepository(
                 toolCallDetailLevel = settings.toolCallDetailLevel,
                 autoExpandReasoning = settings.autoExpandReasoning,
                 sendBehavior = settings.sendBehavior,
+                enterToSend = settings.enterToSend,
                 sidebarGrouping = settings.sidebarGrouping,
                 workspaceTitleSource = settings.workspaceTitleSource,
                 language = settings.language,
@@ -267,6 +269,11 @@ class AppPreferencesRepository(
     fun setSendBehavior(behavior: String) {
         settings.sendBehavior = behavior
         mutableState.update { it.copy(sendBehavior = behavior) }
+    }
+
+    fun setEnterToSend(enabled: Boolean) {
+        settings.enterToSend = enabled
+        mutableState.update { it.copy(enterToSend = enabled) }
     }
 
     fun setSidebarGrouping(grouping: String) {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -171,6 +171,7 @@ fun ChatHomeScreen(
     supportsPermissions: Boolean = true,
     onToggleAutoAccept: (Boolean) -> Unit = {},
     sendBehavior: String = "interrupt",
+    enterToSend: Boolean = false,
     onSendMessage: (String) -> Unit,
     onPermission: (String, PermissionResponse, Boolean) -> Unit,
     onAbort: () -> Unit,
@@ -493,6 +494,7 @@ fun ChatHomeScreen(
                     onSelectClaudePermissionMode = onSelectClaudePermissionMode,
                     onToggleAutoAccept = onToggleAutoAccept,
                     sendBehavior = sendBehavior,
+                    enterToSend = enterToSend,
                     contextTokensUsed = state.contextTokensUsed,
                     contextLimit =
                         providers
@@ -921,6 +923,7 @@ private fun ChatComposer(
     claudePermissionMode: ClaudePermissionMode?,
     onSelectClaudePermissionMode: (ClaudePermissionMode) -> Unit,
     sendBehavior: String,
+    enterToSend: Boolean,
     contextTokensUsed: Long,
     contextLimit: Long,
     showSlashCommands: Boolean,
@@ -1056,8 +1059,19 @@ private fun ChatComposer(
                                 fontSize = MaterialTheme.typography.bodyLarge.fontSize,
                                 lineHeight = MaterialTheme.typography.bodyLarge.lineHeight,
                             ),
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                        keyboardActions = KeyboardActions(onSend = { onSend() }),
+                        keyboardOptions =
+                            KeyboardOptions(
+                                imeAction =
+                                    if (enterToSend) ImeAction.Send else ImeAction.Default,
+                            ),
+                        keyboardActions =
+                            KeyboardActions(
+                                onSend = {
+                                    if (enterToSend) {
+                                        onSend()
+                                    }
+                                },
+                            ),
                         cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                     )
                 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
@@ -93,6 +93,8 @@ fun SettingsScreenV2(
     onAutoExpandReasoningChange: (Boolean) -> Unit = {},
     sendBehavior: String = "interrupt",
     onSendBehaviorChange: (String) -> Unit = {},
+    enterToSend: Boolean = false,
+    onEnterToSendChange: (Boolean) -> Unit = {},
     wakeWordEnabled: Boolean = false,
 ) {
     var showThemeDialog by remember { mutableStateOf(false) }
@@ -217,6 +219,13 @@ fun SettingsScreenV2(
                             if (sendBehavior == "interrupt") "queue" else "interrupt",
                         )
                     },
+                )
+                SettingsDivider()
+                SettingsToggleRow(
+                    icon = Icons.Default.Chat,
+                    title = stringResource(R.string.enter_to_send_row),
+                    checked = enterToSend,
+                    onCheckedChange = onEnterToSendChange,
                 )
             }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -812,6 +812,7 @@ fun AndCodeApp(
                         onDismissQuestion = chatViewModel::dismissQuestion,
                         autoAcceptPermissions = settingsState.autoAcceptPermissions,
                         onToggleAutoAccept = settingsViewModel::setAutoAcceptPermissions,
+                        enterToSend = preferences.enterToSend,
                         onSendMessage = chatViewModel::sendMessage,
                         onPermission = chatViewModel::respondToPermission,
                         onAbort = chatViewModel::abort,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -84,6 +84,8 @@ fun NavGraphBuilder.settingsNavGraph(
             onAutoExpandReasoningChange = { appPreferences.setAutoExpandReasoning(it) },
             sendBehavior = preferences().sendBehavior,
             onSendBehaviorChange = { appPreferences.setSendBehavior(it) },
+            enterToSend = preferences().enterToSend,
+            onEnterToSendChange = { appPreferences.setEnterToSend(it) },
             wakeWordEnabled = settingsState.wakeWordEnabled,
         )
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -500,6 +500,7 @@
     <string name="send_behavior_row">سلوك الإرسال</string>
     <string name="send_behavior_interrupt">مقاطعة</string>
     <string name="send_behavior_queue">قائمة انتظار</string>
+    <string name="enter_to_send_row">الإدخال يرسل الرسالة</string>
 
     <string name="drawer_archive_session">أرشفة</string>
     <string name="drawer_selected_count">%1$d محدد</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -500,6 +500,7 @@
     <string name="send_behavior_row">Comportamiento de envío</string>
     <string name="send_behavior_interrupt">Interrumpir</string>
     <string name="send_behavior_queue">Cola</string>
+    <string name="enter_to_send_row">Enter envía el mensaje</string>
 
     <string name="drawer_archive_session">Archivar</string>
     <string name="drawer_selected_count">%1$d seleccionado(s)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -500,6 +500,7 @@
     <string name="send_behavior_row">Comportement d\'envoi</string>
     <string name="send_behavior_interrupt">Interrompre</string>
     <string name="send_behavior_queue">File d\'attente</string>
+    <string name="enter_to_send_row">Entrée envoie le message</string>
 
     <string name="drawer_archive_session">Archiver</string>
     <string name="drawer_selected_count">%1$d sélectionné(s)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -512,6 +512,7 @@
     <string name="send_behavior_row">送信動作</string>
     <string name="send_behavior_interrupt">割り込み</string>
     <string name="send_behavior_queue">キュー</string>
+    <string name="enter_to_send_row">Enter で送信</string>
 
     <!-- Drawer session actions -->
     <string name="drawer_archive_session">アーカイブ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -500,6 +500,7 @@
     <string name="send_behavior_row">Comportamento de envio</string>
     <string name="send_behavior_interrupt">Interromper</string>
     <string name="send_behavior_queue">Fila</string>
+    <string name="enter_to_send_row">Enter envia a mensagem</string>
 
     <string name="drawer_archive_session">Arquivar</string>
     <string name="drawer_selected_count">%1$d selecionado(s)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -500,6 +500,7 @@
     <string name="send_behavior_row">Поведение отправки</string>
     <string name="send_behavior_interrupt">Прервать</string>
     <string name="send_behavior_queue">В очередь</string>
+    <string name="enter_to_send_row">Enter отправляет сообщение</string>
 
     <string name="drawer_archive_session">Архивировать</string>
     <string name="drawer_selected_count">Выбрано: %1$d</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -500,6 +500,7 @@
     <string name="send_behavior_row">发送行为</string>
     <string name="send_behavior_interrupt">中断</string>
     <string name="send_behavior_queue">排队</string>
+    <string name="enter_to_send_row">回车键发送消息</string>
 
     <string name="drawer_archive_session">归档</string>
     <string name="drawer_selected_count">已选 %1$d 项</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,6 +516,7 @@
     <string name="send_behavior_row">Send behavior</string>
     <string name="send_behavior_interrupt">Interrupt</string>
     <string name="send_behavior_queue">Queue</string>
+    <string name="enter_to_send_row">Enter sends message</string>
 
     <!-- Drawer session actions -->
     <string name="drawer_archive_session">Archive</string>


### PR DESCRIPTION
## Summary

Adds a chat setting to control whether pressing Enter sends the message or inserts a newline.

- Default (OFF): Enter inserts a newline — the previous auto-send on Enter no longer happens.
- Toggle ON: Enter sends the message (previous behavior). The send button always works.

## Changes

- `SecureSettingsRepository`: persist `enterToSend` (default `false`)
- `AppPreferences`/repository: new `enterToSend` preference + setter
- `SettingsScreenV2`: "Enter sends message" toggle in the Chat section
- `ChatHomeScreen`: `ImeAction` switches between `Send` and `Default` based on the setting
- `strings.xml`: new `enter_to_send_row` string

## Verification

- `:app:compileDebugKotlin` passes
- `spotlessCheck` passes
- `ChatViewModelTest` passes