### PR TITLE
fix: resolve markdown image guest paths to host workspace

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -519,13 +519,34 @@ private fun decodeDataImage(url: String): android.graphics.Bitmap? {
     }.getOrNull()
 }
 
-internal fun decodeImageFromUrlOrPath(url: String): Bitmap? {
+internal fun resolveImageFile(
+    url: String,
+    workspaceHostDir: File,
+): File? {
+    if (url.startsWith("data:") || url.startsWith("http://") || url.startsWith("https://")) {
+        return null
+    }
+    val raw = if (url.startsWith("file://")) url.removePrefix("file://") else url
+    val candidates =
+        buildList {
+            when {
+                raw == "/workspace" -> add(workspaceHostDir)
+                raw.startsWith("/workspace/") -> add(File(workspaceHostDir, raw.removePrefix("/workspace/")))
+            }
+            add(File(raw))
+            if (!raw.startsWith("/")) add(File(workspaceHostDir, raw))
+        }
+    return candidates.distinctBy { it.path }.firstOrNull { it.exists() }
+}
+
+internal fun decodeImageFromUrlOrPath(
+    url: String,
+    workspaceHostDir: File,
+): Bitmap? {
     if (url.startsWith("data:")) {
         return decodeDataImage(url)
     }
-    val rawPath = if (url.startsWith("file://")) url.removePrefix("file://") else url
-    val path = if (rawPath.startsWith("/")) rawPath else "/$rawPath"
-    if (!File(path).exists()) return null
+    val path = resolveImageFile(url, workspaceHostDir)?.absolutePath ?: return null
     return runCatching {
         val options =
             BitmapFactory.Options().apply {
@@ -549,11 +570,12 @@ internal fun decodeImageFromUrlOrPath(url: String): Bitmap? {
 
 @Composable
 private fun MarkdownImageView(image: MarkdownInline.Image) {
+    val workspaceHostDir = remember { File(LocalContext.current.filesDir, "runtime/workspace") }
     val bitmapState =
         produceState<Bitmap?>(initialValue = null, key1 = image.url) {
             value =
                 withContext(Dispatchers.IO) {
-                    decodeImageFromUrlOrPath(image.url)
+                    decodeImageFromUrlOrPath(image.url, workspaceHostDir)
                 }
         }
     val bitmap = bitmapState.value

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -570,7 +570,8 @@ internal fun decodeImageFromUrlOrPath(
 
 @Composable
 private fun MarkdownImageView(image: MarkdownInline.Image) {
-    val workspaceHostDir = remember { File(LocalContext.current.filesDir, "runtime/workspace") }
+    val context = LocalContext.current
+    val workspaceHostDir = remember { File(context.filesDir, "runtime/workspace") }
     val bitmapState =
         produceState<Bitmap?>(initialValue = null, key1 = image.url) {
             value =

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ResolveImageFileTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ResolveImageFileTest.kt
@@ -1,0 +1,46 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ResolveImageFileTest {
+    @get:Rule
+    val folder = TemporaryFolder()
+
+    @Test
+    fun `guest workspace path maps to host workspace dir`() {
+        val image = File(folder.root, "rabbit.png").apply { writeText("x") }
+        assertEquals(image, resolveImageFile("/workspace/rabbit.png", folder.root))
+    }
+
+    @Test
+    fun `absolute host path is resolved as-is`() {
+        val image = folder.newFile("host.png").apply { writeText("x") }
+        assertEquals(image, resolveImageFile(image.absolutePath, folder.root))
+    }
+
+    @Test
+    fun `relative path is resolved against workspace dir`() {
+        val image =
+            File(folder.root, "sub/img.png").apply {
+                parentFile.mkdirs()
+                writeText("x")
+            }
+        assertEquals(image, resolveImageFile("sub/img.png", folder.root))
+    }
+
+    @Test
+    fun `data and http urls are not file paths`() {
+        assertNull(resolveImageFile("data:image/png;base64,abc", folder.root))
+        assertNull(resolveImageFile("https://example.com/a.png", folder.root))
+    }
+
+    @Test
+    fun `missing file returns null`() {
+        assertNull(resolveImageFile("/workspace/missing.png", folder.root))
+    }
+}


### PR DESCRIPTION
Markdown images rendered as placeholders because the model emits guest sandbox paths (e.g. `/workspace/rabbit.png`) that do not exist on the Android host. PRoot bind-mounts the host workspace dir to `/workspace` inside the sandbox, so the host path is `filesDir/runtime/workspace/<rel>`.

Add `resolveImageFile` that maps guest `/workspace/...` paths to the host workspace dir while still accepting absolute host paths and workspace-relative paths. `MarkdownImageView` now passes the host workspace dir through. Unit tests cover the mapping.