### PR TITLE
feat: preserve and view chat images

### DIFF
--- a/app/src/androidTest/java/com/yugahashimoto/andcode/feature/chat/ChatImageViewerInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/yugahashimoto/andcode/feature/chat/ChatImageViewerInstrumentedTest.kt
@@ -1,0 +1,51 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.yugahashimoto.andcode.core.api.PromptAttachment
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatImageViewerInstrumentedTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun sentImageOpensViewerAndCanRequestDownload() {
+        val attachment =
+            PromptAttachment(
+                "pixel.png",
+                "image/png",
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+            )
+        var selected by mutableStateOf<ChatImageSource?>(null)
+        var downloaded: ChatImageSource? = null
+
+        composeRule.setContent {
+            MessageBubble(ChatMessage(isUser = true, attachments = listOf(attachment))) { selected = it }
+            selected?.let { source ->
+                ChatImageViewerDialog(
+                    source = source,
+                    onDismiss = { selected = null },
+                    onDownload = { downloaded = it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("chat-image-thumbnail").performClick()
+        composeRule.onNodeWithTag("chat-image-viewer").assertIsDisplayed()
+        composeRule.onNodeWithTag("chat-image-download").performClick()
+
+        composeRule.runOnIdle { assertEquals("pixel.png", downloaded?.filename) }
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -3,6 +3,7 @@ package com.yugahashimoto.andcode.feature.chat
 import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -200,6 +201,8 @@ fun ChatHomeScreen(
     val isAtBottom = remember { mutableStateOf(true) }
     var showActionSheet by remember { mutableStateOf<Pair<String, String>?>(null) }
     var activityGroupId by remember { mutableStateOf<String?>(null) }
+    var selectedImage by remember { mutableStateOf<ChatImageSource?>(null) }
+    var legacyDownload by remember { mutableStateOf<ChatImageSource?>(null) }
     val timelineEntries = remember(state.messages) { groupConversationTimeline(state.messages) }
     val clipboardManager = LocalClipboardManager.current
     val coroutineScope = rememberCoroutineScope()
@@ -212,6 +215,21 @@ fun ChatHomeScreen(
         }
     }
     val context = androidx.compose.ui.platform.LocalContext.current
+    val imageSaveLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("image/*")) { uri ->
+            val source = legacyDownload
+            legacyDownload = null
+            if (uri != null && source != null) {
+                coroutineScope.launch {
+                    val saved = saveChatImageToUri(context, source, uri)
+                    android.widget.Toast.makeText(
+                        context,
+                        if (saved) R.string.image_saved else R.string.image_save_failed,
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+            }
+        }
 
     val cameraLauncher =
         rememberLauncherForActivityResult(
@@ -408,7 +426,11 @@ fun ChatHomeScreen(
                                             )
                                         },
                                 ) {
-                                    TimelineEntryRow(entry, onOpenActivity = { activityGroupId = it })
+                                    TimelineEntryRow(
+                                        entry,
+                                        onOpenActivity = { activityGroupId = it },
+                                        onImageClick = { selectedImage = it },
+                                    )
                                 }
                             }
                             if (state.isRunning && timelineEntries.isNotEmpty()) {
@@ -659,6 +681,28 @@ fun ChatHomeScreen(
                 )
             }
         }
+    }
+
+    selectedImage?.let { source ->
+        ChatImageViewerDialog(
+            source = source,
+            onDismiss = { selectedImage = null },
+            onDownload = {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    coroutineScope.launch {
+                        val saved = saveChatImageToPictures(context, it)
+                        android.widget.Toast.makeText(
+                            context,
+                            if (saved) R.string.image_saved else R.string.image_save_failed,
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                    }
+                } else {
+                    legacyDownload = it
+                    imageSaveLauncher.launch(safeImageFilename(it))
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatImageViewer.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatImageViewer.kt
@@ -1,0 +1,306 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.util.Base64
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.yugahashimoto.andcode.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.URL
+
+data class ChatImageSource(
+    val url: String,
+    val mime: String,
+    val filename: String? = null,
+    val preview: Bitmap? = null,
+)
+
+@Composable
+fun ChatImageViewerDialog(
+    source: ChatImageSource,
+    onDismiss: () -> Unit,
+    onDownload: (ChatImageSource) -> Unit,
+) {
+    val context = LocalContext.current
+    val loadResult by
+        produceState(initialValue = false to source.preview, source.url) {
+            value = true to loadChatImageBitmap(context, source)
+        }
+    val loaded = loadResult.first
+    val bitmap = loadResult.second
+    var scale by remember(source.url) { mutableFloatStateOf(1f) }
+    var offset by remember(source.url) { mutableStateOf(Offset.Zero) }
+    val transformState =
+        rememberTransformableState { zoomChange, panChange, _ ->
+            scale = (scale * zoomChange).coerceIn(1f, 5f)
+            offset = if (scale == 1f) Offset.Zero else offset + panChange
+        }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+    ) {
+        Box(Modifier.fillMaxSize().background(Color.Black).testTag("chat-image-viewer")) {
+            when (val image = bitmap) {
+                null ->
+                    if (loaded) {
+                        Text(
+                            stringResource(R.string.image_load_failed),
+                            color = Color.White,
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    } else {
+                        CircularProgressIndicator(Modifier.align(Alignment.Center), color = Color.White)
+                    }
+                else ->
+                    Image(
+                        bitmap = image.asImageBitmap(),
+                        contentDescription = source.filename ?: stringResource(R.string.cd_image_preview),
+                        contentScale = ContentScale.Fit,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .graphicsLayer(
+                                    scaleX = scale,
+                                    scaleY = scale,
+                                    translationX = offset.x,
+                                    translationY = offset.y,
+                                )
+                                .transformable(transformState),
+                    )
+            }
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.TopStart).padding(12.dp).testTag("chat-image-close"),
+            ) {
+                Icon(Icons.Default.Close, stringResource(R.string.cd_close_image), tint = Color.White)
+            }
+            IconButton(
+                onClick = { onDownload(source) },
+                modifier = Modifier.align(Alignment.TopEnd).padding(12.dp).testTag("chat-image-download"),
+            ) {
+                Icon(Icons.Default.Download, stringResource(R.string.cd_download_image), tint = Color.White)
+            }
+            if (!loaded) {
+                Text(
+                    text = stringResource(R.string.image_loading),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.align(Alignment.Center).padding(top = 72.dp),
+                )
+            }
+        }
+    }
+}
+
+suspend fun loadChatImageBitmap(
+    context: Context,
+    source: ChatImageSource,
+): Bitmap? =
+    withContext(Dispatchers.IO) {
+        val bytes = loadChatImageBytes(context, source) ?: return@withContext source.preview
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@withContext source.preview
+        var sample = 1
+        while (bounds.outWidth / sample > VIEWER_MAX_DIMENSION || bounds.outHeight / sample > VIEWER_MAX_DIMENSION) {
+            sample *= 2
+        }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, BitmapFactory.Options().apply { inSampleSize = sample })
+            ?: source.preview
+    }
+
+suspend fun loadChatImageBytes(
+    context: Context,
+    source: ChatImageSource,
+): ByteArray? =
+    withContext(Dispatchers.IO) {
+        runCatching {
+            when {
+                source.url.startsWith("data:") -> {
+                    val data = parseDataImageUri(source.url) ?: error("Invalid image data URL")
+                    require(data.base64.length <= MAX_IMAGE_BASE64_CHARS)
+                    Base64.decode(data.base64, Base64.DEFAULT).also { require(it.size <= MAX_IMAGE_BYTES) }
+                }
+                source.url.startsWith("content:") ->
+                    context.contentResolver.openInputStream(Uri.parse(source.url))!!.use(::readLimited)
+                source.url.startsWith("http://") || source.url.startsWith("https://") -> loadRemoteImage(source)
+                else -> {
+                    val workspace = File(context.filesDir, "runtime/workspace")
+                    val roots =
+                        listOf(
+                            File(context.filesDir, "runtime/environment/antigravity-rootfs"),
+                            File(context.filesDir, "runtime/environment/rootfs"),
+                        )
+                    val allowedRoots = listOf(workspace) + roots
+                    val file =
+                        imageFileCandidates(source.url, workspace, roots).firstOrNull { candidate ->
+                            candidate.exists() && allowedRoots.any { root -> candidate.isInside(root) }
+                        }
+                    file?.inputStream()?.use(::readLimited)
+                        ?: error("Image file not found")
+                }
+            }
+        }.getOrNull()
+    }
+
+suspend fun saveChatImageToPictures(
+    context: Context,
+    source: ChatImageSource,
+): Boolean =
+    withContext(Dispatchers.IO) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return@withContext false
+        val bytes = loadOriginalOrPreviewBytes(context, source) ?: return@withContext false
+        val values =
+            ContentValues().apply {
+                put(MediaStore.Images.Media.DISPLAY_NAME, safeImageFilename(source))
+                put(MediaStore.Images.Media.MIME_TYPE, effectiveImageMime(source))
+                put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/AndCode")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        val resolver = context.contentResolver
+        val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values) ?: return@withContext false
+        try {
+            resolver.openOutputStream(uri)?.use { it.write(bytes) } ?: error("Cannot open image destination")
+            resolver.update(uri, ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) }, null, null)
+            true
+        } catch (_: Exception) {
+            resolver.delete(uri, null, null)
+            false
+        }
+    }
+
+suspend fun saveChatImageToUri(
+    context: Context,
+    source: ChatImageSource,
+    destination: Uri,
+): Boolean =
+    withContext(Dispatchers.IO) {
+        val bytes = loadOriginalOrPreviewBytes(context, source) ?: return@withContext false
+        runCatching {
+            context.contentResolver.openOutputStream(destination)?.use { it.write(bytes) }
+                ?: error("Cannot open image destination")
+        }.isSuccess
+    }
+
+fun safeImageFilename(source: ChatImageSource): String {
+    val fallbackExtension = effectiveImageMime(source).substringAfter('/', "jpg").substringBefore('+').ifBlank { "jpg" }
+    val raw = source.filename?.takeIf { it.isNotBlank() } ?: "andcode-image-${System.currentTimeMillis()}.$fallbackExtension"
+    return raw.replace(Regex("[^A-Za-z0-9._-]"), "_").ifBlank { "andcode-image.$fallbackExtension" }
+}
+
+private fun effectiveImageMime(source: ChatImageSource): String {
+    if (source.mime.startsWith("image/") && source.mime != "image/*") return source.mime
+    parseDataImageUri(source.url)?.mime?.let { return it }
+    return when (source.url.substringBefore('?').substringAfterLast('.', "").lowercase()) {
+        "jpg", "jpeg" -> "image/jpeg"
+        "webp" -> "image/webp"
+        "gif" -> "image/gif"
+        "bmp" -> "image/bmp"
+        "svg" -> "image/svg+xml"
+        else -> "image/png"
+    }
+}
+
+private suspend fun loadOriginalOrPreviewBytes(
+    context: Context,
+    source: ChatImageSource,
+): ByteArray? =
+    loadChatImageBytes(context, source)
+        ?: source.preview?.let { bitmap ->
+            ByteArrayOutputStream().use { output ->
+                if (bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) output.toByteArray() else null
+            }
+        }
+
+private fun loadRemoteImage(source: ChatImageSource): ByteArray {
+    val url = URL(source.url)
+    require(url.protocol == "https" && url.host.isPublicHost()) { "Private image URL is not allowed" }
+    val connection = url.openConnection() as HttpURLConnection
+    connection.connectTimeout = 10_000
+    connection.readTimeout = 20_000
+    connection.instanceFollowRedirects = false
+    try {
+        require(connection.responseCode in 200..299)
+        require(connection.contentType.orEmpty().substringBefore(';').startsWith("image/"))
+        return connection.inputStream.use(::readLimited)
+    } finally {
+        connection.disconnect()
+    }
+}
+
+private fun String.isPublicHost(): Boolean =
+    InetAddress.getAllByName(this).all { address ->
+        !address.isAnyLocalAddress &&
+            !address.isLoopbackAddress &&
+            !address.isLinkLocalAddress &&
+            !address.isSiteLocalAddress &&
+            !(address is Inet6Address && (address.address.first().toInt() and 0xFE) == 0xFC)
+    }
+
+private fun File.isInside(root: File): Boolean {
+    val canonicalRoot = root.canonicalFile.toPath()
+    return canonicalFile.toPath().startsWith(canonicalRoot)
+}
+
+private fun readLimited(input: java.io.InputStream): ByteArray {
+    val output = ByteArrayOutputStream()
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    var total = 0
+    while (true) {
+        val read = input.read(buffer)
+        if (read < 0) break
+        total += read
+        require(total <= MAX_IMAGE_BYTES) { "Image is too large" }
+        output.write(buffer, 0, read)
+    }
+    return output.toByteArray()
+}
+
+private const val MAX_IMAGE_BYTES = 25 * 1024 * 1024
+private const val MAX_IMAGE_BASE64_CHARS = 34_952_536
+private const val VIEWER_MAX_DIMENSION = 4096

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -3,8 +3,8 @@ package com.yugahashimoto.andcode.feature.chat
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.util.Base64
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -63,8 +64,6 @@ import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.ui.theme.AndCodeWarning
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -77,7 +76,10 @@ private val TOOL_CALL_ECHO_REGEX =
 private fun String.hideToolCallEcho(): String = TOOL_CALL_ECHO_REGEX.replace(this, "").replace(Regex("[ \t]+\n"), "\n").trim()
 
 @Composable
