### PR TITLE
fix: surface Claude Code apk install failures in-app

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/ClaudeCodeCard.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/ClaudeCodeCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.OpenInNew
@@ -65,11 +66,13 @@ fun ClaudeCodeCard(
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             }
             is ClaudeInstallStatus.Failed -> {
-                Text(
-                    text = install.message,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
+                SelectionContainer {
+                    Text(
+                        text = install.message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
                 if (showInstallActions) {
                     Button(onClick = onInstall, modifier = Modifier.fillMaxWidth()) {
                         Icon(Icons.Default.Build, contentDescription = null)

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
@@ -228,7 +228,11 @@ object ClaudeCodeInstaller {
     private val APK_ERROR_PATTERN =
         Regex("(?i)\\b(error|warning|fatal|conflict|overwrite|unsatisfiable|masked|untrusted|denied|no space left|not found|failed to)\\b")
 
-    internal fun failureMessage(operation: String, exitCode: Int, log: File): String {
+    internal fun failureMessage(
+        operation: String,
+        exitCode: Int,
+        log: File,
+    ): String {
         val text = log.takeIf(File::isFile)?.readText().orEmpty()
         val errors = extractApkErrors(text)
         val tail = text.takeLast(2_000)

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
@@ -56,6 +56,28 @@ object ClaudeCodeInstaller {
         $CLAUDE_BINARY --version
         """.trimIndent()
 
+    private val INSTALL_DIAGNOSTICS_SCRIPT =
+        """
+        echo '--- and-code apk diagnostics ---'
+        echo '-- df -h / --'
+        df -h / 2>&1 || true
+        echo '-- apk add -s claude-code util-linux --'
+        /sbin/apk add -s claude-code util-linux 2>&1 || true
+        echo '-- apk policy claude-code --'
+        /sbin/apk policy claude-code 2>&1 || true
+        """.trimIndent()
+
+    private val UPDATE_DIAGNOSTICS_SCRIPT =
+        """
+        echo '--- and-code apk diagnostics ---'
+        echo '-- df -h / --'
+        df -h / 2>&1 || true
+        echo '-- apk add -s --upgrade claude-code --'
+        /sbin/apk add -s --upgrade claude-code 2>&1 || true
+        echo '-- apk policy claude-code --'
+        /sbin/apk policy claude-code 2>&1 || true
+        """.trimIndent()
+
     /** Steps reported while [installInto] runs, so the UI can show more than a spinner. */
     enum class Step {
         ADDING_REPOSITORY,
@@ -85,9 +107,10 @@ object ClaudeCodeInstaller {
         onStep(Step.DOWNLOADING_PACKAGE)
         val exitCode = runInRootfs(INSTALL_SCRIPT, rootfs, suite, runtimeDirectory, log, timeoutMinutes)
         onStep(Step.VERIFYING)
-        check(exitCode == 0) {
-            "Claude Code installation failed (exit $exitCode): ${log.takeIf(File::isFile)?.readText()?.takeLast(2_000).orEmpty()}"
+        if (exitCode != 0) {
+            collectDiagnostics(INSTALL_DIAGNOSTICS_SCRIPT, rootfs, suite, runtimeDirectory, log, timeoutMinutes)
         }
+        check(exitCode == 0) { failureMessage("installation", exitCode, log) }
         check(File(rootfs, CLAUDE_BINARY.removePrefix("/")).isFile) {
             "Claude Code reported success but $CLAUDE_BINARY is missing"
         }
@@ -129,9 +152,10 @@ object ClaudeCodeInstaller {
                 delete()
             }
         val exitCode = runInRootfs(UPDATE_SCRIPT, rootfs, suite, runtimeDirectory, log, timeoutMinutes)
-        check(exitCode == 0) {
-            "Claude Code update failed (exit $exitCode): ${log.takeIf(File::isFile)?.readText()?.takeLast(2_000).orEmpty()}"
+        if (exitCode != 0) {
+            collectDiagnostics(UPDATE_DIAGNOSTICS_SCRIPT, rootfs, suite, runtimeDirectory, log, timeoutMinutes)
         }
+        check(exitCode == 0) { failureMessage("update", exitCode, log) }
     }
 
     fun isInstalledIn(rootfs: File): Boolean = File(rootfs, CLAUDE_BINARY.removePrefix("/")).isFile
@@ -143,6 +167,7 @@ object ClaudeCodeInstaller {
         runtimeDirectory: File,
         log: File,
         timeoutMinutes: Long,
+        append: Boolean = false,
     ): Int {
         val prootTmp = File(runtimeDirectory, "proot-tmp").apply { mkdirs() }
         val process =
@@ -171,7 +196,9 @@ object ClaudeCodeInstaller {
                     script,
                 ),
             ).redirectErrorStream(true)
-                .redirectOutput(ProcessBuilder.Redirect.to(log))
+                .redirectOutput(
+                    if (append) ProcessBuilder.Redirect.appendTo(log) else ProcessBuilder.Redirect.to(log),
+                )
                 .apply {
                     environment().clear()
                     environment().putAll(localRuntimeEnvironment(suite.environment(), prootTmp))
@@ -184,4 +211,55 @@ object ClaudeCodeInstaller {
         }
         return process.exitValue()
     }
+
+    private fun collectDiagnostics(
+        script: String,
+        rootfs: File,
+        suite: EmbeddedCommandSuite.Paths,
+        runtimeDirectory: File,
+        log: File,
+        timeoutMinutes: Long,
+    ) {
+        runCatching {
+            runInRootfs(script, rootfs, suite, runtimeDirectory, log, timeoutMinutes, append = true)
+        }
+    }
+
+    private val APK_ERROR_PATTERN =
+        Regex("(?i)\\b(error|warning|fatal|conflict|overwrite|unsatisfiable|masked|untrusted|denied|no space left|not found|failed to)\\b")
+
+    internal fun failureMessage(operation: String, exitCode: Int, log: File): String {
+        val text = log.takeIf(File::isFile)?.readText().orEmpty()
+        val errors = extractApkErrors(text)
+        val tail = text.takeLast(2_000)
+        val primary =
+            errors.lineSequence().firstOrNull()
+                ?: tail.lineSequence().map(String::trim).firstOrNull { it.isNotBlank() }.orEmpty()
+        return buildString {
+            append("Claude Code ")
+            append(operation)
+            append(" failed (exit ")
+            append(exitCode)
+            append("): ")
+            append(primary)
+            if (errors.isNotBlank()) {
+                append('\n')
+                append(errors)
+            }
+            append("\n--- log tail ---\n")
+            append(tail)
+        }
+    }
+
+    internal fun extractApkErrors(text: String): String =
+        text.lineSequence()
+            .map(String::trim)
+            .filter { it.isNotEmpty() }
+            .filter { line ->
+                !line.startsWith("fetch ") &&
+                    !line.startsWith("(") &&
+                    APK_ERROR_PATTERN.containsMatchIn(line)
+            }
+            .take(40)
+            .joinToString("\n")
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
@@ -140,7 +140,7 @@ class ClaudeCodeTarget(
         }.onSuccess { version ->
             mutableState.value = RuntimeState.Connected(version)
         }.onFailure { error ->
-            mutableState.value = RuntimeState.Failed(error.message?.takeLast(500) ?: messages.installFailed)
+            mutableState.value = RuntimeState.Failed(error.message ?: messages.installFailed)
         }
     }
 

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
@@ -1,0 +1,62 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ClaudeCodeInstallerTest {
+    @Test
+    fun `extractApkErrors keeps ERROR and WARNING and summary lines`() {
+        val log =
+            """
+            v3.24.1-299 [https://example/main]
+            OK: 28595 distinct packages available
+            ERROR: unable to select packages:
+              claude-code-2.1.108-r1:
+            WARNING: something went wrong
+            1 error; 2322.8 MiB in 392 packages
+            """.trimIndent()
+        val errors = ClaudeCodeInstaller.extractApkErrors(log)
+        assertTrue(errors.contains("ERROR: unable to select packages:"))
+        assertTrue(errors.contains("WARNING: something went wrong"))
+        assertTrue(errors.contains("1 error; 2322.8 MiB in 392 packages"))
+    }
+
+    @Test
+    fun `extractApkErrors drops fetch and progress lines even when they contain a keyword`() {
+        val log =
+            """
+            fetch https://dl-cdn.alpinelinux.org/alpine/v3.24/main/aarch64/error/APKINDEX.tar.gz
+            (12/392) Installing error-handler (1.0-r0)
+            ERROR: boom
+            """.trimIndent()
+        val errors = ClaudeCodeInstaller.extractApkErrors(log)
+        assertFalse(errors.contains("fetch "))
+        assertFalse(errors.contains("(12/392)"))
+        assertTrue(errors.contains("ERROR: boom"))
+    }
+
+    @Test
+    fun `extractApkErrors returns empty when nothing matches`() {
+        assertEquals("", ClaudeCodeInstaller.extractApkErrors("OK: 100 distinct packages available\n"))
+    }
+
+    @Test
+    fun `failureMessage puts the primary error on the first line so compact views show it`() {
+        val log =
+            File.createTempFile("claude-install", ".log").apply {
+                deleteOnExit()
+                writeText(
+                    "OK: 28595 distinct packages available\nERROR: unable to select packages:\n1 error; 2322.8 MiB in 392 packages\n",
+                )
+            }
+        val message = ClaudeCodeInstaller.failureMessage("installation", 1, log)
+        val firstLine = message.lineSequence().first()
+        assertTrue(
+            firstLine.startsWith("Claude Code installation failed (exit 1): ERROR: unable to select packages:"),
+        )
+        assertTrue(message.contains("--- log tail ---"))
+    }
+}


### PR DESCRIPTION
## 問題
Claude Code のインストール/アップデート失敗時、apk の `ERROR:` 行がどの画面にも表示されず、原因がアプリ内で特定できなかった。

エラー文が3段階で削られていた:
- installer: ログ末尾 2000 文字のみ
- target: さらに `takeLast(500)`
- 一覧: `compactRuntimeError` で先頭1行160文字

加えて失敗時の apk 診断を集めておらず、apk 本体が原因行を出さないケースでは実機ログ無しに原因確定不能だった。

## 修正
- `ClaudeCodeInstaller`: 終了コード非0時に `apk add -s` / `apk policy` / `df -h` をログへ追記。ログから ERROR/WARNING/競合行を抽出し、主要行を失敗メッセージの先頭に配置。
- `ClaudeCodeTarget`: `takeLast(500)` を撤廃。
- `ClaudeCodeCard`: エラー文を `SelectionContainer` で囲み選択/コピー可能に。
- 単体テスト `ClaudeCodeInstallerTest` を追加。

## 検証
- 追加テストで正規表現の抽出挙動と `failureMessage` の先頭行を検証。
- 注: この環境には Android SDK が無いため Gradle ビルド/テストは未実行。CI での確認をお願いします。