### PR TITLE
fix: preserve PRoot hard links across runtime activation

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
@@ -62,6 +62,10 @@ object ClaudeCodeInstaller {
           exit 1
         fi
         /sbin/apk update
+        # Older runtime activations left PRoot's emulated hard links for unzip pointing at the
+        # removed staging directory. The host repairs those links before this script runs; clear
+        # apk's persisted broken-files flag so it no longer makes every package operation exit 1.
+        /sbin/apk fix unzip
         /sbin/apk add --no-cache --upgrade claude-code
         $CLAUDE_BINARY --version
         """.trimIndent()

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivation.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivation.kt
@@ -2,6 +2,8 @@ package com.yugahashimoto.andcode.runtime.local
 
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
 
 internal fun activateRuntimeEnvironment(
     active: File,
@@ -13,6 +15,7 @@ internal fun activateRuntimeEnvironment(
     require(staging.isDirectory) { "Runtime staging environment is missing" }
     requireSameParent(active, staging, rollback)
     deleteRecursivelyRequired(rollback)
+    normalizeRuntimeSymlinks(staging)
 
     var previousMoved = false
     var stagingActivated = false
@@ -38,6 +41,47 @@ internal fun activateRuntimeEnvironment(
         }
         throw error
     }
+}
+
+/**
+ * Makes PRoot's hard-link emulation survive an atomic environment directory move.
+ *
+ * `--link2symlink` represents hard links as absolute host paths. Packages installed while the
+ * rootfs is staged therefore retain `environment.staging` in their link targets after activation.
+ * Convert those links to relative paths, and also repair environments created by older releases.
+ */
+internal fun normalizeRuntimeSymlinks(environment: File) {
+    if (!environment.isDirectory) return
+    val marker = File(environment, ".internal-symlinks-relative")
+    if (marker.isFile) return
+
+    val current = environment.toPath().toAbsolutePath().normalize()
+    val possibleRoots =
+        listOf(
+            current,
+            current.resolveSibling("environment.staging"),
+            current.resolveSibling("environment.rollback"),
+            current.resolveSibling("environment.failed"),
+        )
+    Files.walk(current).use { paths ->
+        paths.filter(Files::isSymbolicLink).forEach { link ->
+            val target = Files.readSymbolicLink(link)
+            if (!target.isAbsolute) return@forEach
+            val normalizedTarget = target.normalize()
+            val oldRoot = possibleRoots.firstOrNull(normalizedTarget::startsWith) ?: return@forEach
+            val targetInCurrent = current.resolve(oldRoot.relativize(normalizedTarget))
+            replaceSymlink(link, link.parent.relativize(targetInCurrent))
+        }
+    }
+    marker.writeText("normalized\n")
+}
+
+private fun replaceSymlink(
+    link: Path,
+    target: Path,
+) {
+    Files.delete(link)
+    Files.createSymbolicLink(link, target)
 }
 
 internal fun recoverInterruptedRuntimeEnvironment(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
@@ -212,19 +212,20 @@ class LocalRuntimeInstaller(
      * complete, usable runtime and callers that need OpenCode check [InstalledRuntime.openCode].
      */
     fun installedRuntime(): InstalledRuntime? =
-        accessCoordinator.read {
+        accessCoordinator.write {
             val active = File(runtimeDirectory, "environment")
+            normalizeRuntimeSymlinks(active)
             val metadataFile = File(runtimeDirectory, METADATA_FILE)
             val rootfs = File(active, "rootfs")
-            if (!metadataFile.isFile || !rootfs.isDirectory) return@read null
+            if (!metadataFile.isFile || !rootfs.isDirectory) return@write null
             val metadata =
                 runCatching {
                     json.decodeFromString<LocalRuntimeMetadata>(metadataFile.readText())
-                }.getOrNull() ?: return@read null
+                }.getOrNull() ?: return@write null
             val commandSuite =
                 runCatching {
                     EmbeddedCommandSuite(context, runtimeDirectory, abi).ensureInstalled()
-                }.getOrNull() ?: return@read null
+                }.getOrNull() ?: return@write null
             InstalledRuntime(
                 metadata,
                 commandSuite,

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivationTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivationTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.nio.file.Files
 
 class LocalRuntimeEnvironmentActivationTest {
     private val json =
@@ -160,6 +161,50 @@ class LocalRuntimeEnvironmentActivationTest {
         assertEquals("new", active.resolve("marker.txt").readText())
         assertFalse(rollback.exists())
         assertFalse(staging.exists())
+    }
+
+    @Test
+    fun `activation converts proot hard link symlinks to relative paths`() {
+        val root = temporaryFolder.newFolder("runtime-links")
+        val active = root.resolve("environment")
+        val staging = root.resolve("environment.staging").apply { mkdirs() }
+        val bin = staging.resolve("rootfs/usr/bin").apply { mkdirs() }
+        val backing = bin.resolve(".l2s.unzip.0002").apply { writeText("binary") }
+        val intermediary = bin.resolve(".l2s.unzip")
+        val executable = bin.resolve("unzip")
+        Files.createSymbolicLink(intermediary.toPath(), backing.toPath().toAbsolutePath())
+        Files.createSymbolicLink(executable.toPath(), intermediary.toPath().toAbsolutePath())
+
+        activateRuntimeEnvironment(
+            active = active,
+            staging = staging,
+            rollback = root.resolve("environment.rollback"),
+            finalizeActivation = {},
+        )
+
+        val activatedExecutable = active.resolve("rootfs/usr/bin/unzip")
+        assertFalse(Files.readSymbolicLink(activatedExecutable.toPath()).isAbsolute)
+        assertEquals("binary", activatedExecutable.readText())
+    }
+
+    @Test
+    fun `normalization repairs links left behind by an older staging activation`() {
+        val root = temporaryFolder.newFolder("runtime-stale-links")
+        val active = root.resolve("environment").apply { mkdirs() }
+        val bin = active.resolve("rootfs/usr/bin").apply { mkdirs() }
+        val backing = bin.resolve(".l2s.unzip.0002").apply { writeText("binary") }
+        val staleRoot = root.resolve("environment.staging").toPath().toAbsolutePath()
+        val executable = bin.resolve("unzip")
+        Files.createSymbolicLink(
+            executable.toPath(),
+            staleRoot.resolve("rootfs/usr/bin/${backing.name}"),
+        )
+
+        normalizeRuntimeSymlinks(active)
+
+        assertFalse(Files.readSymbolicLink(executable.toPath()).isAbsolute)
+        assertEquals("binary", executable.readText())
+        assertTrue(active.resolve(".internal-symlinks-relative").isFile)
     }
 
     private fun metadata(version: String) =


### PR DESCRIPTION
## Summary
- convert PRoot hard-link emulation symlinks to relative paths before activating a staged runtime
- repair stale links in existing runtime installations once
- clear the persisted unzip broken-files flag before Claude Code updates

## Testing
- `git diff --check`
- `./gradlew detekt`
- Android unit tests deferred to CI because this environment has no Android SDK