### PR TITLE
fix: send image attachments to on-device Claude Code

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -1,6 +1,9 @@
 package com.yugahashimoto.andcode.feature.chat
 
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Base64
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
@@ -91,9 +94,20 @@ fun MessageBubble(message: ChatMessage) {
                 contentColor = MaterialTheme.colorScheme.onPrimary,
             ) {
                 Column(modifier = Modifier.padding(14.dp)) {
-                    message.imagePreviews.forEach { preview ->
+                    // Images persist in the transcript as base64 data-URL file parts, so once the
+                    // message is recorded they render straight from the attachment and survive the
+                    // reload that follows a completed send. The transient imagePreviews bitmaps only
+                    // stand in for the optimistic echo before the message reaches the transcript, or
+                    // for runtimes whose attachment URLs are not inlineable data URLs.
+                    val decodedImages =
+                        remember(message.attachments) {
+                            message.attachments
+                                .filter { it.mime.startsWith("image/") }
+                                .mapNotNull { decodeDataUrlImage(it.url) }
+                        }
+                    (decodedImages.ifEmpty { message.imagePreviews }).forEach { bitmap ->
                         Image(
-                            bitmap = preview.asImageBitmap(),
+                            bitmap = bitmap.asImageBitmap(),
                             contentDescription = stringResource(R.string.cd_image_preview),
                             modifier =
                                 Modifier
@@ -126,6 +140,20 @@ fun MessageBubble(message: ChatMessage) {
             }
         }
     }
+}
+
+/**
+ * Decodes a base64 `data:` image URL into a bitmap, or null when the URL is not an inlineable data
+ * URL (e.g. a remote runtime returned a plain http/file reference). Failures are swallowed so a
+ * single unreadable attachment never crashes the transcript.
+ */
+private fun decodeDataUrlImage(url: String): Bitmap? {
+    val base64 = url.substringAfter("base64,", missingDelimiterValue = "")
+    if (base64.isEmpty()) return null
+    return runCatching {
+        val bytes = Base64.decode(base64, Base64.DEFAULT)
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    }.getOrNull()
 }
 
 @Composable

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -746,9 +746,24 @@ class ChatViewModel(
                                 }
                             if (!sessionCompleted && !hasResponse) return@onSuccess
                             streamedParts.clear()
+                            // Re-attach the in-memory previews the same way the polling loop does:
+                            // the final reload otherwise drops them, and a runtime whose attachment
+                            // URLs are not inlineable data URLs would lose the just-sent image the
+                            // moment the send completed.
+                            val previewsById =
+                                _uiState.value.messages.associate { it.id to it.imagePreviews }
+                            val uiMessages =
+                                serverMessages.mapNotNull(::toUiMessage).map { message ->
+                                    val previews =
+                                        previewsById[message.id].orEmpty().ifEmpty {
+                                            message.attachments
+                                                .mapNotNull { pendingPreviewsByFilename[it.filename] }
+                                        }
+                                    message.copy(imagePreviews = previews)
+                                }
                             _uiState.update {
                                 it.copy(
-                                    messages = serverMessages.mapNotNull(::toUiMessage),
+                                    messages = uiMessages,
                                     isRunning = false,
                                     isThinking = false,
                                 )

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeRuntime.kt
@@ -6,6 +6,7 @@ import com.yugahashimoto.andcode.core.api.OpenCodeMessageInfo
 import com.yugahashimoto.andcode.core.api.OpenCodePart
 import com.yugahashimoto.andcode.core.api.OpenCodeTime
 import com.yugahashimoto.andcode.core.api.OpenCodeTodo
+import com.yugahashimoto.andcode.core.api.PromptAttachment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -193,12 +194,13 @@ class ClaudeCodeRuntime(
         permissionMode: ClaudePermissionMode,
         model: String?,
         effort: String?,
+        attachments: List<PromptAttachment> = emptyList(),
     ): Result<Unit> =
         runCatching {
             val session = ensureProcess(sessionId, directory.ifBlank { "/workspace" }, permissionMode, model, effort)
-            recordUserMessage(sessionId, prompt)
+            recordUserMessage(sessionId, prompt, attachments)
             session.process.outputStream.apply {
-                write((json.encodeToString(JsonObject.serializer(), userMessage(prompt)) + "\n").toByteArray())
+                write((json.encodeToString(JsonObject.serializer(), userMessage(prompt, attachments)) + "\n").toByteArray())
                 flush()
             }
             Unit
@@ -343,29 +345,75 @@ class ClaudeCodeRuntime(
             }
         }
 
-    private fun userMessage(prompt: String): JsonObject =
-        JsonObject(
+    /**
+     * Builds one stream-json user turn.
+     *
+     * The content array follows the Anthropic Messages API shape the CLI expects on stdin: any
+     * attachments become `image`/`document` blocks and the typed text follows them. Attachments the
+     * model cannot ingest inline (anything that is not an image or a PDF) are dropped here rather than
+     * sent as unusable blocks that would make the CLI reject the whole turn.
+     */
+    private fun userMessage(
+        prompt: String,
+        attachments: List<PromptAttachment>,
+    ): JsonObject {
+        val content =
+            buildList {
+                attachments.forEach { attachment -> attachmentBlock(attachment)?.let(::add) }
+                // Keep the text block even when blank so an attachment-only turn is still well-formed.
+                if (prompt.isNotEmpty() || isEmpty()) {
+                    add(
+                        JsonObject(
+                            mapOf(
+                                "type" to JsonPrimitive("text"),
+                                "text" to JsonPrimitive(prompt),
+                            ),
+                        ),
+                    )
+                }
+            }
+        return JsonObject(
             mapOf(
                 "type" to JsonPrimitive("user"),
                 "message" to
                     JsonObject(
                         mapOf(
                             "role" to JsonPrimitive("user"),
-                            "content" to
-                                JsonArray(
-                                    listOf(
-                                        JsonObject(
-                                            mapOf(
-                                                "type" to JsonPrimitive("text"),
-                                                "text" to JsonPrimitive(prompt),
-                                            ),
-                                        ),
-                                    ),
-                                ),
+                            "content" to JsonArray(content),
                         ),
                     ),
             ),
         )
+    }
+
+    /**
+     * Turns a `data:` attachment URL into the block the Messages API inlines it as, or null when the
+     * type cannot be inlined. [AttachmentImporter] always emits base64 data URLs, so this parses that
+     * shape and reuses the recorded [PromptAttachment.mime].
+     */
+    private fun attachmentBlock(attachment: PromptAttachment): JsonObject? {
+        val base64 = attachment.url.substringAfter("base64,", missingDelimiterValue = "")
+        if (base64.isEmpty()) return null
+        val kind =
+            when {
+                attachment.mime.startsWith("image/") -> "image"
+                attachment.mime == "application/pdf" -> "document"
+                else -> return null
+            }
+        return JsonObject(
+            mapOf(
+                "type" to JsonPrimitive(kind),
+                "source" to
+                    JsonObject(
+                        mapOf(
+                            "type" to JsonPrimitive("base64"),
+                            "media_type" to JsonPrimitive(attachment.mime),
+                            "data" to JsonPrimitive(base64),
+                        ),
+                    ),
+            ),
+        )
+    }
 
     private fun handleLine(
         sessionId: String,
@@ -430,9 +478,27 @@ class ClaudeCodeRuntime(
     private fun recordUserMessage(
         sessionId: String,
         prompt: String,
+        attachments: List<PromptAttachment>,
     ) {
         val timestamp = System.currentTimeMillis()
         val messageId = "user-${UUID.randomUUID()}"
+        val parts =
+            buildList {
+                add(OpenCodePart("$messageId-text", sessionId, messageId, "text", text = prompt))
+                attachments.forEachIndexed { index, attachment ->
+                    add(
+                        OpenCodePart(
+                            id = "$messageId-file-$index",
+                            sessionId = sessionId,
+                            messageId = messageId,
+                            type = "file",
+                            filename = attachment.filename,
+                            mime = attachment.mime,
+                            url = attachment.url,
+                        ),
+                    )
+                }
+            }
         messageStore.upsert(
             sessionId,
             OpenCodeMessage(
@@ -443,7 +509,7 @@ class ClaudeCodeRuntime(
                         role = "user",
                         time = OpenCodeTime(timestamp, timestamp),
                     ),
-                parts = listOf(OpenCodePart("$messageId-text", sessionId, messageId, "text", text = prompt)),
+                parts = parts,
             ),
         )
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
@@ -256,6 +256,7 @@ class ClaudeCodeTarget(
                 permissionMode = ClaudePermissionMode.fromCliValue(record.permissionMode),
                 model = model,
                 effort = effort,
+                attachments = request.attachments,
             ).getOrThrow()
         }
     }


### PR DESCRIPTION
## Problem

Sending an image to the **on-device Claude Code** agent silently did nothing:

1. **Images never reached Claude.** `ClaudeCodeTarget.sendMessage` received `request.attachments` but only forwarded `request.text` to the runtime — the attachments were dropped. Only OpenCode's remote path (`parts` → `file` blocks) handled images.
2. **The image disappeared from the chat once the send completed.** It showed briefly (the optimistic `imagePreviews` bitmaps) but vanished on the final transcript reload, because that reload produced a message with no previews and the bubble never rendered image *attachments* from the transcript.

## Fix

- **`ClaudeCodeTarget`** — forward `request.attachments` to `runtime.send`.
- **`ClaudeCodeRuntime`** — `send()` accepts attachments; `userMessage()` now builds the Anthropic Messages API content shape the stream-json CLI expects on stdin, turning base64 `data:` URLs into `image` / `document` (PDF) blocks. Types the model can't inline are dropped rather than sent as blocks that would make the CLI reject the whole turn. `recordUserMessage()` records attachments as `file` parts so they persist in the transcript.
- **`ChatMessageComponents`** — render image attachments by decoding their data URL (`decodeDataUrlImage`), falling back to the transient `imagePreviews` when the URL isn't an inlineable data URL. Images now survive a completed send and a session reopen.
- **`ChatViewModel`** — re-attach in-memory previews on the final reload (as the polling loop already does), so runtimes whose attachment URLs aren't data URLs (e.g. OpenCode) also keep showing the just-sent image.

## Antigravity

Checked as well: `agy` is driven one-shot via `--print "<text>"` and has no input channel for images (stream-json is output-only), so inline image input isn't possible there. Left unchanged.

## Testing

Not built in this environment (no Android SDK). Please verify with `./gradlew :app:assembleDebug` and a manual send of an image to Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)