### PR TITLE
fix: dismiss keyboard and enable edge swipe for the navigation drawer

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -88,7 +90,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -101,6 +102,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.testTag
@@ -203,7 +205,6 @@ fun ChatHomeScreen(
     val coroutineScope = rememberCoroutineScope()
     var showSlashCommands by remember { mutableStateOf(false) }
     var showSidePanel by remember { mutableStateOf(false) }
-    var dragOffset by remember { mutableFloatStateOf(0f) }
     val attachedImages = remember { mutableStateListOf<Bitmap>() }
     DisposableEffect(Unit) {
         onDispose {
@@ -283,19 +284,31 @@ fun ChatHomeScreen(
         modifier =
             Modifier
                 .fillMaxSize()
-                .pointerInput(Unit) {
-                    detectHorizontalDragGestures { change, dragAmount ->
-                        val atEdge = change.position.x > size.width - 80f || showSidePanel
-                        if (!atEdge) return@detectHorizontalDragGestures
-                        change.consume()
-                        dragOffset += dragAmount
-                        if (dragOffset < -100f && change.position.x > size.width - 80f) {
-                            showSidePanel = true
-                            dragOffset = 0f
-                        }
-                        if (dragOffset > 100f && showSidePanel) {
-                            showSidePanel = false
-                            dragOffset = 0f
+                .pointerInput(showSidePanel) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val onRightEdge = down.position.x > size.width - 80f || showSidePanel
+                        if (!onRightEdge) return@awaitEachGesture
+                        awaitHorizontalTouchSlopOrCancellation(down.id) { change, _ ->
+                            change.consume()
+                        } ?: return@awaitEachGesture
+                        var offset = 0f
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                            if (!change.pressed) break
+                            val dragAmount = change.positionChange().x
+                            if (dragAmount == 0f) continue
+                            change.consume()
+                            offset += dragAmount
+                            if (offset < -100f) {
+                                showSidePanel = true
+                                break
+                            }
+                            if (offset > 100f && showSidePanel) {
+                                showSidePanel = false
+                                break
+                            }
                         }
                     }
                 },

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -129,6 +130,7 @@ fun AndCodeApp(
     targetSessionId: String? = null,
 ) {
     val context = LocalContext.current
+    val keyboardController = LocalSoftwareKeyboardController.current
     val app = context.applicationContext as AndCodeApplication
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -552,8 +554,17 @@ fun AndCodeApp(
                 }
         }
 
+    fun openDrawer() {
+        keyboardController?.hide()
+        drawerScope.launch { drawerState.open() }
+    }
+
     fun closeDrawer() {
         drawerScope.launch { drawerState.close() }
+    }
+
+    LaunchedEffect(drawerState.isOpen) {
+        if (drawerState.isOpen) keyboardController?.hide()
     }
 
     AndCodeTheme(
@@ -830,7 +841,7 @@ fun AndCodeApp(
                         onRefreshCatalog = app.catalogRepository::refreshProvidersOnly,
                         onOpenDrawer = {
                             app.catalogRepository.refreshSessionsOnly()
-                            drawerScope.launch { drawerState.open() }
+                            openDrawer()
                         },
                         subagents = subagentInfos,
                         onSubagentClick = { childSessionId ->
@@ -863,7 +874,7 @@ fun AndCodeApp(
                         }
                     },
                     appVersion = appVersion,
-                    onOpenDrawer = { drawerScope.launch { drawerState.open() } },
+                    onOpenDrawer = { openDrawer() },
                     onOpenAssistantSettings = onOpenAssistantSettings,
                     assistantActive = { assistantActive },
                     onShowDiagnostics = { showDiagnostics = true },


### PR DESCRIPTION
## Summary

- **Dismiss the keyboard when the drawer opens.** Pressing the menu button while the composer is focused left the keyboard up, covering the drawer. The drawer now hides the IME on open, whether opened via the toolbar button or the edge swipe.
- **Enable the edge-swipe gesture on the chat screen.** The chat screen's right-edge side-panel gesture handler used `detectHorizontalDragGestures`, which consumed *all* horizontal drags across the screen, so the navigation drawer's swipe-to-open never won the gesture arena on chat. It now only claims drags that start on the right edge (or while the side panel is open), letting left-edge swipes open the drawer.

## Changes

- `app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt`
  - Added `openDrawer()` which hides the keyboard before opening the drawer; both chat and settings `onOpenDrawer` callbacks use it.
  - Added a `LaunchedEffect` on the drawer state so the keyboard is dismissed whenever the drawer opens (covers gesture-opened drawers too).
- `app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt`
  - Replaced `detectHorizontalDragGestures` with an `awaitEachGesture` handler that only claims horizontal drags starting on the right edge (or when the side panel is open). Left-edge drags propagate to the drawer.