### PR TITLE
debug: show resolved image path candidates in debug builds

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import com.yugahashimoto.andcode.BuildConfig
 import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
@@ -519,24 +520,42 @@ private fun decodeDataImage(url: String): android.graphics.Bitmap? {
     }.getOrNull()
 }
 
+internal fun imageFileCandidates(
+    url: String,
+    workspaceHostDir: File,
+): List<File> {
+    if (url.startsWith("data:") || url.startsWith("http://") || url.startsWith("https://")) {
+        return emptyList()
+    }
+    val raw = if (url.startsWith("file://")) url.removePrefix("file://") else url
+    return buildList {
+        when {
+            raw == "/workspace" -> add(workspaceHostDir)
+            raw.startsWith("/workspace/") -> add(File(workspaceHostDir, raw.removePrefix("/workspace/")))
+        }
+        add(File(raw))
+        if (!raw.startsWith("/")) add(File(workspaceHostDir, raw))
+    }
+        .distinctBy { it.path }
+}
+
 internal fun resolveImageFile(
     url: String,
     workspaceHostDir: File,
-): File? {
-    if (url.startsWith("data:") || url.startsWith("http://") || url.startsWith("https://")) {
-        return null
-    }
-    val raw = if (url.startsWith("file://")) url.removePrefix("file://") else url
-    val candidates =
-        buildList {
-            when {
-                raw == "/workspace" -> add(workspaceHostDir)
-                raw.startsWith("/workspace/") -> add(File(workspaceHostDir, raw.removePrefix("/workspace/")))
-            }
-            add(File(raw))
-            if (!raw.startsWith("/")) add(File(workspaceHostDir, raw))
+): File? = imageFileCandidates(url, workspaceHostDir).firstOrNull { it.exists() }
+
+internal fun debugImageResolution(
+    url: String,
+    workspaceHostDir: File,
+): String {
+    val candidates = imageFileCandidates(url, workspaceHostDir)
+    val detail =
+        if (candidates.isEmpty()) {
+            "(non-file url)"
+        } else {
+            candidates.joinToString("; ") { "${it.path}=${it.exists()}" }
         }
-    return candidates.distinctBy { it.path }.firstOrNull { it.exists() }
+    return "url=$url | $detail"
 }
 
 internal fun decodeImageFromUrlOrPath(
@@ -580,6 +599,7 @@ private fun MarkdownImageView(image: MarkdownInline.Image) {
                 }
         }
     val bitmap = bitmapState.value
+    val debugInfo = if (BuildConfig.DEBUG) debugImageResolution(image.url, workspaceHostDir) else null
     if (bitmap != null) {
         Image(
             bitmap = bitmap.asImageBitmap(),
@@ -604,10 +624,10 @@ private fun MarkdownImageView(image: MarkdownInline.Image) {
             ) {
                 Icon(Icons.Default.ImageIcon, contentDescription = null)
                 Text(
-                    text = image.text.ifBlank { image.url },
+                    text = debugInfo ?: image.text.ifBlank { image.url },
                     style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                    maxLines = if (debugInfo != null) Int.MAX_VALUE else 1,
+                    overflow = if (debugInfo != null) TextOverflow.Clip else TextOverflow.Ellipsis,
                 )
             }
         }


### PR DESCRIPTION
Observability-only change (DEBUG builds only; release behavior unchanged).

Markdown images still render as placeholders because the actual url the model emits has not been observed on device. The v1.1.15 `/workspace` -> host mapping was a guess that did not match.

In debug builds the placeholder now prints the raw image url plus every host-path candidate with its `exists()` result, e.g. `url=/workspace/x.png | /data/.../runtime/workspace/x.png=false; /workspace/x.png=false`. Release builds keep the original alt-text placeholder.

Install the debug APK from this PR's artifact (or the next release's `and-code-vX-debug.apk`), reproduce, and read the placeholder text to learn the real path shape. The confirmed mapping fix follows in a separate PR; this diagnostic stays behind `BuildConfig.DEBUG`.