### PR TITLE
feat: invoke backend skills and commands from the chat composer

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClient.kt
@@ -397,6 +397,25 @@ class OpenCodeApiClient(
 
     suspend fun skills(): List<OpenCodeSkill> = getList("skill")
 
+    suspend fun executeCommand(
+        sessionId: String,
+        command: String,
+        arguments: String = "",
+        agent: String? = null,
+        model: String? = null,
+        variant: String? = null,
+    ) {
+        val body =
+            buildJsonObject {
+                put("command", command)
+                put("arguments", arguments)
+                agent?.takeIf { it.isNotBlank() }?.let { put("agent", it) }
+                model?.takeIf { it.isNotBlank() }?.let { put("model", it) }
+                variant?.takeIf { it.isNotBlank() }?.let { put("variant", it) }
+            }
+        postWithoutResponse("session/${encodePath(sessionId)}/command", body)
+    }
+
     suspend fun respondPermission(
         sessionId: String,
         permissionId: String,

--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
@@ -371,6 +371,7 @@ data class OpenCodeCommand(
     val name: String,
     val description: String? = null,
     val template: String? = null,
+    val source: String? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -117,7 +117,9 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.OpenCodeAgent
+import com.yugahashimoto.andcode.core.api.OpenCodeCommand
 import com.yugahashimoto.andcode.core.api.OpenCodeProvider
+import com.yugahashimoto.andcode.core.api.OpenCodeSkill
 import com.yugahashimoto.andcode.core.api.PromptAttachment
 import com.yugahashimoto.andcode.feature.workspace.GitHubAutoAttachChips
 import com.yugahashimoto.andcode.feature.workspace.GitHubReference
@@ -502,8 +504,10 @@ fun ChatHomeScreen(
                             ?.models?.get(selectedModelId)
                             ?.limit?.context ?: 0L,
                     showSlashCommands = showSlashCommands,
-                    onSlashCommandSelect = { command ->
-                        input = command.name + " "
+                    slashCommands = state.slashCommands,
+                    slashSkills = state.slashSkills,
+                    onSlashCommandSelect = { suggestion ->
+                        input = suggestion.name + " "
                         showSlashCommands = false
                     },
                     githubRefs = githubRefs,
@@ -927,7 +931,9 @@ private fun ChatComposer(
     contextTokensUsed: Long,
     contextLimit: Long,
     showSlashCommands: Boolean,
-    onSlashCommandSelect: (SlashCommand) -> Unit,
+    slashCommands: List<OpenCodeCommand>,
+    slashSkills: List<OpenCodeSkill>,
+    onSlashCommandSelect: (SlashSuggestion) -> Unit,
     githubRefs: List<GitHubReference>,
     attachedImages: List<Bitmap>,
     onRemoveImage: (Int) -> Unit,
@@ -945,7 +951,7 @@ private fun ChatComposer(
                 .padding(horizontal = 10.dp, vertical = 8.dp),
     ) {
         if (showSlashCommands) {
-            val filtered = SlashCommandRegistry.filter(input)
+            val filtered = SlashCommandRegistry.suggestions(input, slashCommands, slashSkills)
             if (filtered.isNotEmpty()) {
                 Card(
                     modifier =
@@ -955,7 +961,7 @@ private fun ChatComposer(
                     shape = RoundedCornerShape(12.dp),
                 ) {
                     Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                        filtered.forEach { command ->
+                        filtered.forEach { suggestion ->
                             DropdownMenuItem(
                                 text = {
                                     Row(
@@ -963,18 +969,18 @@ private fun ChatComposer(
                                         verticalAlignment = Alignment.CenterVertically,
                                     ) {
                                         Text(
-                                            text = command.name,
+                                            text = suggestion.name,
                                             style = MaterialTheme.typography.labelLarge,
                                             fontWeight = FontWeight.SemiBold,
                                         )
                                         Text(
-                                            text = command.description,
+                                            text = suggestion.description,
                                             style = MaterialTheme.typography.bodySmall,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
                                     }
                                 },
-                                onClick = { onSlashCommandSelect(command) },
+                                onClick = { onSlashCommandSelect(suggestion) },
                             )
                         }
                     }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -6,9 +6,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yugahashimoto.andcode.core.api.ConnectionQuality
 import com.yugahashimoto.andcode.core.api.ConnectionQualityMonitor
+import com.yugahashimoto.andcode.core.api.OpenCodeCommand
 import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import com.yugahashimoto.andcode.core.api.OpenCodeMessage
 import com.yugahashimoto.andcode.core.api.OpenCodePart
+import com.yugahashimoto.andcode.core.api.OpenCodeSkill
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.core.api.PromptAttachment
 import com.yugahashimoto.andcode.core.api.PromptRequest
@@ -255,6 +257,8 @@ data class ChatUiState(
     val selectedModelId: String? = null,
     val selectedAgentId: String? = null,
     val selectedWorkspacePath: String? = null,
+    val slashCommands: List<OpenCodeCommand> = emptyList(),
+    val slashSkills: List<OpenCodeSkill> = emptyList(),
     val offlineQueue: List<String> = emptyList(),
     val isOfflineQueued: Boolean = false,
     val connectionQuality: ConnectionQuality? = null,
@@ -367,6 +371,7 @@ class ChatViewModel(
                                     error = null,
                                 )
                             }
+                            refreshSlashCatalog()
                             return@launch
                         }
                         .onFailure { error -> lastError = error.safeMessage() }
@@ -382,6 +387,27 @@ class ChatViewModel(
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Loads the backend's slash commands and skills so the composer's `/` popup can offer them.
+     */
+    fun refreshSlashCatalog() {
+        val currentBackend = backend ?: return
+        viewModelScope.launch {
+            runCatching { currentBackend.commands() }
+                .onSuccess { commands ->
+                    if (backend == currentBackend) {
+                        _uiState.update { it.copy(slashCommands = commands) }
+                    }
+                }
+            runCatching { currentBackend.skills() }
+                .onSuccess { skills ->
+                    if (backend == currentBackend) {
+                        _uiState.update { it.copy(slashSkills = skills) }
+                    }
+                }
         }
     }
 
@@ -617,6 +643,14 @@ class ChatViewModel(
             return
         }
 
+        // A known backend command or skill is executed through the runtime's own command handling
+        // (OpenCode expands the template server-side) rather than sent as a plain prompt.
+        val slashCommand = matchSlashCommand(normalized)
+        if (slashCommand != null) {
+            sendSlashCommand(slashCommand.first, slashCommand.second)
+            return
+        }
+
         if (!_uiState.value.isConnected) {
             offlineMessageQueue.update { it + normalized }
             val userMessage =
@@ -790,6 +824,185 @@ class ChatViewModel(
                 reportError(error)
             }
         }
+    }
+
+    /**
+     * Sends a slash command or skill through the runtime's command handling.
+     *
+     * OpenCode expands the command's template server-side and runs it as a turn; Claude Code and
+     * Antigravity receive `/name` as a prompt and interpret it themselves. The turn is completed and
+     * polled exactly like [sendMessage], so the same completion signals drive the UI.
+     */
+    fun sendSlashCommand(
+        command: String,
+        arguments: String,
+    ) {
+        val currentBackend = backend
+        if (currentBackend == null) {
+            _uiState.update { it.copy(error = "OpenCode connection is not configured") }
+            return
+        }
+        val displayText = "/$command${arguments.takeIf { it.isNotBlank() }?.let { " $it" }.orEmpty()}"
+        val messageIdsBeforeSend = _uiState.value.messages.map { it.id }.toSet()
+
+        if (!_uiState.value.isConnected) {
+            offlineMessageQueue.update { it + displayText }
+            val userMessage =
+                ChatMessage(
+                    isUser = true,
+                    parts = listOf(ChatPart.Text(id = UUID.randomUUID().toString(), text = displayText)),
+                )
+            _uiState.update {
+                it.copy(
+                    messages = it.messages + userMessage,
+                    offlineQueue = it.offlineQueue + displayText,
+                    isOfflineQueued = true,
+                )
+            }
+            return
+        }
+
+        val mustQueue = (currentBackend as? RuntimeTarget)?.capabilities?.forcesQueue == true
+        if ((_sendBehavior.value == "queue" || mustQueue) && _uiState.value.isRunning) {
+            messageQueue.update { it + displayText }
+            return
+        }
+
+        val userMessage =
+            ChatMessage(
+                isUser = true,
+                parts = listOf(ChatPart.Text(id = UUID.randomUUID().toString(), text = displayText)),
+            )
+        _uiState.update {
+            it.copy(
+                messages = it.messages + userMessage,
+                isRunning = true,
+                isThinking = true,
+                partialText = "",
+                error = null,
+            )
+        }
+
+        viewModelScope.launch {
+            var capturedSessionId: String? = null
+            runCatching {
+                val existingSessionId = _uiState.value.sessionId
+                val session =
+                    if (existingSessionId == null) {
+                        currentBackend.createSession(
+                            title = null,
+                            directory = _uiState.value.selectedWorkspacePath,
+                        )
+                    } else {
+                        null
+                    }
+                val targetSessionId = existingSessionId ?: requireNotNull(session).id
+                capturedSessionId = targetSessionId
+                if (session != null) {
+                    _uiState.update {
+                        it.copy(sessionId = session.id, sessionTitle = session.title)
+                    }
+                    onSessionCreated()
+                }
+
+                // The command endpoint on OpenCode runs the whole turn before answering, so it is
+                // fired in its own coroutine: the poll loop below (and the SSE stream) drive the UI
+                // without waiting on an HTTP call that may outlive a long turn.
+                viewModelScope.launch {
+                    runCatching {
+                        currentBackend.executeCommand(
+                            sessionId = targetSessionId,
+                            command = command,
+                            arguments = arguments,
+                        )
+                    }.onFailure { error -> reportError(error) }
+                }
+
+                runCatching { currentBackend.session(targetSessionId).title }
+                    .onSuccess { title ->
+                        if (title.isNotBlank()) _uiState.update { it.copy(sessionTitle = title) }
+                    }
+                clearDraft(targetSessionId)
+                var sessionCompleted = false
+
+                fun isStillActive() = _uiState.value.sessionId == targetSessionId
+                val pollFinished =
+                    withTimeoutOrNull(RESPONSE_POLL_TIMEOUT_MS) {
+                        while (isStillActive() && _uiState.value.isRunning) {
+                            delay(RESPONSE_POLL_INTERVAL_MS)
+                            if (!isStillActive()) return@withTimeoutOrNull
+                            runCatching { currentBackend.listMessages(targetSessionId) }
+                                .onSuccess { serverMessages ->
+                                    if (!isStillActive()) return@onSuccess
+                                    val uiMessages = serverMessages.mapNotNull(::toUiMessage)
+                                    if (uiMessages.isNotEmpty() && uiMessages != _uiState.value.messages) {
+                                        _uiState.update { it.copy(messages = uiMessages) }
+                                    }
+                                    if (turnFinished(serverMessages, messageIdsBeforeSend)) {
+                                        sessionCompleted = true
+                                        _uiState.update { it.copy(isRunning = false, isThinking = false) }
+                                    }
+                                }
+                        }
+                    }
+                if (isStillActive() && (sessionCompleted || pollFinished == null)) {
+                    runCatching { currentBackend.listMessages(targetSessionId) }
+                        .onSuccess { serverMessages ->
+                            if (!isStillActive()) return@onSuccess
+                            val hasResponse =
+                                serverMessages.any { message ->
+                                    message.info.role == "assistant" && message.info.id !in messageIdsBeforeSend
+                                }
+                            if (!sessionCompleted && !hasResponse) return@onSuccess
+                            streamedParts.clear()
+                            _uiState.update {
+                                it.copy(
+                                    messages = serverMessages.mapNotNull(::toUiMessage),
+                                    isRunning = false,
+                                    isThinking = false,
+                                )
+                            }
+                            refreshContextUsage(targetSessionId)
+                        }
+                }
+            }.onFailure { error ->
+                if (capturedSessionId == null || _uiState.value.sessionId == capturedSessionId) {
+                    _uiState.update {
+                        it.copy(
+                            isRunning = false,
+                            isThinking = false,
+                        )
+                    }
+                }
+                reportError(error)
+            }
+        }
+    }
+
+    /**
+     * If [text] invokes a command or skill the backend knows about, returns it as `(name, arguments)`.
+     *
+     * App-level commands (`/new`, `/clear`, …) are not backend commands, so they are left alone and
+     * keep their existing handling.
+     */
+    private fun matchSlashCommand(text: String): Pair<String, String>? {
+        if (!text.startsWith("/")) return null
+        val firstLineEnd = text.indexOf('\n')
+        val firstLine = if (firstLineEnd == -1) text else text.substring(0, firstLineEnd)
+        val tokens = firstLine.split(" ")
+        val rawName = tokens.firstOrNull()?.trimStart('/')?.trim().orEmpty()
+        if (rawName.isEmpty()) return null
+        val restOfLine = tokens.drop(1).joinToString(" ")
+        val restOfInput = if (firstLineEnd == -1) "" else text.substring(firstLineEnd + 1)
+        val arguments =
+            when {
+                restOfLine.isNotEmpty() && restOfInput.isNotEmpty() -> "$restOfLine\n$restOfInput"
+                else -> restOfLine + restOfInput
+            }
+        val state = _uiState.value
+        val known =
+            state.slashCommands.any { it.name == rawName } || state.slashSkills.any { it.name == rawName }
+        return if (known) rawName to arguments else null
     }
 
     /**

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/SlashCommandRegistry.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/SlashCommandRegistry.kt
@@ -1,5 +1,8 @@
 package com.yugahashimoto.andcode.feature.chat
 
+import com.yugahashimoto.andcode.core.api.OpenCodeCommand
+import com.yugahashimoto.andcode.core.api.OpenCodeSkill
+
 enum class SlashAction { NEW_CHAT, CLEAR, MODEL, AGENT, ATTACH, HELP }
 
 data class SlashCommand(
@@ -7,6 +10,27 @@ data class SlashCommand(
     val description: String,
     val action: SlashAction,
 )
+
+/**
+ * One entry in the composer's slash-command popup: either an app-level command or a command/skill
+ * the connected backend advertises. All of them end up inserting `/<name> ` into the input; the
+ * send path then routes backend commands and skills through the runtime's command handling.
+ */
+sealed interface SlashSuggestion {
+    val name: String
+    val description: String
+
+    data class App(val command: SlashCommand) : SlashSuggestion {
+        override val name: String = command.name
+        override val description: String = command.description
+    }
+
+    data class Backend(
+        override val name: String,
+        override val description: String,
+        val isSkill: Boolean = false,
+    ) : SlashSuggestion
+}
 
 object SlashCommandRegistry {
     val commands: List<SlashCommand> =
@@ -19,9 +43,27 @@ object SlashCommandRegistry {
             SlashCommand("/help", "Show help", SlashAction.HELP),
         )
 
-    fun filter(query: String): List<SlashCommand> {
+    /**
+     * Builds the popup list: app commands first, then the backend's commands and skills, filtering
+     * everything by what the user has typed so far.
+     */
+    fun suggestions(
+        query: String,
+        backendCommands: List<OpenCodeCommand>,
+        backendSkills: List<OpenCodeSkill>,
+    ): List<SlashSuggestion> {
         val trimmed = query.trim()
-        if (trimmed.isEmpty()) return commands
-        return commands.filter { it.name.startsWith(trimmed, ignoreCase = true) }
+
+        fun matches(name: String): Boolean = trimmed.isEmpty() || name.startsWith(trimmed, ignoreCase = true)
+
+        val app = commands.filter { matches(it.name) }.map(SlashSuggestion::App)
+        val backend =
+            backendCommands
+                .filter { matches("/${it.name}") }
+                .map { SlashSuggestion.Backend("/${it.name}", it.description.orEmpty()) } +
+                backendSkills
+                    .filter { matches("/${it.name}") }
+                    .map { SlashSuggestion.Backend("/${it.name}", it.description.orEmpty(), isSkill = true) }
+        return app + backend.sortedBy { it.name }
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/OpenCodeBackend.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/OpenCodeBackend.kt
@@ -207,6 +207,21 @@ interface OpenCodeBackend {
 
     suspend fun skills(): List<OpenCodeSkill> = unsupported("skills")
 
+    /**
+     * Executes a slash command or skill by name in [sessionId].
+     *
+     * OpenCode expands the command's template server-side and runs it as a prompt. For runtimes
+     * without a command endpoint (Claude Code, Antigravity) the name is sent as a message instead,
+     * letting the CLI's own slash-command handling pick it up.
+     */
+    suspend fun executeCommand(
+        sessionId: String,
+        command: String,
+        arguments: String,
+    ) {
+        sendMessage(sessionId, PromptRequest(text = "/$command${arguments.takeIf { it.isNotBlank() }?.let { " $it" }.orEmpty()}"))
+    }
+
     fun events(): Flow<OpenCodeEvent>
 
     private fun unsupported(capability: String): Nothing =

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalOpenCodeBackend.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalOpenCodeBackend.kt
@@ -239,6 +239,12 @@ class LocalOpenCodeBackend(
 
     override suspend fun skills(): List<OpenCodeSkill> = delegate().skills()
 
+    override suspend fun executeCommand(
+        sessionId: String,
+        command: String,
+        arguments: String,
+    ) = delegate().executeCommand(sessionId, command, arguments)
+
     override fun events(): Flow<OpenCodeEvent> = delegate().events()
 
     private data class CachedDelegate(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
@@ -270,6 +270,12 @@ class LocalRuntimeTarget(
 
     override suspend fun skills(): List<com.yugahashimoto.andcode.core.api.OpenCodeSkill> = backend.skills()
 
+    override suspend fun executeCommand(
+        sessionId: String,
+        command: String,
+        arguments: String,
+    ) = backend.executeCommand(sessionId, command, arguments)
+
     override suspend fun summarizeSession(
         sessionId: String,
         providerId: String,

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteOpenCodeBackend.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteOpenCodeBackend.kt
@@ -208,5 +208,19 @@ class RemoteOpenCodeBackend(
 
     override suspend fun skills(): List<OpenCodeSkill> = client.skills()
 
+    override suspend fun executeCommand(
+        sessionId: String,
+        command: String,
+        arguments: String,
+    ) {
+        client.executeCommand(
+            sessionId = sessionId,
+            command = command,
+            arguments = arguments,
+            agent = null,
+            model = null,
+        )
+    }
+
     override fun events(): Flow<OpenCodeEvent> = client.events()
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
@@ -239,6 +239,12 @@ class RemoteRuntimeTarget(
 
     override suspend fun skills(): List<com.yugahashimoto.andcode.core.api.OpenCodeSkill> = backend.skills()
 
+    override suspend fun executeCommand(
+        sessionId: String,
+        command: String,
+        arguments: String,
+    ) = backend.executeCommand(sessionId, command, arguments)
+
     override suspend fun summarizeSession(
         sessionId: String,
         providerId: String,

--- a/app/src/test/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClientTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClientTest.kt
@@ -118,6 +118,21 @@ class OpenCodeApiClientTest {
         }
 
     @Test
+    fun `executes a slash command with arguments`() =
+        runBlocking {
+            server.enqueue(MockResponse().setResponseCode(204))
+            val client = client()
+
+            client.executeCommand(sessionId = "s1", command = "changelog", arguments = "v1.0")
+
+            val request = server.takeRequest()
+            assertEquals("/session/s1/command", request.path)
+            val json = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+            assertEquals("changelog", json["command"]!!.jsonPrimitive.content)
+            assertEquals("v1.0", json["arguments"]!!.jsonPrimitive.content)
+        }
+
+    @Test
     fun `summarizes a session with the selected model`() =
         runBlocking {
             server.enqueue(MockResponse().setBody("true"))

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -1,12 +1,14 @@
 package com.yugahashimoto.andcode.feature.chat
 
 import com.yugahashimoto.andcode.core.api.OpenCodeAgent
+import com.yugahashimoto.andcode.core.api.OpenCodeCommand
 import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import com.yugahashimoto.andcode.core.api.OpenCodeHealth
 import com.yugahashimoto.andcode.core.api.OpenCodeMessage
 import com.yugahashimoto.andcode.core.api.OpenCodeMessageInfo
 import com.yugahashimoto.andcode.core.api.OpenCodePart
 import com.yugahashimoto.andcode.core.api.OpenCodeSession
+import com.yugahashimoto.andcode.core.api.OpenCodeSkill
 import com.yugahashimoto.andcode.core.api.OpenCodeTime
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.core.api.PromptAttachment
@@ -189,6 +191,85 @@ class ChatViewModelTest {
             assertEquals("/root/demo", backend.lastCreateDirectory)
             assertEquals("/root/demo", viewModel.uiState.value.selectedWorkspacePath)
         }
+
+    @Test
+    fun `slash command for a known backend command is executed as a command`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+
+            viewModel.sendMessage("/changelog v1.0")
+            advanceUntilIdle()
+
+            assertEquals(0, backend.sentPrompts.size)
+            assertEquals(1, backend.executedCommands.size)
+            assertEquals("changelog", backend.executedCommands.single().command)
+            assertEquals("v1.0", backend.executedCommands.single().arguments)
+            assertEquals(1, backend.createSessionCalls)
+            assertEquals("/changelog v1.0", viewModel.uiState.value.messages.single().text)
+        }
+
+    @Test
+    fun `slash command for a known skill is executed as a command`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+
+            viewModel.sendMessage("/git-release")
+            advanceUntilIdle()
+
+            assertEquals(0, backend.sentPrompts.size)
+            assertEquals(1, backend.executedCommands.size)
+            assertEquals("git-release", backend.executedCommands.single().command)
+            assertEquals("", backend.executedCommands.single().arguments)
+        }
+
+    @Test
+    fun `slash command that is not known is sent as a plain prompt`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+
+            viewModel.sendMessage("/nonexistent")
+            advanceUntilIdle()
+
+            assertEquals(1, backend.sentPrompts.size)
+            assertEquals("/nonexistent", backend.sentPrompts.single().second.text)
+            assertEquals(0, backend.executedCommands.size)
+        }
+
+    @Test
+    fun `refresh slash catalog loads commands and skills`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+
+            viewModel.refreshSlashCatalog()
+            advanceUntilIdle()
+
+            assertEquals(listOf("changelog"), viewModel.uiState.value.slashCommands.map { it.name })
+            assertEquals(listOf("git-release"), viewModel.uiState.value.slashSkills.map { it.name })
+        }
+
+    @Test
+    fun `slash suggestions merge app commands with backend commands and skills`() {
+        val suggestions =
+            SlashCommandRegistry.suggestions(
+                query = "/",
+                backendCommands = listOf(OpenCodeCommand("commit", "Write commit")),
+                backendSkills = listOf(OpenCodeSkill("git-release", "Create a release", "release")),
+            )
+        val names = suggestions.map { it.name }
+        assertTrue("/new" in names)
+        assertTrue("/commit" in names)
+        assertTrue("/git-release" in names)
+        val skill = suggestions.filterIsInstance<SlashSuggestion.Backend>().first { it.name == "/git-release" }
+        assertTrue(skill.isSkill)
+    }
 
     @Test
     fun `auto accept approves permissions without showing card`() =
@@ -877,6 +958,9 @@ class ChatViewModelTest {
         val abortedSessions = mutableListOf<String>()
         var healthFailuresRemaining = 0
         var failCreateSession = false
+        val commands = mutableListOf(OpenCodeCommand("changelog", "Draft changelog", "Write the changelog for the release"))
+        val skills = mutableListOf(OpenCodeSkill("git-release", "Create a release", "release"))
+        val executedCommands = mutableListOf<CommandCall>()
 
         override suspend fun health(): OpenCodeHealth {
             if (healthFailuresRemaining > 0) {
@@ -911,6 +995,18 @@ class ChatViewModelTest {
         override suspend fun listProviders(): ProviderCatalog = ProviderCatalog()
 
         override suspend fun listAgents(): List<OpenCodeAgent> = emptyList()
+
+        override suspend fun commands(): List<OpenCodeCommand> = commands
+
+        override suspend fun skills(): List<OpenCodeSkill> = skills
+
+        override suspend fun executeCommand(
+            sessionId: String,
+            command: String,
+            arguments: String,
+        ) {
+            executedCommands += CommandCall(sessionId, command, arguments)
+        }
 
         override suspend fun sendMessage(
             sessionId: String,
@@ -999,5 +1095,11 @@ class ChatViewModelTest {
         val permissionId: String,
         val third: PermissionResponse,
         val remember: Boolean,
+    )
+
+    private data class CommandCall(
+        val sessionId: String,
+        val command: String,
+        val arguments: String,
     )
 }


### PR DESCRIPTION
## Summary

The chat composer's slash-command popup (`/`) now shows the connected backend's **commands and skills** in addition to the app's built-in commands (`/new`, `/clear`, etc.). Sending a known command or skill routes it through the runtime's own command handling rather than sending it as a plain prompt.

## How it works per runtime

| Runtime | Execution |
|---|---|
| opencode (local/remote) | `POST /session/{id}/command` — the server expands the command/skill template and runs it as a turn |
| Claude Code | `/name` is sent as a prompt; the CLI interprets it |
| Antigravity | `/name` is sent as a prompt |

## Changes

- `OpenCodeApiClient.executeCommand()` (`POST /session/{id}/command`) + `source` field on `OpenCodeCommand`
- `OpenCodeBackend.executeCommand()` on the interface and all implementations
- `ChatViewModel`: loads the slash catalog (`commands()`/`skills()`) into `ChatUiState`, routes `/known` text to `sendSlashCommand`, and polls the turn to completion like `sendMessage`
- `ChatHomeScreen` / `SlashCommandRegistry`: merged suggestions (app commands + backend commands + skills)
- Unit tests for routing, the slash catalog, and the new endpoint

## Test plan

- `./gradlew :app:testDebugUnitTest` — pass
- `./gradlew :app:lintDebug` — pass