-fun MessageBubble(message: ChatMessage) {
+fun MessageBubble(
+    message: ChatMessage,
+    onImageClick: (ChatImageSource) -> Unit = {},
+) {
     val displayText = remember(message.text) { message.text.hideToolCallEcho() }
     Box(
         modifier = Modifier.fillMaxWidth(),
@@ -105,23 +107,29 @@ fun MessageBubble(message: ChatMessage) {
                     // reload that follows a completed send. The transient imagePreviews bitmaps only
                     // stand in for the optimistic echo before the message reaches the transcript, or
                     // for runtimes whose attachment URLs are not inlineable data URLs.
-                    val decodedImages =
-                        remember(message.attachments) {
-                            message.attachments
-                                .filter { it.mime.startsWith("image/") }
-                                .mapNotNull { decodeDataUrlImage(it.url) }
-                        }
-                    (decodedImages.ifEmpty { message.imagePreviews }).forEach { bitmap ->
-                        Image(
-                            bitmap = bitmap.asImageBitmap(),
-                            contentDescription = stringResource(R.string.cd_image_preview),
-                            modifier =
-                                Modifier
-                                    .widthIn(max = 280.dp)
-                                    .heightIn(max = 220.dp)
-                                    .padding(bottom = 8.dp),
-                            contentScale = ContentScale.Fit,
+                    val imageAttachments = message.attachments.filter { it.mime.startsWith("image/") }
+                    imageAttachments.forEachIndexed { index, attachment ->
+                        ChatImageThumbnail(
+                            source =
+                                ChatImageSource(
+                                    attachment.url,
+                                    attachment.mime,
+                                    attachment.filename,
+                                    message.imagePreviews.getOrNull(index),
+                                ),
+                            modifier = Modifier.widthIn(max = 280.dp).heightIn(max = 220.dp).padding(bottom = 8.dp),
+                            onImageClick = onImageClick,
                         )
+                    }
+                    if (imageAttachments.isEmpty()) {
+                        message.imagePreviews.forEachIndexed { index, bitmap ->
+                            val source = ChatImageSource("preview:${message.id}:$index", "image/jpeg", preview = bitmap)
+                            ChatImageThumbnail(
+                                source = source,
+                                modifier = Modifier.widthIn(max = 280.dp).heightIn(max = 220.dp).padding(bottom = 8.dp),
+                                onImageClick = onImageClick,
+                            )
+                        }
                     }
                     message.attachments.forEach { attachment ->
                         if (attachment.mime.startsWith("image/")) return@forEach
@@ -151,29 +159,16 @@ fun MessageBubble(message: ChatMessage) {
     }
 }
 
-/**
- * Decodes a base64 `data:` image URL into a bitmap, or null when the URL is not an inlineable data
- * URL (e.g. a remote runtime returned a plain http/file reference). Failures are swallowed so a
- * single unreadable attachment never crashes the transcript.
- */
-private fun decodeDataUrlImage(url: String): Bitmap? {
-    val base64 = url.substringAfter("base64,", missingDelimiterValue = "")
-    if (base64.isEmpty()) return null
-    return runCatching {
-        val bytes = Base64.decode(base64, Base64.DEFAULT)
-        BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-    }.getOrNull()
-}
-
 @Composable
 fun TimelineEntryRow(
     entry: TimelineEntry,
     onOpenActivity: (String) -> Unit = {},
+    onImageClick: (ChatImageSource) -> Unit = {},
 ) {
     when (entry) {
-        is TimelineEntry.UserMessage -> MessageBubble(entry.message)
-        is TimelineEntry.Body -> MarkdownText(entry.part.text)
-        is TimelineEntry.Image -> ImagePartView(entry.part)
+        is TimelineEntry.UserMessage -> MessageBubble(entry.message, onImageClick)
+        is TimelineEntry.Body -> MarkdownText(entry.part.text, onImageClick = onImageClick)
+        is TimelineEntry.Image -> ImagePartView(entry.part, onImageClick)
         is TimelineEntry.Activity ->
             AssistantActivityRow(
                 parts = entry.parts,
@@ -334,6 +329,7 @@ private fun LinkedText(
 private fun MarkdownText(
     text: String,
     onFilePathClick: (String) -> Unit = {},
+    onImageClick: (ChatImageSource) -> Unit = {},
 ) {
     val blocks = remember(text) { MarkdownLite.parse(text) }
     val codeInlineBackground = MaterialTheme.colorScheme.surfaceVariant
@@ -377,7 +373,7 @@ private fun MarkdownText(
                     block.inlines.forEach { inline ->
                         if (inline is MarkdownInline.Image) {
                             flushInlines()
-                            MarkdownImageView(inline)
+                            MarkdownImageView(inline, onImageClick)
                         } else {
                             currentInlines += inline
                         }
@@ -579,91 +575,53 @@ internal fun decodeImageFromUrlOrPath(
 }
 
 @Composable
-private fun MarkdownImageView(image: MarkdownInline.Image) {
-    val context = LocalContext.current
-    val workspaceHostDir = remember { File(context.filesDir, "runtime/workspace") }
-    val rootfsDirs =
-        remember {
-            listOf(
-                File(context.filesDir, "runtime/environment/antigravity-rootfs"),
-                File(context.filesDir, "runtime/environment/rootfs"),
-            )
-        }
-    val bitmapState =
-        produceState<Bitmap?>(initialValue = null, key1 = image.url) {
-            value =
-                withContext(Dispatchers.IO) {
-                    decodeImageFromUrlOrPath(image.url, workspaceHostDir, rootfsDirs)
-                }
-        }
-    val bitmap = bitmapState.value
-    if (bitmap != null) {
-        Image(
-            bitmap = bitmap.asImageBitmap(),
-            contentDescription = image.text.ifBlank { stringResource(R.string.cd_image_preview) },
-            modifier =
-                Modifier
-                    .widthIn(max = 320.dp)
-                    .heightIn(max = 320.dp)
-                    .padding(vertical = 4.dp),
-            contentScale = ContentScale.Fit,
-        )
-    } else {
-        Surface(
-            shape = RoundedCornerShape(10.dp),
-            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
-            modifier = Modifier.padding(vertical = 4.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                modifier = Modifier.padding(10.dp),
-            ) {
-                Icon(Icons.Default.ImageIcon, contentDescription = null)
-                Text(
-                    text = image.text.ifBlank { image.url },
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        }
-    }
+private fun MarkdownImageView(
+    image: MarkdownInline.Image,
+    onImageClick: (ChatImageSource) -> Unit,
+) {
+    ChatImageThumbnail(
+        source = ChatImageSource(image.url, "image/*", image.text.ifBlank { null }),
+        modifier = Modifier.widthIn(max = 320.dp).heightIn(max = 320.dp).padding(vertical = 4.dp),
+        onImageClick = onImageClick,
+    )
 }
 
 @Composable
-private fun ImagePartView(part: ChatPart.Image) {
+private fun ImagePartView(
+    part: ChatPart.Image,
+    onImageClick: (ChatImageSource) -> Unit,
+) {
+    ChatImageThumbnail(
+        source = ChatImageSource(part.url, part.mime, part.filename),
+        modifier = Modifier.widthIn(max = 320.dp).heightIn(max = 320.dp),
+        onImageClick = onImageClick,
+    )
+}
+
+@Composable
+private fun ChatImageThumbnail(
+    source: ChatImageSource,
+    modifier: Modifier,
+    onImageClick: (ChatImageSource) -> Unit,
+) {
     val context = LocalContext.current
-    val workspaceHostDir = remember { File(context.filesDir, "runtime/workspace") }
-    val rootfsDirs =
-        remember {
-            listOf(
-                File(context.filesDir, "runtime/environment/antigravity-rootfs"),
-                File(context.filesDir, "runtime/environment/rootfs"),
-            )
-        }
     val bitmapState =
-        produceState<Bitmap?>(initialValue = null, key1 = part.url) {
-            value =
-                withContext(Dispatchers.IO) {
-                    decodeImageFromUrlOrPath(part.url, workspaceHostDir, rootfsDirs)
-                }
+        produceState(initialValue = source.preview, source.url) {
+            value = loadChatImageBitmap(context, source)
         }
     val bitmap = bitmapState.value
     if (bitmap != null) {
         Image(
             bitmap = bitmap.asImageBitmap(),
-            contentDescription = part.filename ?: stringResource(R.string.cd_image_preview),
-            modifier =
-                Modifier
-                    .widthIn(max = 320.dp)
-                    .heightIn(max = 320.dp),
+            contentDescription = source.filename ?: stringResource(R.string.cd_image_preview),
+            modifier = modifier.testTag("chat-image-thumbnail").clickable { onImageClick(source.copy(preview = bitmap)) },
             contentScale = ContentScale.Fit,
         )
     } else {
         Surface(
             shape = RoundedCornerShape(10.dp),
             color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+            modifier = modifier.testTag("chat-image-thumbnail").clickable { onImageClick(source) },
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -672,7 +630,7 @@ private fun ImagePartView(part: ChatPart.Image) {
             ) {
                 Icon(Icons.Default.ImageIcon, contentDescription = null)
                 Text(
-                    text = part.filename ?: part.mime,
+                    text = source.filename ?: source.mime,
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -92,6 +92,38 @@ data class ChatMessage(
         get() = parts.filterIsInstance<ChatPart.Text>().joinToString("") { it.text }
 }
 
+/** Keeps optimistic image data when a runtime replaces the transcript with its persisted copy. */
+internal fun mergeReloadedMessages(
+    reloaded: List<ChatMessage>,
+    existing: List<ChatMessage>,
+    previewsByFilename: Map<String, Bitmap> = emptyMap(),
+): List<ChatMessage> {
+    val usedExisting = mutableSetOf<Int>()
+    return reloaded.map { message ->
+        val existingIndex =
+            existing.indices.firstOrNull { it !in usedExisting && existing[it].id == message.id }
+                ?: existing.indices.firstOrNull { index ->
+                    val candidate = existing[index]
+                    index !in usedExisting &&
+                        message.isUser && candidate.isUser &&
+                        candidate.text == message.text &&
+                        (message.text.isNotBlank() || candidate.attachments.isNotEmpty())
+                }
+        val previous = existingIndex?.let { index -> existing[index].also { usedExisting += index } }
+        val reloadedImageNames = message.attachments.filter { it.mime.startsWith("image/") }.map { it.filename }.toSet()
+        val missingImages =
+            previous?.attachments.orEmpty().filter {
+                it.mime.startsWith("image/") && it.filename !in reloadedImageNames
+            }
+        val attachments = message.attachments + missingImages
+        val previews =
+            previous?.imagePreviews.orEmpty().ifEmpty {
+                attachments.mapNotNull { previewsByFilename[it.filename] }
+            }
+        message.copy(attachments = attachments, imagePreviews = previews)
+    }
+}
+
 data class PendingQuestionUi(
     val request: QuestionRequest,
     val selectedAnswers: List<List<String>>,
@@ -127,6 +159,12 @@ private const val TRANSIENT_RECOVERY_MAX_BACKOFF_MS = 30_000L
 private const val TRANSIENT_RECOVERY_MAX_ATTEMPTS = 20
 private const val HEALTH_CHECK_ATTEMPTS = 15
 private const val HEALTH_CHECK_DELAY_MS = 2000L
+
+private data class QueuedPrompt(
+    val text: String,
+    val attachments: List<PromptAttachment>,
+    val imagePreviews: List<Bitmap>,
+)
 
 internal fun OpenCodePart.toChatPart(): ChatPart? {
     val partId = id ?: return null
@@ -298,8 +336,8 @@ class ChatViewModel(
     private val _workspaceTitleSource = MutableStateFlow("title")
     val workspaceTitleSource: StateFlow<String> = _workspaceTitleSource.asStateFlow()
 
-    private val messageQueue = MutableStateFlow<List<String>>(emptyList())
-    private val offlineMessageQueue = MutableStateFlow<List<String>>(emptyList())
+    private val messageQueue = MutableStateFlow<List<QueuedPrompt>>(emptyList())
+    private val offlineMessageQueue = MutableStateFlow<List<QueuedPrompt>>(emptyList())
 
     private var eventJob: Job? = null
     private var tts: TextToSpeech? = null
@@ -553,7 +591,7 @@ class ChatViewModel(
                     _uiState.update {
                         it.copy(
                             isLoadingHistory = false,
-                            messages = messages.mapNotNull(::toUiMessage),
+                            messages = mergeReloadedMessages(messages.mapNotNull(::toUiMessage), it.messages),
                             selectedProviderId = selectedModel?.providerId ?: it.selectedProviderId,
                             selectedModelId = selectedModel?.modelId ?: it.selectedModelId,
                         )
@@ -652,17 +690,23 @@ class ChatViewModel(
         }
 
         if (!_uiState.value.isConnected) {
-            offlineMessageQueue.update { it + normalized }
+            offlineMessageQueue.update {
+                it + QueuedPrompt(normalized, pendingAttachments, _uiState.value.imagePreviews)
+            }
             val userMessage =
                 ChatMessage(
                     isUser = true,
                     parts = listOf(ChatPart.Text(id = UUID.randomUUID().toString(), text = normalized)),
+                    attachments = pendingAttachments,
+                    imagePreviews = _uiState.value.imagePreviews,
                 )
             _uiState.update {
                 it.copy(
                     messages = it.messages + userMessage,
                     offlineQueue = it.offlineQueue + normalized,
                     isOfflineQueued = true,
+                    attachments = emptyList(),
+                    imagePreviews = emptyList(),
                 )
             }
             return
@@ -673,7 +717,10 @@ class ChatViewModel(
         // request, which surfaced as a crash. See RuntimeCapabilities.forcesQueue.
         val mustQueue = (currentBackend as? RuntimeTarget)?.capabilities?.forcesQueue == true
         if ((_sendBehavior.value == "queue" || mustQueue) && _uiState.value.isRunning) {
-            messageQueue.update { it + normalized }
+            messageQueue.update {
+                it + QueuedPrompt(normalized, pendingAttachments, _uiState.value.imagePreviews)
+            }
+            _uiState.update { it.copy(attachments = emptyList(), imagePreviews = emptyList()) }
             return
         }
 
@@ -762,18 +809,12 @@ class ChatViewModel(
                             runCatching { currentBackend.listMessages(targetSessionId) }
                                 .onSuccess { serverMessages ->
                                     if (!isStillActive()) return@onSuccess
-                                    val previewsById =
-                                        _uiState.value.messages
-                                            .associate { it.id to it.imagePreviews }
                                     val uiMessages =
-                                        serverMessages.mapNotNull(::toUiMessage).map { message ->
-                                            val previews =
-                                                previewsById[message.id].orEmpty().ifEmpty {
-                                                    message.attachments
-                                                        .mapNotNull { pendingPreviewsByFilename[it.filename] }
-                                                }
-                                            message.copy(imagePreviews = previews)
-                                        }
+                                        mergeReloadedMessages(
+                                            serverMessages.mapNotNull(::toUiMessage),
+                                            _uiState.value.messages,
+                                            pendingPreviewsByFilename,
+                                        )
                                     if (uiMessages.isNotEmpty() && uiMessages != _uiState.value.messages) {
                                         _uiState.update { it.copy(messages = uiMessages) }
                                     }
@@ -804,17 +845,12 @@ class ChatViewModel(
                             // the final reload otherwise drops them, and a runtime whose attachment
                             // URLs are not inlineable data URLs would lose the just-sent image the
                             // moment the send completed.
-                            val previewsById =
-                                _uiState.value.messages.associate { it.id to it.imagePreviews }
                             val uiMessages =
-                                serverMessages.mapNotNull(::toUiMessage).map { message ->
-                                    val previews =
-                                        previewsById[message.id].orEmpty().ifEmpty {
-                                            message.attachments
-                                                .mapNotNull { pendingPreviewsByFilename[it.filename] }
-                                        }
-                                    message.copy(imagePreviews = previews)
-                                }
+                                mergeReloadedMessages(
+                                    serverMessages.mapNotNull(::toUiMessage),
+                                    _uiState.value.messages,
+                                    pendingPreviewsByFilename,
+                                )
                             _uiState.update {
                                 it.copy(
                                     messages = uiMessages,
@@ -861,7 +897,7 @@ class ChatViewModel(
         val messageIdsBeforeSend = _uiState.value.messages.map { it.id }.toSet()
 
         if (!_uiState.value.isConnected) {
-            offlineMessageQueue.update { it + displayText }
+            offlineMessageQueue.update { it + QueuedPrompt(displayText, emptyList(), emptyList()) }
             val userMessage =
                 ChatMessage(
                     isUser = true,
@@ -879,7 +915,7 @@ class ChatViewModel(
 
         val mustQueue = (currentBackend as? RuntimeTarget)?.capabilities?.forcesQueue == true
         if ((_sendBehavior.value == "queue" || mustQueue) && _uiState.value.isRunning) {
-            messageQueue.update { it + displayText }
+            messageQueue.update { it + QueuedPrompt(displayText, emptyList(), emptyList()) }
             return
         }
 
@@ -949,7 +985,11 @@ class ChatViewModel(
                             runCatching { currentBackend.listMessages(targetSessionId) }
                                 .onSuccess { serverMessages ->
                                     if (!isStillActive()) return@onSuccess
-                                    val uiMessages = serverMessages.mapNotNull(::toUiMessage)
+                                    val uiMessages =
+                                        mergeReloadedMessages(
+                                            serverMessages.mapNotNull(::toUiMessage),
+                                            _uiState.value.messages,
+                                        )
                                     if (uiMessages.isNotEmpty() && uiMessages != _uiState.value.messages) {
                                         _uiState.update { it.copy(messages = uiMessages) }
                                     }
@@ -972,7 +1012,11 @@ class ChatViewModel(
                             streamedParts.clear()
                             _uiState.update {
                                 it.copy(
-                                    messages = serverMessages.mapNotNull(::toUiMessage),
+                                    messages =
+                                        mergeReloadedMessages(
+                                            serverMessages.mapNotNull(::toUiMessage),
+                                            it.messages,
+                                        ),
                                     isRunning = false,
                                     isThinking = false,
                                 )
@@ -1281,7 +1325,7 @@ class ChatViewModel(
                                 streamedParts.clear()
                                 _uiState.update {
                                     it.copy(
-                                        messages = messages.mapNotNull(::toUiMessage),
+                                        messages = mergeReloadedMessages(messages.mapNotNull(::toUiMessage), it.messages),
                                     )
                                 }
                             }
@@ -1420,7 +1464,7 @@ class ChatViewModel(
         viewModelScope.launch {
             runCatching { currentBackend.listMessages(sessionId) }
                 .onSuccess { messages ->
-                    val uiMessages = messages.mapNotNull(::toUiMessage)
+                    val uiMessages = mergeReloadedMessages(messages.mapNotNull(::toUiMessage), _uiState.value.messages)
                     if (uiMessages.isNotEmpty()) {
                         _uiState.update { it.copy(messages = uiMessages) }
                     }
@@ -1564,7 +1608,15 @@ class ChatViewModel(
         val queued = messageQueue.value
         if (queued.isEmpty()) return
         messageQueue.value = emptyList()
-        queued.forEach { sendMessage(it) }
+        queued.forEach { queuedPrompt ->
+            _uiState.update {
+                it.copy(
+                    attachments = queuedPrompt.attachments,
+                    imagePreviews = queuedPrompt.imagePreviews,
+                )
+            }
+            sendMessage(queuedPrompt.text)
+        }
     }
 
     private fun drainOfflineQueue() {
@@ -1572,7 +1624,15 @@ class ChatViewModel(
         if (queued.isEmpty()) return
         offlineMessageQueue.value = emptyList()
         _uiState.update { it.copy(offlineQueue = emptyList(), isOfflineQueued = false) }
-        queued.forEach { sendMessage(it) }
+        queued.forEach { queuedPrompt ->
+            _uiState.update {
+                it.copy(
+                    attachments = queuedPrompt.attachments,
+                    imagePreviews = queuedPrompt.imagePreviews,
+                )
+            }
+            sendMessage(queuedPrompt.text)
+        }
     }
 
     override fun onCleared() {
@@ -1656,7 +1716,7 @@ class ChatViewModel(
                     .onSuccess { messages ->
                         streamedParts.clear()
                         _uiState.update {
-                            it.copy(messages = messages.mapNotNull(::toUiMessage))
+                            it.copy(messages = mergeReloadedMessages(messages.mapNotNull(::toUiMessage), it.messages))
                         }
                     }
                     .isSuccess

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
@@ -6,6 +6,7 @@ import com.yugahashimoto.andcode.core.api.OpenCodeMessageInfo
 import com.yugahashimoto.andcode.core.api.OpenCodeModelReference
 import com.yugahashimoto.andcode.core.api.OpenCodePart
 import com.yugahashimoto.andcode.core.api.OpenCodeTime
+import com.yugahashimoto.andcode.core.api.PromptAttachment
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -15,6 +16,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.util.Base64
 
 @Serializable
 data class AntigravitySessionRecord(
@@ -152,12 +154,21 @@ class AntigravityRuntime(
         model: String? = null,
         variant: String? = null,
         permissionMode: AntigravityPermissionMode = AntigravityPermissionMode.DEFAULT,
+        attachments: List<PromptAttachment> = emptyList(),
     ): Result<String> =
         withContext(Dispatchers.IO) {
             runCatching {
                 val runtime = installedRuntimeProvider() ?: error("Linux environment is not installed")
                 require(isInstalled()) { "Antigravity is not installed" }
                 AntigravityGuestSettings.repair(runtime)
+                val promptWithAttachments =
+                    prepareAntigravityPrompt(
+                        runtimeDirectory,
+                        sessionId,
+                        records[sessionId]?.lastStep ?: 0,
+                        prompt,
+                        attachments,
+                    )
                 // Normally unreachable now that the app always queues a send behind a running
                 // Antigravity turn (see RuntimeCapabilities.forcesQueue) - kept as a safety net for
                 // e.g. two clients racing the same session. Marking the kill as intentional here is
@@ -185,7 +196,7 @@ class AntigravityRuntime(
                             addAll(AntigravityModels.cliArgs(model, variant))
                             addAll(permissionMode.cliArgs)
                             add("--print")
-                            add(prompt)
+                            add(promptWithAttachments)
                         }
                     val stderrLog = File(runtimeDirectory, "logs/agy-stderr.log").also { it.parentFile?.mkdirs() }
                     val process =
@@ -226,7 +237,22 @@ class AntigravityRuntime(
                             OpenCodeMessageInfo(userId, sessionId, "user", OpenCodeTime(turnNow, turnNow, turnNow)),
                             // A part without an id is dropped when the chat maps the transcript for
                             // display, so an id-less part is invisible however well the run went.
-                            listOf(OpenCodePart(id = "$userId-text", type = "text", text = prompt)),
+                            buildList {
+                                add(OpenCodePart(id = "$userId-text", type = "text", text = prompt))
+                                attachments.forEachIndexed { index, attachment ->
+                                    add(
+                                        OpenCodePart(
+                                            id = "$userId-file-$index",
+                                            sessionId = sessionId,
+                                            messageId = userId,
+                                            type = "file",
+                                            filename = attachment.filename,
+                                            mime = attachment.mime,
+                                            url = attachment.url,
+                                        ),
+                                    )
+                                }
+                            },
                         ),
                     )
                     persist()
@@ -330,6 +356,8 @@ class AntigravityRuntime(
         abort(sessionId)
         val removed = records.remove(sessionId) != null
         messages.remove(sessionId)
+        val safeSession = sessionId.replace(Regex("[^A-Za-z0-9._-]"), "_")
+        File(runtimeDirectory, "workspace/.andcode-attachments/$safeSession").deleteRecursively()
         persist()
         return removed
     }
@@ -486,8 +514,55 @@ class AntigravityRuntime(
     private fun persist() {
         runCatching {
             recordsFile.parentFile?.mkdirs()
-            recordsFile.writeText(json.encodeToString(records.values.toList()))
-            messagesFile.writeText(json.encodeToString(messages.mapValues { it.value.toList() }))
+            writeAtomically(recordsFile, json.encodeToString(records.values.toList()))
+            writeAtomically(messagesFile, json.encodeToString(messages.mapValues { it.value.toList() }))
         }
     }
 }
+
+private fun writeAtomically(
+    destination: File,
+    content: String,
+) {
+    val temporary = File(destination.parentFile, ".${destination.name}.tmp")
+    temporary.writeText(content)
+    check(temporary.renameTo(destination)) { "Cannot replace ${destination.name}" }
+}
+
+/**
+ * Materializes inline attachments in the shared workspace and references them through agy's native
+ * `@path` context syntax. This is the non-interactive equivalent of attaching a file in its TUI.
+ */
+internal fun prepareAntigravityPrompt(
+    runtimeDirectory: File,
+    sessionId: String,
+    turn: Long,
+    prompt: String,
+    attachments: List<PromptAttachment>,
+): String {
+    if (attachments.isEmpty()) return prompt
+    val safeSession = sessionId.replace(Regex("[^A-Za-z0-9._-]"), "_")
+    val attachmentDir =
+        File(runtimeDirectory, "workspace/.andcode-attachments/$safeSession/$turn").apply {
+            check(mkdirs() || isDirectory) { "Cannot create Antigravity attachment directory" }
+        }
+    val references =
+        attachments.mapIndexed { index, attachment ->
+            require(attachment.mime.startsWith("image/") || attachment.mime == "application/pdf") {
+                "Antigravity cannot attach ${attachment.mime}"
+            }
+            val marker = ";base64,"
+            val encoded = attachment.url.substringAfter(marker, missingDelimiterValue = "")
+            require(attachment.url.startsWith("data:") && encoded.isNotEmpty()) {
+                "Antigravity requires an inline attachment"
+            }
+            require(encoded.length <= MAX_ANTIGRAVITY_ATTACHMENT_BASE64_CHARS) { "Antigravity attachment is too large" }
+            val safeName = attachment.filename.replace(Regex("[^A-Za-z0-9._-]"), "_").ifBlank { "attachment-$index" }
+            val file = File(attachmentDir, "$index-$safeName")
+            file.writeBytes(Base64.getDecoder().decode(encoded))
+            "@/workspace/.andcode-attachments/$safeSession/$turn/${file.name}"
+        }
+    return (references + prompt).joinToString("\n")
+}
+
+private const val MAX_ANTIGRAVITY_ATTACHMENT_BASE64_CHARS = 34_952_536

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
@@ -151,7 +151,16 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
             AntigravityPermissionMode.fromAgentId(request.agent)
                 ?.also { runtime.setSessionMode(sessionId, it) }
                 ?: AntigravityPermissionMode.fromCliValue(record.permissionMode)
-        runtime.send(sessionId, record.workspace, request.text, record.conversationId, model, variant, permissionMode).getOrThrow()
+        runtime.send(
+            sessionId,
+            record.workspace,
+            request.text,
+            record.conversationId,
+            model,
+            variant,
+            permissionMode,
+            request.attachments,
+        ).getOrThrow()
         // Claude Code summarises while its answer is still streaming; here it has to wait for the
         // send to finish, because two concurrent `agy` processes hang each other. Failure is silent:
         // the prompt-derived name set above is already in the drawer and simply stays.

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -584,6 +584,12 @@
     <string name="cd_session">Session</string>
     <string name="cd_attachment">Attachment</string>
     <string name="cd_image_preview">Image preview</string>
+    <string name="cd_close_image">Close image</string>
+    <string name="cd_download_image">Download image</string>
+    <string name="image_loading">Loading image...</string>
+    <string name="image_load_failed">Could not load image</string>
+    <string name="image_saved">Image saved to Pictures/AndCode</string>
+    <string name="image_save_failed">Could not save image</string>
     <string name="cd_reasoning">Reasoning</string>
     <string name="cd_tool">Tool</string>
     <string name="cd_file_changes">File changes</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -584,6 +584,12 @@
     <string name="cd_session">Session</string>
     <string name="cd_attachment">Attachment</string>
     <string name="cd_image_preview">Image preview</string>
+    <string name="cd_close_image">Cerrar imagen</string>
+    <string name="cd_download_image">Descargar imagen</string>
+    <string name="image_loading">Cargando imagen...</string>
+    <string name="image_load_failed">No se pudo cargar la imagen</string>
+    <string name="image_saved">Imagen guardada en Pictures/AndCode</string>
+    <string name="image_save_failed">No se pudo guardar la imagen</string>
     <string name="cd_reasoning">Reasoning</string>
     <string name="cd_tool">Tool</string>
     <string name="cd_file_changes">File changes</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -584,6 +584,12 @@
     <string name="cd_session">Session</string>
     <string name="cd_attachment">Attachment</string>
     <string name="cd_image_preview">Image preview</string>
+    <string name="cd_close_image">Fermer l\'image</string>
+    <string name="cd_download_image">Telecharger l\'image</string>
+    <string name="image_loading">Chargement de l\'image...</string>
+    <string name="image_load_failed">Impossible de charger l\'image</string>
+    <string name="image_saved">Image enregistree dans Pictures/AndCode</string>
+    <string name="image_save_failed">Impossible d\'enregistrer l\'image</string>
     <string name="cd_reasoning">Reasoning</string>
     <string name="cd_tool">Tool</string>
     <string name="cd_file_changes">File changes</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -597,6 +597,12 @@
     <string name="cd_session">セッション</string>
     <string name="cd_attachment">添付ファイル</string>
     <string name="cd_image_preview">画像プレビュー</string>
+    <string name="cd_close_image">画像を閉じる</string>
+    <string name="cd_download_image">画像をダウンロード</string>
+    <string name="image_loading">画像を読み込み中...</string>
+    <string name="image_load_failed">画像を読み込めませんでした</string>
+    <string name="image_saved">Pictures/AndCodeに保存しました</string>
+    <string name="image_save_failed">画像を保存できませんでした</string>
     <string name="cd_reasoning">推論</string>
     <string name="cd_tool">ツール</string>
     <string name="cd_file_changes">ファイル変更</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -584,6 +584,12 @@
     <string name="cd_session">Session</string>
     <string name="cd_attachment">Attachment</string>
     <string name="cd_image_preview">Image preview</string>
+    <string name="cd_close_image">Fechar imagem</string>
+    <string name="cd_download_image">Baixar imagem</string>
+    <string name="image_loading">Carregando imagem...</string>
+    <string name="image_load_failed">Nao foi possivel carregar a imagem</string>
+    <string name="image_saved">Imagem salva em Pictures/AndCode</string>
+    <string name="image_save_failed">Nao foi possivel salvar a imagem</string>
     <string name="cd_reasoning">Reasoning</string>
     <string name="cd_tool">Tool</string>
     <string name="cd_file_changes">File changes</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -584,6 +584,12 @@
     <string name="cd_session">Session</string>
     <string name="cd_attachment">Attachment</string>
     <string name="cd_image_preview">Image preview</string>
+    <string name="cd_close_image">Close image</string>
+    <string name="cd_download_image">Download image</string>
+    <string name="image_loading">Loading image...</string>
+    <string name="image_load_failed">Could not load image</string>
+    <string name="image_saved">Image saved to Pictures/AndCode</string>
+    <string name="image_save_failed">Could not save image</string>
     <string name="cd_reasoning">Reasoning</string>
     <string name="cd_tool">Tool</string>
     <string name="cd_file_changes">File changes</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -584,6 +584,12 @@
     <string name="cd_session">Session</string>
     <string name="cd_attachment">Attachment</string>
     <string name="cd_image_preview">Image preview</string>
+    <string name="cd_close_image">关闭图片</string>
+    <string name="cd_download_image">下载图片</string>
+    <string name="image_loading">正在加载图片...</string>
+    <string name="image_load_failed">无法加载图片</string>
+    <string name="image_saved">图片已保存到 Pictures/AndCode</string>
+    <string name="image_save_failed">无法保存图片</string>
     <string name="cd_reasoning">Reasoning</string>
     <string name="cd_tool">Tool</string>
     <string name="cd_file_changes">File changes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -598,6 +598,12 @@
     <string name="cd_session">Session</string>
     <string name="cd_attachment">Attachment</string>
     <string name="cd_image_preview">Image preview</string>
+    <string name="cd_close_image">Close image</string>
+    <string name="cd_download_image">Download image</string>
+    <string name="image_loading">Loading image…</string>
+    <string name="image_load_failed">Could not load image</string>
+    <string name="image_saved">Image saved to Pictures/AndCode</string>
+    <string name="image_save_failed">Could not save image</string>
     <string name="cd_reasoning">Reasoning</string>
     <string name="cd_tool">Tool</string>
     <string name="cd_file_changes">File changes</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePersistenceTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePersistenceTest.kt
@@ -1,0 +1,54 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import com.yugahashimoto.andcode.core.api.PromptAttachment
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatImagePersistenceTest {
+    @Test
+    fun `reload keeps optimistic image when runtime omits file part`() {
+        val image = PromptAttachment("photo.jpg", "image/jpeg", "data:image/jpeg;base64,AQ==")
+        val optimistic =
+            ChatMessage(
+                id = "client-id",
+                isUser = true,
+                parts = listOf(ChatPart.Text("client-text", "look")),
+                attachments = listOf(image),
+            )
+        val persisted =
+            ChatMessage(
+                id = "server-id",
+                isUser = true,
+                parts = listOf(ChatPart.Text("server-text", "look")),
+            )
+
+        val merged = mergeReloadedMessages(listOf(persisted), listOf(optimistic))
+
+        assertEquals("server-id", merged.single().id)
+        assertEquals(listOf(image), merged.single().attachments)
+    }
+
+    @Test
+    fun `reload prefers runtime image part`() {
+        val optimisticImage = PromptAttachment("photo.jpg", "image/jpeg", "data:image/jpeg;base64,AQ==")
+        val persistedImage = PromptAttachment("photo.jpg", "image/jpeg", "data:image/jpeg;base64,Ag==")
+        val optimistic = ChatMessage(isUser = true, attachments = listOf(optimisticImage))
+        val persisted = ChatMessage(id = "server-id", isUser = true, attachments = listOf(persistedImage))
+
+        val merged = mergeReloadedMessages(listOf(persisted), listOf(optimistic))
+
+        assertEquals(listOf(persistedImage), merged.single().attachments)
+    }
+
+    @Test
+    fun `reload restores only missing images from optimistic message`() {
+        val first = PromptAttachment("first.jpg", "image/jpeg", "data:image/jpeg;base64,AQ==")
+        val second = PromptAttachment("second.jpg", "image/jpeg", "data:image/jpeg;base64,Ag==")
+        val optimistic = ChatMessage(isUser = true, attachments = listOf(first, second))
+        val persisted = ChatMessage(id = "server-id", isUser = true, attachments = listOf(first))
+
+        val merged = mergeReloadedMessages(listOf(persisted), listOf(optimistic))
+
+        assertEquals(listOf(first, second), merged.single().attachments)
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityAttachmentTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityAttachmentTest.kt
@@ -1,0 +1,66 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import com.yugahashimoto.andcode.core.api.PromptAttachment
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.util.Base64
+
+class AntigravityAttachmentTest {
+    @get:Rule
+    val folder = TemporaryFolder()
+
+    @Test
+    fun `materializes image and references it in prompt`() {
+        val bytes = byteArrayOf(1, 2, 3, 4)
+        val prompt =
+            prepareAntigravityPrompt(
+                runtimeDirectory = folder.root,
+                sessionId = "session/unsafe",
+                turn = 3,
+                prompt = "Describe this image",
+                attachments =
+                    listOf(
+                        PromptAttachment(
+                            filename = "photo one.png",
+                            mime = "image/png",
+                            url = "data:image/png;base64,${Base64.getEncoder().encodeToString(bytes)}",
+                        ),
+                    ),
+            )
+
+        assertEquals(
+            "@/workspace/.andcode-attachments/session_unsafe/3/0-photo_one.png\nDescribe this image",
+            prompt,
+        )
+        assertArrayEquals(
+            bytes,
+            folder.root.resolve("workspace/.andcode-attachments/session_unsafe/3/0-photo_one.png").readBytes(),
+        )
+
+        prepareAntigravityPrompt(
+            folder.root,
+            "session/unsafe",
+            4,
+            "Next image",
+            listOf(PromptAttachment("next.png", "image/png", "data:image/png;base64,AQ==")),
+        )
+        assertArrayEquals(
+            bytes,
+            folder.root.resolve("workspace/.andcode-attachments/session_unsafe/3/0-photo_one.png").readBytes(),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `rejects unsupported attachments instead of silently dropping them`() {
+        prepareAntigravityPrompt(
+            folder.root,
+            "session",
+            0,
+            "prompt",
+            listOf(PromptAttachment("notes.txt", "text/plain", "data:text/plain;base64,dGVzdA==")),
+        )
+    }
+}

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -29,4 +29,6 @@ much harder to parse.
 
 Hook records use schema version 1 JSONL and contain only conversation/transcript paths, event type, tool metadata, step and stop reason. Tokens, prompts and environment variables must not be written to the hook bridge. Session records retain the app UUID, Antigravity conversation id, workspace and last step so a killed process can be resumed.
 
+Image and PDF attachments are decoded into a turn-specific directory under `/workspace/.andcode-attachments` and passed to print mode through Antigravity's native `@path` context mentions. The original file parts are stored in the app transcript, matching the OpenCode and Claude Code targets, so attachments survive completion, reconnects and app restarts. Unsupported attachment types fail the send instead of appearing attached only in the Android UI.
+
 Device acceptance still requires an x86_64 emulator and arm64 device: install and digest verification, `agy --version`, `models`, browser OAuth, a smoke prompt, file/tool use, permission/question flows, abort, session switching, network recovery and task-kill relaunch. An APK build or version command alone is not completion evidence.


### PR DESCRIPTION
## Summary
- keep sent image attachments across transcript reloads and queued sends
- pass Antigravity image/PDF attachments through workspace @path context and persist file parts
- add tappable full-screen image viewer with pinch zoom and MediaStore/SAF download
- add unit and Compose coverage for persistence, Antigravity attachment materialization, and viewer interaction

## Verification
- spotlessKotlinCheck
- :app:testDebugUnitTest
- :app:compileDebugAndroidTestKotlin

Instrumentation execution was not possible because no Android device was connected.