### PR TITLE
fix: refresh Claude Code apk signing key on update

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
@@ -51,6 +51,16 @@ object ClaudeCodeInstaller {
     private val UPDATE_SCRIPT =
         """
         set -e
+        # Refresh the signing key on every update so a rotated or expired key cannot strand an
+        # upgrade behind an untrusted repository (every version then resolves as masked in: stable).
+        # If the download fails, keep the existing key so a transient outage does not block an
+        # otherwise-valid update; only abort when there is no key to fall back to.
+        if /usr/bin/wget -qO $SIGNING_KEY_PATH.new $SIGNING_KEY_URL; then
+          mv -f $SIGNING_KEY_PATH.new $SIGNING_KEY_PATH
+        elif [ ! -s $SIGNING_KEY_PATH ]; then
+          echo "claude-code signing key is missing and could not be downloaded" >&2
+          exit 1
+        fi
         /sbin/apk update
         /sbin/apk add --no-cache --upgrade claude-code
         $CLAUDE_BINARY --version
@@ -235,7 +245,12 @@ object ClaudeCodeInstaller {
     ): String {
         val text = log.takeIf(File::isFile)?.readText().orEmpty()
         val errors = extractApkErrors(text)
+        val head = text.take(1_500)
         val tail = text.takeLast(2_000)
+        // The tail is often filled by the post-failure `apk policy` diagnostics, which pushes the
+        // `apk update` WARNING/ERROR lines (emitted early) out of view. Include the head, skipping it
+        // only when the log is short enough that head and tail already overlap.
+        val showHead = text.length > head.length + tail.length
         val primary =
             errors.lineSequence().firstOrNull()
                 ?: tail.lineSequence().map(String::trim).firstOrNull { it.isNotBlank() }.orEmpty()
@@ -249,6 +264,10 @@ object ClaudeCodeInstaller {
             if (errors.isNotBlank()) {
                 append('\n')
                 append(errors)
+            }
+            if (showHead) {
+                append("\n--- log head ---\n")
+                append(head)
             }
             append("\n--- log tail ---\n")
             append(tail)


### PR DESCRIPTION
## Problem
Updating Claude Code from the Workspaces card failed with `Claude Code update failed (exit 1): 1 error; ... in 392 packages`, and the in-app log showed only a list of versions (e.g. `2.1.212-r1: https://.../stable`) ending in `lib/apk/db/installed`.

That list is the post-failure `apk policy` diagnostic filling the log tail. Every version being listed as available only from `stable` (and the installed one from `lib/apk/db/installed`) means the `stable` repository was not trusted/usable by apk, so the solver masked every version and `--upgrade` could not resolve anything.

## Cause
The signing key is fetched only on install (`INSTALL_SCRIPT`), never on update (`UPDATE_SCRIPT`). A rotated or expired key therefore leaves the repository untrusted on every subsequent update, reproducing the same single error each time. Separately, the real `apk update` WARNING/ERROR is emitted early in the log but was hidden because the failure message only kept the tail.

## Fix
- `UPDATE_SCRIPT` now refreshes the apk signing key before `apk update`, falling back to the existing key if the download fails (only aborting when no key exists), so a rotated/expired key no longer strands upgrades.
- Failure messages now include the log head (when it does not overlap the tail), so the early apk WARNING/ERROR is visible in-app instead of being pushed out by the `apk policy` diagnostics.

## Verification
- `./gradlew spotlessCheck` passes (detekt has no app sources; `ktlint_standard_max-line-length` is disabled).
- `compileDebugKotlin`/`lintDebug`/`testDebugUnitTest` could not run here (no Android SDK in this environment); the change is standard Kotlin string/`buildString` code plus a shell heredoc.