### PR TITLE
refactor: share local agent context source

### DIFF
--- a/app/src/main/assets/and-code-agent-context.md
+++ b/app/src/main/assets/and-code-agent-context.md
@@ -1,0 +1,9 @@
+You are running inside and-code (AndCode), a native Android application that hosts coding agents.
+
+Runtime context:
+- This is an Android/PRoot environment, not a normal desktop Linux machine.
+- The guest workspace is mounted at /workspace and is the intended location for repository work.
+- Prefer portable, non-interactive commands and do not assume systemd, Docker, a graphical desktop, or unrestricted host access.
+- The user is interacting with you through and-code's mobile UI, so keep explanations and requested actions clear and actionable.
+
+Treat these facts as execution context, not as a request to modify the and-code application itself unless the user explicitly asks for that.

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AndCodeAgentContext.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AndCodeAgentContext.kt
@@ -1,0 +1,44 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import android.content.Context
+import java.io.File
+
+internal const val AND_CODE_AGENT_CONTEXT_ASSET = "and-code-agent-context.md"
+
+private const val RUNTIME_CONTEXT_PATH = "root/.config/and-code/agent-context.md"
+
+private val AGENT_CONTEXT_PATHS =
+    listOf(
+        "root/.config/opencode/and-code-context.md",
+        "root/.claude/CLAUDE.md",
+        "root/.gemini/GEMINI.md",
+    )
+
+internal fun ensureAndCodeAgentContext(
+    rootfs: File,
+    context: Context,
+) {
+    val agentContext =
+        context.assets.open(AND_CODE_AGENT_CONTEXT_ASSET).use { input ->
+            input.readBytes()
+        }
+    installAndCodeAgentContext(rootfs, agentContext)
+}
+
+internal fun installAndCodeAgentContext(
+    rootfs: File,
+    agentContext: ByteArray,
+) {
+    val source = File(rootfs, RUNTIME_CONTEXT_PATH)
+    source.parentFile?.mkdirs()
+    if (!source.isFile || !source.readBytes().contentEquals(agentContext)) {
+        source.writeBytes(agentContext)
+    }
+    AGENT_CONTEXT_PATHS.forEach { relativePath ->
+        val target = File(rootfs, relativePath)
+        if (!target.isFile || !target.readBytes().contentEquals(agentContext)) {
+            target.parentFile?.mkdirs()
+            source.copyTo(target, overwrite = true)
+        }
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
@@ -133,6 +133,7 @@ class LocalRuntimeInstaller(
                         null
                     }
                 if (antigravityRootfs != null) {
+                    ensureAndCodeAgentContext(antigravityRootfs, context)
                     copyCaCertificates(rootfs, antigravityRootfs)
                     // Keep the Android-vision tool surface added for Claude/OpenCode available
                     // to agy's Debian tool runner as well. The scripts still fail closed when adb
@@ -143,6 +144,7 @@ class LocalRuntimeInstaller(
                 // the whole environment directory, so without this the user is signed out of every
                 // agent whenever another one is added or the runtime is reinstalled.
                 carryOverHomeDirectory(File(active, "rootfs"), rootfs)
+                ensureAndCodeAgentContext(rootfs, context)
                 onShared(0.91f, context.getString(R.string.install_step_installing_dev_tools))
                 installDevelopmentTools(rootfs, commandSuite)
                 if (LocalAgent.CLAUDE_CODE in requestedAgents) {
@@ -230,6 +232,9 @@ class LocalRuntimeInstaller(
                 File(rootfs, "usr/local/bin/opencode").takeIf { it.isFile },
                 File(active, "antigravity-rootfs").takeIf { metadata.has(LocalAgent.ANTIGRAVITY) && it.isDirectory },
             )
+        }?.also { installed ->
+            ensureAndCodeAgentContext(installed.rootfs, context)
+            installed.antigravityRootfs?.let { ensureAndCodeAgentContext(it, context) }
         }
 
     /** Metadata of the active install, without requiring the command suite to be extractable. */

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -48,7 +48,6 @@ class LocalRuntimeProcessLauncher(
         beforeStart(runtime)
         val rootfs = runtime.rootfs
         val suite = runtime.commandSuite
-        ensureAndCodeAgentContext(rootfs)
         val logs = File(runtimeDirectory, "logs").apply { mkdirs() }
         val logFile = File(logs, "opencode-local.log")
         truncateLogFile(logFile, maxLogBytes)

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncher.kt
@@ -351,29 +351,3 @@ internal fun localRuntimeEnvironment(
 
 private const val AND_CODE_OPENCODE_CONFIG_CONTENT =
     "{\"instructions\":[\"/root/.config/opencode/and-code-context.md\"]}"
-
-private val AND_CODE_AGENT_CONTEXT =
-    """
-You are running inside and-code (AndCode), a native Android application that hosts coding agents.
-
-Runtime context:
-- This is an Android/PRoot environment, not a normal desktop Linux machine.
-- The guest workspace is mounted at /workspace and is the intended location for repository work.
-- Prefer portable, non-interactive commands and do not assume systemd, Docker, a graphical desktop, or unrestricted host access.
-- The user is interacting with you through and-code's mobile UI, so keep explanations and requested actions clear and actionable.
-
-Treat these facts as execution context, not as a request to modify the and-code application itself unless the user explicitly asks for that.
-    """.trimIndent()
-
-internal fun ensureAndCodeAgentContext(rootfs: File) {
-    listOf(
-        "root/.config/opencode/and-code-context.md",
-        "root/.claude/CLAUDE.md",
-        "root/.gemini/GEMINI.md",
-    ).forEach { relativePath ->
-        File(rootfs, relativePath).apply {
-            parentFile?.mkdirs()
-            writeText(AND_CODE_AGENT_CONTEXT)
-        }
-    }
-}

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncherTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeProcessLauncherTest.kt
@@ -43,10 +43,10 @@ class LocalRuntimeProcessLauncherTest {
     }
 
     @Test
-    fun `guest OpenCode context identifies the Android host environment`() {
+    fun `guest agent context is copied to each agent's instruction path`() {
         val rootfs = temporaryFolder.newFolder("rootfs")
 
-        ensureAndCodeAgentContext(rootfs)
+        installAndCodeAgentContext(rootfs, AGENT_CONTEXT_FIXTURE.toByteArray())
 
         listOf(
             "root/.config/opencode/and-code-context.md",
@@ -54,10 +54,14 @@ class LocalRuntimeProcessLauncherTest {
             "root/.gemini/GEMINI.md",
         ).forEach { relativePath ->
             val context = File(rootfs, relativePath).readText()
-            assertTrue(context.contains("and-code (AndCode)"))
-            assertTrue(context.contains("Android/PRoot"))
-            assertTrue(context.contains("/workspace"))
+            assertEquals(AGENT_CONTEXT_FIXTURE, context)
         }
+    }
+
+    private companion object {
+        const val AGENT_CONTEXT_FIXTURE =
+            "You are running inside and-code (AndCode), a native Android application.\n" +
+                "This is an Android/PRoot environment with a /workspace mount."
     }
 
     @Test


### PR DESCRIPTION
## Summary
- move the AndCode runtime instructions into one packaged asset
- copy the shared source into OpenCode, Claude Code, and Antigravity instruction paths
- synchronize existing Alpine and Debian runtimes when they are loaded

## Testing
- `./gradlew :spotlessCheck`