### PR TITLE
feat: Add Markdown image parsing and rendering support in chat

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -517,16 +517,36 @@ internal fun decodeImageFromUrlOrPath(url: String): android.graphics.Bitmap? {
     if (url.startsWith("data:")) {
         return decodeDataImage(url)
     }
-    val path = if (url.startsWith("file://")) url.substring(7) else url
-    if (path.startsWith("/")) {
-        return runCatching { android.graphics.BitmapFactory.decodeFile(path) }.getOrNull()
-    }
-    return null
+    val rawPath = if (url.startsWith("file://")) url.removePrefix("file://") else url
+    val path = if (rawPath.startsWith("/")) rawPath else "/$rawPath"
+    if (!java.io.File(path).exists()) return null
+    return runCatching {
+        val options = android.graphics.BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+        }
+        android.graphics.BitmapFactory.decodeFile(path, options)
+        if (options.outWidth <= 0 || options.outHeight <= 0) return null
+
+        val maxDim = 1024
+        var sampleSize = 1
+        while (options.outWidth / sampleSize > maxDim || options.outHeight / sampleSize > maxDim) {
+            sampleSize *= 2
+        }
+        val decodeOptions = android.graphics.BitmapFactory.Options().apply {
+            inSampleSize = sampleSize
+        }
+        android.graphics.BitmapFactory.decodeFile(path, decodeOptions)
+    }.getOrNull()
 }
 
 @Composable
 private fun MarkdownImageView(image: MarkdownInline.Image) {
-    val bitmap = remember(image.url) { decodeImageFromUrlOrPath(image.url) }
+    val bitmapState = androidx.compose.runtime.produceState<android.graphics.Bitmap?>(initialValue = null, key1 = image.url) {
+        value = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            decodeImageFromUrlOrPath(image.url)
+        }
+    }
+    val bitmap = bitmapState.value
     if (bitmap != null) {
         Image(
             bitmap = bitmap.asImageBitmap(),
@@ -651,6 +671,13 @@ private fun renderInline(
                     withStyle(
                         SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
                     ) { append(inline.text) }
+                    addStringAnnotation("link", inline.url, start, length)
+                }
+                is MarkdownInline.Image -> {
+                    val start = length
+                    withStyle(
+                        SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
+                    ) { append(inline.text.ifBlank { "[Image]" }) }
                     addStringAnnotation("link", inline.url, start, length)
                 }
             }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -354,14 +354,30 @@ private fun MarkdownText(
                         codeBackground = codeInlineBackground,
                         onFilePathClick = onFilePathClick,
                     )
-                is MarkdownBlock.Paragraph ->
-                    InlineText(
-                        inlines = block.inlines,
-                        style = bodyStyle,
-                        linkColor = linkColor,
-                        codeBackground = codeInlineBackground,
-                        onFilePathClick = onFilePathClick,
-                    )
+                is MarkdownBlock.Paragraph -> {
+                    val currentInlines = mutableListOf<MarkdownInline>()
+                    fun flushInlines() {
+                        if (currentInlines.isNotEmpty()) {
+                            InlineText(
+                                inlines = currentInlines.toList(),
+                                style = bodyStyle,
+                                linkColor = linkColor,
+                                codeBackground = codeInlineBackground,
+                                onFilePathClick = onFilePathClick,
+                            )
+                            currentInlines.clear()
+                        }
+                    }
+                    block.inlines.forEach { inline ->
+                        if (inline is MarkdownInline.Image) {
+                            flushInlines()
+                            MarkdownImageView(inline)
+                        } else {
+                            currentInlines += inline
+                        }
+                    }
+                    flushInlines()
+                }
                 is MarkdownBlock.CodeBlock ->
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
@@ -495,6 +511,54 @@ private fun decodeDataImage(url: String): android.graphics.Bitmap? {
         val bytes = android.util.Base64.decode(data.base64, android.util.Base64.DEFAULT)
         android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
     }.getOrNull()
+}
+
+internal fun decodeImageFromUrlOrPath(url: String): android.graphics.Bitmap? {
+    if (url.startsWith("data:")) {
+        return decodeDataImage(url)
+    }
+    val path = if (url.startsWith("file://")) url.substring(7) else url
+    if (path.startsWith("/")) {
+        return runCatching { android.graphics.BitmapFactory.decodeFile(path) }.getOrNull()
+    }
+    return null
+}
+
+@Composable
+private fun MarkdownImageView(image: MarkdownInline.Image) {
+    val bitmap = remember(image.url) { decodeImageFromUrlOrPath(image.url) }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = image.text.ifBlank { stringResource(R.string.cd_image_preview) },
+            modifier =
+                Modifier
+                    .widthIn(max = 320.dp)
+                    .heightIn(max = 320.dp)
+                    .padding(vertical = 4.dp),
+            contentScale = ContentScale.Fit,
+        )
+    } else {
+        Surface(
+            shape = RoundedCornerShape(10.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+            modifier = Modifier.padding(vertical = 4.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.padding(10.dp),
+            ) {
+                Icon(Icons.Default.ImageIcon, contentDescription = null)
+                Text(
+                    text = image.text.ifBlank { image.url },
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -62,6 +63,9 @@ import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.ui.theme.AndCodeWarning
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -356,6 +360,8 @@ private fun MarkdownText(
                     )
                 is MarkdownBlock.Paragraph -> {
                     val currentInlines = mutableListOf<MarkdownInline>()
+
+                    @Composable
                     fun flushInlines() {
                         if (currentInlines.isNotEmpty()) {
                             InlineText(
@@ -513,18 +519,19 @@ private fun decodeDataImage(url: String): android.graphics.Bitmap? {
     }.getOrNull()
 }
 
-internal fun decodeImageFromUrlOrPath(url: String): android.graphics.Bitmap? {
+internal fun decodeImageFromUrlOrPath(url: String): Bitmap? {
     if (url.startsWith("data:")) {
         return decodeDataImage(url)
     }
     val rawPath = if (url.startsWith("file://")) url.removePrefix("file://") else url
     val path = if (rawPath.startsWith("/")) rawPath else "/$rawPath"
-    if (!java.io.File(path).exists()) return null
+    if (!File(path).exists()) return null
     return runCatching {
-        val options = android.graphics.BitmapFactory.Options().apply {
-            inJustDecodeBounds = true
-        }
-        android.graphics.BitmapFactory.decodeFile(path, options)
+        val options =
+            BitmapFactory.Options().apply {
+                inJustDecodeBounds = true
+            }
+        BitmapFactory.decodeFile(path, options)
         if (options.outWidth <= 0 || options.outHeight <= 0) return null
 
         val maxDim = 1024
@@ -532,20 +539,23 @@ internal fun decodeImageFromUrlOrPath(url: String): android.graphics.Bitmap? {
         while (options.outWidth / sampleSize > maxDim || options.outHeight / sampleSize > maxDim) {
             sampleSize *= 2
         }
-        val decodeOptions = android.graphics.BitmapFactory.Options().apply {
-            inSampleSize = sampleSize
-        }
-        android.graphics.BitmapFactory.decodeFile(path, decodeOptions)
+        val decodeOptions =
+            BitmapFactory.Options().apply {
+                inSampleSize = sampleSize
+            }
+        BitmapFactory.decodeFile(path, decodeOptions)
     }.getOrNull()
 }
 
 @Composable
 private fun MarkdownImageView(image: MarkdownInline.Image) {
-    val bitmapState = androidx.compose.runtime.produceState<android.graphics.Bitmap?>(initialValue = null, key1 = image.url) {
-        value = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            decodeImageFromUrlOrPath(image.url)
+    val bitmapState =
+        produceState<Bitmap?>(initialValue = null, key1 = image.url) {
+            value =
+                withContext(Dispatchers.IO) {
+                    decodeImageFromUrlOrPath(image.url)
+                }
         }
-    }
     val bitmap = bitmapState.value
     if (bitmap != null) {
         Image(

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/MarkdownLite.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/MarkdownLite.kt
@@ -14,6 +14,8 @@ sealed interface MarkdownInline {
     data class Code(override val text: String) : MarkdownInline
 
     data class Link(override val text: String, val url: String) : MarkdownInline
+
+    data class Image(override val text: String, val url: String) : MarkdownInline
 }
 
 sealed interface MarkdownBlock {
@@ -40,6 +42,7 @@ object MarkdownLite {
             "`([^`]+)`" +
                 "|\\*\\*([^*]+)\\*\\*" +
                 "|~~([^~]+)~~" +
+                "|!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)" +
                 "|\\[([^\\]]+)\\]\\(([^)\\s]+)\\)" +
                 "|\\*([^*]+)\\*" +
                 "|(?<![\\w@])(https?://[A-Za-z0-9][A-Za-z0-9._~:/?#\\[\\]@!&'()*+,;=%-]*)",
@@ -152,14 +155,17 @@ object MarkdownLite {
             val code = match.groups[1]?.value
             val bold = match.groups[2]?.value
             val strike = match.groups[3]?.value
-            val linkText = match.groups[4]?.value
-            val linkUrl = match.groups[5]?.value
-            val italic = match.groups[6]?.value
-            val bareUrl = match.groups[7]?.value
+            val imageAlt = match.groups[4]?.value
+            val imageUrl = match.groups[5]?.value
+            val linkText = match.groups[6]?.value
+            val linkUrl = match.groups[7]?.value
+            val italic = match.groups[8]?.value
+            val bareUrl = match.groups[9]?.value
             when {
                 code != null -> result += MarkdownInline.Code(code)
                 bold != null -> result += MarkdownInline.Bold(bold)
                 strike != null -> result += MarkdownInline.Strikethrough(strike)
+                imageAlt != null && imageUrl != null -> result += MarkdownInline.Image(imageAlt, imageUrl)
                 linkText != null && linkUrl != null -> result += MarkdownInline.Link(linkText, linkUrl)
                 italic != null -> result += MarkdownInline.Italic(italic)
                 bareUrl != null -> {

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/MarkdownLiteTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/MarkdownLiteTest.kt
@@ -203,4 +203,19 @@ class MarkdownLiteTest {
             paragraph.inlines,
         )
     }
+
+    @Test
+    fun `markdown image is parsed`() {
+        val paragraph =
+            MarkdownLite.parse("Look at ![rabbit](/path/to/rabbit.png) image")
+                .single() as MarkdownBlock.Paragraph
+        assertEquals(
+            listOf(
+                MarkdownInline.Plain("Look at "),
+                MarkdownInline.Image("rabbit", "/path/to/rabbit.png"),
+                MarkdownInline.Plain(" image"),
+            ),
+            paragraph.inlines,
+        )
+    }
 }


### PR DESCRIPTION
Added support for parsing and rendering markdown images in chat using MarkdownLite and ChatMessageComponents.