### PR TITLE
feat: expose AndCode context to local agents

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -48,6 +48,7 @@ class LocalRuntimeProcessLauncher(
         beforeStart(runtime)
         val rootfs = runtime.rootfs
         val suite = runtime.commandSuite
+        ensureAndCodeAgentContext(rootfs)
         val logs = File(runtimeDirectory, "logs").apply { mkdirs() }
         val logFile = File(logs, "opencode-local.log")
         truncateLogFile(logFile, maxLogBytes)
@@ -339,6 +340,7 @@ internal fun localRuntimeEnvironment(
         put("XDG_DATA_HOME", "/root/.local/share")
         put("XDG_STATE_HOME", "/root/.local/state")
         put("OPENCODE_CONFIG_DIR", "/root/.config/opencode")
+        put("OPENCODE_CONFIG_CONTENT", AND_CODE_OPENCODE_CONFIG_CONTENT)
         put("OPENCODE_DISABLE_AUTOUPDATE", "true")
         put("USE_BUILTIN_RIPGREP", "0")
         githubToken?.takeIf(String::isNotBlank)?.let {
@@ -346,3 +348,31 @@ internal fun localRuntimeEnvironment(
             put("GH_TOKEN", it)
         }
     }
+
+private const val AND_CODE_OPENCODE_CONFIG_CONTENT =
+    "{\"instructions\":[\"/root/.config/opencode/and-code-context.md\"]}"
+
+private const val AND_CODE_AGENT_CONTEXT = """
+You are running inside and-code (AndCode), a native Android application that hosts coding agents.
+
+Runtime context:
+- This is an Android/PRoot environment, not a normal desktop Linux machine.
+- The guest workspace is mounted at /workspace and is the intended location for repository work.
+- Prefer portable, non-interactive commands and do not assume systemd, Docker, a graphical desktop, or unrestricted host access.
+- The user is interacting with you through and-code's mobile UI, so keep explanations and requested actions clear and actionable.
+
+Treat these facts as execution context, not as a request to modify the and-code application itself unless the user explicitly asks for that.
+""".trimIndent()
+
+internal fun ensureAndCodeAgentContext(rootfs: File) {
+    listOf(
+        "root/.config/opencode/and-code-context.md",
+        "root/.claude/CLAUDE.md",
+        "root/.gemini/GEMINI.md",
+    ).forEach { relativePath ->
+        File(rootfs, relativePath).apply {
+            parentFile?.mkdirs()
+            writeText(AND_CODE_AGENT_CONTEXT)
+        }
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -352,7 +352,8 @@ internal fun localRuntimeEnvironment(
 private const val AND_CODE_OPENCODE_CONFIG_CONTENT =
     "{\"instructions\":[\"/root/.config/opencode/and-code-context.md\"]}"
 
-private const val AND_CODE_AGENT_CONTEXT = """
+private val AND_CODE_AGENT_CONTEXT =
+    """
 You are running inside and-code (AndCode), a native Android application that hosts coding agents.
 
 Runtime context:
@@ -362,7 +363,7 @@ Runtime context:
 - The user is interacting with you through and-code's mobile UI, so keep explanations and requested actions clear and actionable.
 
 Treat these facts as execution context, not as a request to modify the and-code application itself unless the user explicitly asks for that.
-""".trimIndent()
+    """.trimIndent()
 
 internal fun ensureAndCodeAgentContext(rootfs: File) {
     listOf(

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncherTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncherTest.kt
@@ -36,6 +36,28 @@ class LocalRuntimeProcessLauncherTest {
         assertEquals("/android/proot-tmp", environment["PROOT_TMP_DIR"])
         assertEquals("/native/lib", environment["LD_LIBRARY_PATH"])
         assertTrue(environment["OPENCODE_DISABLE_AUTOUPDATE"] == "true")
+        assertEquals(
+            "{\"instructions\":[\"/root/.config/opencode/and-code-context.md\"]}",
+            environment["OPENCODE_CONFIG_CONTENT"],
+        )
+    }
+
+    @Test
+    fun `guest OpenCode context identifies the Android host environment`() {
+        val rootfs = temporaryFolder.newFolder("rootfs")
+
+        ensureAndCodeAgentContext(rootfs)
+
+        listOf(
+            "root/.config/opencode/and-code-context.md",
+            "root/.claude/CLAUDE.md",
+            "root/.gemini/GEMINI.md",
+        ).forEach { relativePath ->
+            val context = File(rootfs, relativePath).readText()
+            assertTrue(context.contains("and-code (AndCode)"))
+            assertTrue(context.contains("Android/PRoot"))
+            assertTrue(context.contains("/workspace"))
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- inject AndCode Android/PRoot context into local OpenCode, Claude Code, and Antigravity environments
- add coverage for the generated guest context files and OpenCode config

## Testing
- 
-  (blocked: Android SDK is not configured in the environment)