### PR TITLE
fix: stop v1.1.19 crashing on background wake-ups and in the schedule editor

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.startup.AppInitializer
+import com.yugahashimoto.andcode.core.diagnostics.CrashLog
 import com.yugahashimoto.andcode.core.notification.RuntimeNotificationHelper
 import com.yugahashimoto.andcode.data.connection.SecureSettingsRepository
 import com.yugahashimoto.andcode.data.repository.ProviderCatalogCache
@@ -132,6 +133,8 @@ class AndCodeApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // First, so a crash in the rest of this method is recorded too.
+        CrashLog.install(this)
         startKoin {
             androidContext(this@AndCodeApplication)
             modules(appModule, viewModelModule)

--- a/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/CrashLog.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/CrashLog.kt
@@ -1,0 +1,69 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+import android.content.Context
+import android.os.Build
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Keeps the stack trace of the last crash so it can be read back on the next launch.
+ *
+ * A phone-only user has no logcat, so a crash that happens away from a desk is otherwise
+ * invisible. The record is written from the uncaught-exception handler, which runs while the
+ * process is already dying - so it stays a single small synchronous file write, and the platform
+ * handler still runs afterwards to crash the app the way it normally would.
+ */
+object CrashLog {
+    /** Registers the handler. Call first in Application.onCreate so startup crashes are caught. */
+    fun install(context: Context) {
+        val appContext = context.applicationContext
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, error ->
+            runCatching { write(appContext, thread, error) }
+            previous?.uncaughtException(thread, error)
+        }
+    }
+
+    /** The last recorded crash, or null when the app has not crashed since the record was cleared. */
+    fun read(context: Context): String? =
+        runCatching {
+            file(context).takeIf(File::exists)?.readText()?.takeIf(String::isNotBlank)
+        }.getOrNull()
+
+    fun clear(context: Context) {
+        runCatching { file(context).delete() }
+    }
+
+    private fun write(
+        context: Context,
+        thread: Thread,
+        error: Throwable,
+    ) {
+        val stackTrace =
+            StringWriter().also { writer ->
+                PrintWriter(writer).use(error::printStackTrace)
+            }.toString()
+        val report =
+            buildString {
+                appendLine("AndCode crash")
+                appendLine("Time: ${TIMESTAMP.format(Date())}")
+                appendLine("Thread: ${thread.name}")
+                appendLine("Android: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
+                appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
+                appendLine()
+                append(stackTrace.take(MAX_TRACE_CHARS))
+            }
+        val target = file(context)
+        target.parentFile?.mkdirs()
+        target.writeText(report)
+    }
+
+    private fun file(context: Context): File = File(File(context.filesDir, "diagnostics"), "last-crash.txt")
+
+    private val TIMESTAMP = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+    private const val MAX_TRACE_CHARS = 12_000
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleAlarmReceiver.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleAlarmReceiver.kt
@@ -18,7 +18,16 @@ class ScheduleAlarmReceiver : BroadcastReceiver() {
         when (intent.action) {
             ACTION_RUN_SCHEDULE -> {
                 val scheduleId = intent.getStringExtra(EXTRA_SCHEDULE_ID) ?: return
-                ScheduleExecutionService.start(context, scheduleId)
+                if (!ScheduleExecutionService.start(context, scheduleId)) {
+                    // The system refused the background foreground-service start; leave a trace in
+                    // the run history so the schedule does not look silently stuck.
+                    app.scheduleRepository.schedule(scheduleId)?.let { schedule ->
+                        app.scheduleRepository.recordRunSkipped(schedule, SKIP_REASON_BLOCKED)
+                    }
+                }
+                // A cron alarm is one-shot: the next one is normally armed once the run settles,
+                // so re-arm here too or a run that never started would end the whole series.
+                app.scheduleManager.rescheduleAll()
             }
             Intent.ACTION_BOOT_COMPLETED,
             Intent.ACTION_MY_PACKAGE_REPLACED,
@@ -30,5 +39,6 @@ class ScheduleAlarmReceiver : BroadcastReceiver() {
     companion object {
         const val ACTION_RUN_SCHEDULE = "com.yugahashimoto.andcode.RUN_SCHEDULE"
         const val EXTRA_SCHEDULE_ID = "schedule_id"
+        private const val SKIP_REASON_BLOCKED = "background start blocked by the system"
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
@@ -487,18 +487,33 @@ private fun TimePickerButton(
     }
 }
 
-/** Mutable timing form state that turns itself back into cron/one-time fields on save. */
+/**
+ * Mutable timing form state that turns itself back into cron/one-time fields on save.
+ *
+ * Every field is snapshot state: the editor reads them during composition, so plain vars would
+ * leave the timing chips, the date/time buttons and the cron field frozen at their initial values.
+ */
 private class TimingState(
-    var mode: TimingMode,
-    var onceDate: LocalDate?,
-    var onceTime: LocalTime?,
-    var dailyTime: LocalTime?,
-    var weeklyDay: DayOfWeek?,
-    var weeklyTime: LocalTime?,
-    var monthlyDay: Int?,
-    var monthlyTime: LocalTime?,
-    var cronText: String,
+    mode: TimingMode,
+    onceDate: LocalDate?,
+    onceTime: LocalTime?,
+    dailyTime: LocalTime?,
+    weeklyDay: DayOfWeek?,
+    weeklyTime: LocalTime?,
+    monthlyDay: Int?,
+    monthlyTime: LocalTime?,
+    cronText: String,
 ) {
+    var mode by mutableStateOf(mode)
+    var onceDate by mutableStateOf(onceDate)
+    var onceTime by mutableStateOf(onceTime)
+    var dailyTime by mutableStateOf(dailyTime)
+    var weeklyDay by mutableStateOf(weeklyDay)
+    var weeklyTime by mutableStateOf(weeklyTime)
+    var monthlyDay by mutableStateOf(monthlyDay)
+    var monthlyTime by mutableStateOf(monthlyTime)
+    var cronText by mutableStateOf(cronText)
+
     fun pendingTime(): LocalTime? =
         when (mode) {
             TimingMode.ONCE -> onceTime

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.yugahashimoto.andcode.AndCodeApplication
@@ -41,12 +42,20 @@ import kotlinx.coroutines.withTimeoutOrNull
 class ScheduleExecutionService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var app: AndCodeApplication
+    private var inForeground = false
 
     override fun onCreate() {
         super.onCreate()
         app = application as AndCodeApplication
         createChannel()
-        startForeground(NOTIFICATION_ID, notification(app.getString(R.string.schedule_notification_starting)))
+        // Android 14+ can still reject the foreground promotion here even though the start itself
+        // was accepted. Bailing out is the only safe answer: a service that cannot enter the
+        // foreground is killed with a crash by the system anyway.
+        inForeground =
+            runCatching {
+                startForeground(NOTIFICATION_ID, notification(app.getString(R.string.schedule_notification_starting)))
+            }.onFailure { error -> Log.w(TAG, "Could not enter the foreground", error) }
+                .isSuccess
     }
 
     override fun onStartCommand(
@@ -55,7 +64,7 @@ class ScheduleExecutionService : Service() {
         startId: Int,
     ): Int {
         val scheduleId = intent?.getStringExtra(EXTRA_SCHEDULE_ID)
-        if (scheduleId == null) {
+        if (scheduleId == null || !inForeground) {
             stopSelf()
             return START_NOT_STICKY
         }
@@ -280,19 +289,35 @@ class ScheduleExecutionService : Service() {
 
     companion object {
         const val EXTRA_SCHEDULE_ID = "schedule_id"
+        private const val TAG = "ScheduleExecution"
         private const val CHANNEL_ID = "andcode_schedule_runs"
         private const val NOTIFICATION_ID = 4201
         private const val LOCAL_RUNTIME_START_TIMEOUT_MS = 5 * 60_000L
 
+        /**
+         * Starts a run, returning false when the platform refused the foreground start.
+         *
+         * Android 12+ only lets a background app start a foreground service when it is exempt,
+         * and an alarm grants that exemption only when it was scheduled exactly. Devices that
+         * withhold the exact-alarm permission therefore wake us through an inexact alarm with no
+         * exemption, and the start throws ForegroundServiceStartNotAllowedException - callers
+         * have to handle the refusal instead of letting it crash the app.
+         */
         fun start(
             context: Context,
             scheduleId: String,
-        ) {
+        ): Boolean {
             val intent =
                 Intent(context, ScheduleExecutionService::class.java).apply {
                     putExtra(EXTRA_SCHEDULE_ID, scheduleId)
                 }
-            ContextCompat.startForegroundService(context, intent)
+            return try {
+                ContextCompat.startForegroundService(context, intent)
+                true
+            } catch (error: Exception) {
+                Log.w(TAG, "Foreground start refused for schedule $scheduleId", error)
+                false
+            }
         }
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleListScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleListScreen.kt
@@ -1,5 +1,7 @@
 package com.yugahashimoto.andcode.feature.schedule
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -41,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -67,8 +70,18 @@ fun ScheduleListScreen(
     onRunNow: (String) -> Unit,
     onDelete: (String) -> Unit,
     onToggleEnabled: (String, Boolean) -> Unit,
+    exactAlarmsAllowed: () -> Boolean,
+    onExactAlarmsGranted: () -> Unit,
 ) {
     var pendingDelete by remember { mutableStateOf<Schedule?>(null) }
+    val context = LocalContext.current
+    // Re-read on the way back from settings: granting is what makes scheduled runs able to start.
+    var alarmsAreExact by remember { mutableStateOf(exactAlarmsAllowed()) }
+    val exactAlarmSettings =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            alarmsAreExact = exactAlarmsAllowed()
+            if (alarmsAreExact) onExactAlarmsGranted()
+        }
 
     Scaffold(
         topBar = {
@@ -100,46 +113,59 @@ fun ScheduleListScreen(
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
-        if (schedules.isEmpty()) {
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(padding)
-                        .padding(horizontal = 24.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Icon(
-                    Icons.Default.Schedule,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(40.dp),
-                )
-                Text(
-                    text = stringResource(R.string.schedule_empty),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            if (!alarmsAreExact) {
+                ExactAlarmBanner(
+                    onAllow = {
+                        // The dedicated screen is missing on some builds, so fall through the
+                        // candidates until one of them opens.
+                        exactAlarmSettingsIntents(context).any { intent ->
+                            runCatching { exactAlarmSettings.launch(intent) }.isSuccess
+                        }
+                    },
                 )
             }
-        } else {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize().padding(padding),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 12.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                items(schedules, key = { it.id }) { schedule ->
-                    ScheduleRow(
-                        schedule = schedule,
-                        lastRun = runs.firstOrNull { it.scheduleId == schedule.id },
-                        nextFireAt = nextFireAt(schedule),
-                        runtimeTargets = runtimeTargets,
-                        onOpen = { onOpenSchedule(schedule.id) },
-                        onEdit = { onEdit(schedule.id) },
-                        onRunNow = { onRunNow(schedule.id) },
-                        onDelete = { pendingDelete = schedule },
-                        onToggleEnabled = { enabled -> onToggleEnabled(schedule.id, enabled) },
+            if (schedules.isEmpty()) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                            .padding(horizontal = 24.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Icon(
+                        Icons.Default.Schedule,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(40.dp),
                     )
+                    Text(
+                        text = stringResource(R.string.schedule_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    items(schedules, key = { it.id }) { schedule ->
+                        ScheduleRow(
+                            schedule = schedule,
+                            lastRun = runs.firstOrNull { it.scheduleId == schedule.id },
+                            nextFireAt = nextFireAt(schedule),
+                            runtimeTargets = runtimeTargets,
+                            onOpen = { onOpenSchedule(schedule.id) },
+                            onEdit = { onEdit(schedule.id) },
+                            onRunNow = { onRunNow(schedule.id) },
+                            onDelete = { pendingDelete = schedule },
+                            onToggleEnabled = { enabled -> onToggleEnabled(schedule.id, enabled) },
+                        )
+                    }
                 }
             }
         }
@@ -164,6 +190,52 @@ fun ScheduleListScreen(
                 }
             },
         )
+    }
+}
+
+/**
+ * Asks for the alarms & reminders permission, without which Android refuses to let a scheduled
+ * run start at all.
+ */
+@Composable
+private fun ExactAlarmBanner(onAllow: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.errorContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 12.dp, top = 10.dp, bottom = 10.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.Schedule,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.schedule_exact_alarm_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Text(
+                    text = stringResource(R.string.schedule_exact_alarm_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+            TextButton(onClick = onAllow) {
+                Text(
+                    text = stringResource(R.string.schedule_exact_alarm_action),
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleManager.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleManager.kt
@@ -4,7 +4,9 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import com.yugahashimoto.andcode.data.schedule.CronExpression
 import com.yugahashimoto.andcode.data.schedule.Schedule
 import com.yugahashimoto.andcode.data.schedule.ScheduleRepository
@@ -32,9 +34,9 @@ class ScheduleManager(
         if (!schedule.enabled) return
         val nextFireAt = nextFireAt(schedule) ?: return
         val triggerAt = nextFireAt.toEpochMilli()
-        // Exact alarms are exempt from Doze and battery optimizations; without the exact-alarm
-        // permission (Android 12+) the alarm still fires, just possibly a few minutes late.
-        if (canScheduleExactAlarms()) {
+        // Exact alarms are exempt from Doze and battery optimizations. An inexact alarm is not
+        // merely late: see [exactAlarmsAllowed] for why the run cannot start from one at all.
+        if (exactAlarmsAllowed()) {
             alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pending)
         } else {
             alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pending)
@@ -62,7 +64,16 @@ class ScheduleManager(
             else -> null
         }
 
-    private fun canScheduleExactAlarms(): Boolean = Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()
+    /**
+     * True when the app may arm exact alarms; always true below Android 12, which does not gate
+     * them.
+     *
+     * An inexact alarm is not just a late alarm. The wake-up it delivers carries no
+     * foreground-service start exemption, so the run cannot be launched at all - and Android 14
+     * denies this permission by default to apps targeting SDK 33 and up. The schedules screen
+     * therefore asks the user for it.
+     */
+    fun exactAlarmsAllowed(): Boolean = Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()
 
     private fun pendingIntent(scheduleId: String): PendingIntent =
         PendingIntent.getBroadcast(
@@ -74,4 +85,23 @@ class ScheduleManager(
             },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
+}
+
+/**
+ * Screens that let the user grant exact alarms, best first.
+ *
+ * The dedicated screen only exists on Android 12+ and some builds do not ship it at all, so the
+ * app's own settings page follows as a fallback the caller can try next.
+ */
+fun exactAlarmSettingsIntents(context: Context): List<Intent> {
+    val appSettings =
+        Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.parse("package:${context.packageName}"),
+        )
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return listOf(appSettings)
+    return listOf(
+        Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM, Uri.parse("package:${context.packageName}")),
+        appSettings,
+    )
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/DiagnosticsSheet.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/DiagnosticsSheet.kt
@@ -17,12 +17,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.BuildConfig
 import com.yugahashimoto.andcode.R
+import com.yugahashimoto.andcode.core.diagnostics.CrashLog
 import com.yugahashimoto.andcode.ui.components.LabelValueRow
 import com.yugahashimoto.andcode.ui.components.SectionCard
 
@@ -46,6 +49,11 @@ fun DiagnosticsSheet(
     val availableBytes = statFs.availableBytes
     val totalBytes = statFs.totalBytes
 
+    val context = LocalContext.current
+    // The dialog shown at launch is easy to close by accident, so the record stays reachable here
+    // until it has been copied.
+    val lastCrash = remember { CrashLog.read(context) }
+
     val markdown =
         buildString {
             appendLine("# AndCode Diagnostics")
@@ -66,6 +74,13 @@ fun DiagnosticsSheet(
             appendLine("## Storage")
             appendLine("- Available: ${formatBytes(availableBytes)}")
             appendLine("- Total: ${formatBytes(totalBytes)}")
+            if (lastCrash != null) {
+                appendLine()
+                appendLine("## Last crash")
+                appendLine("```")
+                appendLine(lastCrash)
+                appendLine("```")
+            }
         }
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
@@ -115,6 +130,20 @@ fun DiagnosticsSheet(
                 }
             }
 
+            if (lastCrash != null) {
+                SectionCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        DiagnosticsSectionHeader(stringResource(R.string.diagnostics_section_last_crash))
+                        Text(
+                            text = lastCrash.lineSequence().take(CRASH_PREVIEW_LINES).joinToString("\n"),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
             Button(
                 onClick = {
                     clipboard.setText(AnnotatedString(markdown))
@@ -139,6 +168,8 @@ private fun DiagnosticsSectionHeader(title: String) {
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
 }
+
+private const val CRASH_PREVIEW_LINES = 12
 
 private fun formatBytes(bytes: Long): String {
     val gb = bytes / (1024.0 * 1024.0 * 1024.0)

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
@@ -69,24 +69,29 @@ class AntigravityController(
      * forever even though the binary is already in the guest.
      */
     fun refresh() {
-        scope.launch {
-            val installed = installer.installedRuntime()
-            val rootfs = installed?.antigravityRootfs
-            val binaryInstalled = rootfs?.resolve("usr/local/bin/agy")?.let { it.isFile && it.canExecute() } == true
-            if (!binaryInstalled) return@launch
-            val version = target.runtime.version()
-            mutableState.value =
-                mutableState.value.copy(
-                    installed = true,
-                    version = version,
-                    install = version?.let(AntigravityInstallStatus::Ready) ?: AntigravityInstallStatus.Idle,
-                )
-            // The token lives in the guest rootfs, so a restarted app is still signed in even
-            // though the in-memory coordinator starts at Idle. `models()` answers that and fills
-            // the picker's catalogue in the same launch - asking twice would mean two agy runs,
-            // and two of those overlapping is what previously hung both of them.
-            if (target.runtime.models().isNotEmpty()) target.auth.markSignedIn()
-        }
+        // Reading the environment on disk can fail on a half-installed or damaged runtime, and
+        // this launch has nothing to catch what it throws: an unhandled exception here takes the
+        // whole app down. Rehydration is best-effort, so a failure just leaves the state as is.
+        scope.launch { runCatching { rehydrate() } }
+    }
+
+    private suspend fun rehydrate() {
+        val installed = installer.installedRuntime()
+        val rootfs = installed?.antigravityRootfs
+        val binaryInstalled = rootfs?.resolve("usr/local/bin/agy")?.let { it.isFile && it.canExecute() } == true
+        if (!binaryInstalled) return
+        val version = target.runtime.version()
+        mutableState.value =
+            mutableState.value.copy(
+                installed = true,
+                version = version,
+                install = version?.let(AntigravityInstallStatus::Ready) ?: AntigravityInstallStatus.Idle,
+            )
+        // The token lives in the guest rootfs, so a restarted app is still signed in even though
+        // the in-memory coordinator starts at Idle. `models()` answers that and fills the picker's
+        // catalogue in the same launch - asking twice would mean two agy runs, and two of those
+        // overlapping is what previously hung both of them.
+        if (target.runtime.models().isNotEmpty()) target.auth.markSignedIn()
     }
 
     /**

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeController.kt
@@ -68,7 +68,9 @@ class ClaudeCodeController(
     /** Reads the sandbox to find out whether Claude Code is installed and signed in. */
     fun refresh() {
         if (installJob?.isActive == true) return
-        scope.launch { refreshBlocking() }
+        // Reading a damaged environment on disk must not reach the uncaught-exception handler and
+        // take the app down; this refresh is best-effort, so a failure leaves the state as is.
+        scope.launch { runCatching { refreshBlocking() } }
     }
 
     /**

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivation.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivation.kt
@@ -2,8 +2,12 @@ package com.yugahashimoto.andcode.runtime.local
 
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 
 internal fun activateRuntimeEnvironment(
     active: File,
@@ -63,17 +67,41 @@ internal fun normalizeRuntimeSymlinks(environment: File) {
             current.resolveSibling("environment.rollback"),
             current.resolveSibling("environment.failed"),
         )
-    Files.walk(current).use { paths ->
-        paths.filter(Files::isSymbolicLink).forEach { link ->
-            val target = Files.readSymbolicLink(link)
-            if (!target.isAbsolute) return@forEach
-            val normalizedTarget = target.normalize()
-            val oldRoot = possibleRoots.firstOrNull(normalizedTarget::startsWith) ?: return@forEach
-            val targetInCurrent = current.resolve(oldRoot.relativize(normalizedTarget))
-            replaceSymlink(link, link.parent.relativize(targetInCurrent))
-        }
-    }
+    // A guest rootfs carries directories the app's own uid cannot open - PRoot's bind-mount points
+    // come out of the tarball with no permissions at all. Walking with a visitor lets those be
+    // skipped; Files.walk would abort the whole traversal with an UncheckedIOException instead.
+    Files.walkFileTree(
+        current,
+        object : SimpleFileVisitor<Path>() {
+            override fun visitFile(
+                file: Path,
+                attributes: BasicFileAttributes,
+            ): FileVisitResult {
+                if (attributes.isSymbolicLink) relativizeSymlink(file, current, possibleRoots)
+                return FileVisitResult.CONTINUE
+            }
+
+            override fun visitFileFailed(
+                file: Path,
+                error: IOException,
+            ): FileVisitResult = FileVisitResult.CONTINUE
+        },
+    )
     marker.writeText("normalized\n")
+}
+
+/** Rewrites [link] to point inside [current] when it still targets an older environment root. */
+private fun relativizeSymlink(
+    link: Path,
+    current: Path,
+    possibleRoots: List<Path>,
+) {
+    val target = Files.readSymbolicLink(link)
+    if (!target.isAbsolute) return
+    val normalizedTarget = target.normalize()
+    val oldRoot = possibleRoots.firstOrNull(normalizedTarget::startsWith) ?: return
+    val targetInCurrent = current.resolve(oldRoot.relativize(normalizedTarget))
+    replaceSymlink(link, link.parent.relativize(targetInCurrent))
 }
 
 private fun replaceSymlink(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
@@ -7,6 +7,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.yugahashimoto.andcode.AndCodeApplication
@@ -112,12 +113,19 @@ class LocalRuntimeService : Service() {
     @Volatile private var autoRestartEnabled = false
     private lateinit var manager: LocalRuntimeManager
     private val backoff = RestartBackoff()
+    private var inForeground = false
 
     override fun onCreate() {
         super.onCreate()
         manager = (application as AndCodeApplication).localRuntimeManager
         createChannel()
-        startForeground(NOTIFICATION_ID, notification(manager.status()))
+        // The platform can refuse the foreground promotion for a service the app started while it
+        // was in the background. Giving up beats being killed for never calling startForeground.
+        inForeground =
+            runCatching { startForeground(NOTIFICATION_ID, notification(manager.status())) }
+                .onFailure { error -> Log.w(TAG, "Could not enter the foreground", error) }
+                .isSuccess
+        if (!inForeground) return
         scope.launch {
             manager.state.collectLatest { status ->
                 getSystemService(NotificationManager::class.java)
@@ -147,6 +155,10 @@ class LocalRuntimeService : Service() {
         flags: Int,
         startId: Int,
     ): Int {
+        if (!inForeground) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
         when (localRuntimeServiceCommand(intent?.action)) {
             LocalRuntimeServiceCommand.InstallAndStart -> {
                 autoRestartEnabled = true
@@ -332,6 +344,7 @@ class LocalRuntimeService : Service() {
     )
 
     companion object {
+        private const val TAG = "LocalRuntimeService"
         private const val CHANNEL_ID = "local_opencode_runtime"
         private const val NOTIFICATION_ID = 4107
         private const val WATCHDOG_INTERVAL_MILLIS = 5_000L
@@ -347,6 +360,15 @@ class LocalRuntimeService : Service() {
         /** Ids of the agents an install should provision; see [LocalRuntimeInstaller.install]. */
         const val EXTRA_AGENTS = "com.yugahashimoto.andcode.local.AGENTS"
 
+        /**
+         * Sends a command to the runtime service, starting it when it is not running yet.
+         *
+         * Android 12+ only lets an app start a foreground service from the background when it is
+         * exempt, and the app is woken in the background by things it does not drive: a schedule's
+         * alarm, a widget update. The auto-start on process creation then reaches this from a
+         * process that holds no exemption, so a refusal has to stay a refusal rather than take the
+         * app down - the runtime comes up on the next start that is allowed.
+         */
         fun send(
             context: Context,
             action: String,
@@ -354,7 +376,8 @@ class LocalRuntimeService : Service() {
         ) {
             val intent = Intent(context, LocalRuntimeService::class.java).setAction(action)
             if (agents.isNotEmpty()) intent.putExtra(EXTRA_AGENTS, agents.map(LocalAgent::id).toTypedArray())
-            ContextCompat.startForegroundService(context, intent)
+            runCatching { ContextCompat.startForegroundService(context, intent) }
+                .onFailure { error -> Log.w(TAG, "Foreground start refused for $action", error) }
         }
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -91,6 +91,7 @@ import com.yugahashimoto.andcode.ui.navigation.ROUTE_SCHEDULES
 import com.yugahashimoto.andcode.ui.navigation.ROUTE_SCHEDULE_EDIT
 import com.yugahashimoto.andcode.ui.navigation.ROUTE_SETTINGS_PROVIDERS
 import com.yugahashimoto.andcode.ui.navigation.SCHEDULE_DETAIL_ROUTE_PATTERN
+import com.yugahashimoto.andcode.ui.navigation.SCHEDULE_EDIT_ARG_ID
 import com.yugahashimoto.andcode.ui.navigation.SCHEDULE_EDIT_ROUTE_PATTERN
 import com.yugahashimoto.andcode.ui.navigation.decodeRouteArg
 import com.yugahashimoto.andcode.ui.navigation.scheduleDetailRoute
@@ -1011,7 +1012,7 @@ fun AndCodeApp(
                     route = SCHEDULE_EDIT_ROUTE_PATTERN,
                     arguments =
                         listOf(
-                            navArgument("scheduleId") {
+                            navArgument(SCHEDULE_EDIT_ARG_ID) {
                                 type = NavType.StringType
                                 nullable = true
                                 defaultValue = null
@@ -1019,7 +1020,7 @@ fun AndCodeApp(
                         ),
                 ) { backStackEntry ->
                     val scheduleId =
-                        backStackEntry.arguments?.getString("scheduleId")
+                        backStackEntry.arguments?.getString(SCHEDULE_EDIT_ARG_ID)
                             ?.takeIf(String::isNotBlank)
                             ?.let(::decodeRouteArg)
                     ScheduleEditorScreen(

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Lock
@@ -44,9 +46,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -60,6 +65,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.yugahashimoto.andcode.AndCodeApplication
 import com.yugahashimoto.andcode.R
+import com.yugahashimoto.andcode.core.diagnostics.CrashLog
 import com.yugahashimoto.andcode.feature.activity.ActivityViewModel
 import com.yugahashimoto.andcode.feature.assistant.SpeechRecognizerManager
 import com.yugahashimoto.andcode.feature.assistant.SpeechResult
@@ -223,6 +229,21 @@ fun AndCodeApp(
         )
     val schedules by scheduleViewModel.schedules.collectAsState()
     val scheduleRuns by scheduleViewModel.runs.collectAsState()
+
+    // A crash the user hit while away from a computer is only recoverable from here. Copying is
+    // what discards the record; closing the dialog only hides it, and the diagnostics sheet still
+    // has it until it has been copied or a later crash replaces it.
+    var lastCrash by remember { mutableStateOf(CrashLog.read(context)) }
+    lastCrash?.let { report ->
+        CrashReportDialog(
+            report = report,
+            onCopied = {
+                CrashLog.clear(context)
+                lastCrash = null
+            },
+            onDismiss = { lastCrash = null },
+        )
+    }
 
     // Which chat the user is actually looking at. A run that finishes while they are elsewhere has
     // to stay unread, so this is tracked separately from the chat view model's own session.
@@ -1249,6 +1270,50 @@ private fun GithubCloneDialog(
         dismissButton = {
             TextButton(onClick = onDismiss, enabled = !isCloning) {
                 Text(stringResource(R.string.cancel))
+            }
+        },
+    )
+}
+
+/** Shows the stack trace of the crash the app came back from, so it can be reported by hand. */
+@Composable
+private fun CrashReportDialog(
+    report: String,
+    onCopied: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val clipboard = LocalClipboardManager.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.crash_report_title)) },
+        text = {
+            Column(
+                modifier = Modifier.heightIn(max = 320.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.crash_report_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    text = report,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                clipboard.setText(AnnotatedString(report))
+                onCopied()
+            }) {
+                Text(stringResource(R.string.crash_report_copy))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.crash_report_dismiss))
             }
         },
     )

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -970,6 +970,10 @@ fun AndCodeApp(
                         },
                         onDelete = scheduleViewModel::delete,
                         onToggleEnabled = scheduleViewModel::setEnabled,
+                        exactAlarmsAllowed = app.scheduleManager::exactAlarmsAllowed,
+                        // Alarms armed while the permission was missing are inexact; granting it
+                        // only takes effect once they are re-armed.
+                        onExactAlarmsGranted = app.scheduleManager::rescheduleAll,
                     )
                 }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/Routes.kt
@@ -41,8 +41,7 @@ const val CODE_VIEWER_ROUTE_PATTERN = "$ROUTE_CODE_VIEWER/{runtimeId}/{workspace
 
 fun scheduleDetailRoute(scheduleId: String): String = "$ROUTE_SCHEDULE_DETAIL/${encodeRouteArg(scheduleId)}"
 
-fun scheduleEditRoute(scheduleId: String): String =
-    "$ROUTE_SCHEDULE_EDIT?$SCHEDULE_EDIT_ARG_ID=${encodeRouteArg(scheduleId)}"
+fun scheduleEditRoute(scheduleId: String): String = "$ROUTE_SCHEDULE_EDIT?$SCHEDULE_EDIT_ARG_ID=${encodeRouteArg(scheduleId)}"
 
 fun codeViewerRoute(
     runtimeId: String,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/Routes.kt
@@ -26,8 +26,14 @@ const val ROUTE_SCHEDULES = "schedules"
 const val ROUTE_SCHEDULE_DETAIL = "schedule-detail"
 const val SCHEDULE_DETAIL_ROUTE_PATTERN = "$ROUTE_SCHEDULE_DETAIL/{scheduleId}"
 const val ROUTE_SCHEDULE_EDIT = "schedule-edit"
-const val ROUTE_SCHEDULE_EDIT_NEW = ROUTE_SCHEDULE_EDIT
-const val SCHEDULE_EDIT_ROUTE_PATTERN = "$ROUTE_SCHEDULE_EDIT/{scheduleId}"
+
+/**
+ * The editor doubles as the "new schedule" screen, so [SCHEDULE_EDIT_ARG_ID] has to be optional.
+ * Navigation only treats query parameters as optional - as a path segment it would be required and
+ * navigating to the bare [ROUTE_SCHEDULE_EDIT] would not match any destination.
+ */
+const val SCHEDULE_EDIT_ARG_ID = "scheduleId"
+const val SCHEDULE_EDIT_ROUTE_PATTERN = "$ROUTE_SCHEDULE_EDIT?$SCHEDULE_EDIT_ARG_ID={$SCHEDULE_EDIT_ARG_ID}"
 const val ROUTE_CODE_VIEWER = "code-viewer"
 const val ROUTE_TERMINAL = "terminal"
 
@@ -35,7 +41,8 @@ const val CODE_VIEWER_ROUTE_PATTERN = "$ROUTE_CODE_VIEWER/{runtimeId}/{workspace
 
 fun scheduleDetailRoute(scheduleId: String): String = "$ROUTE_SCHEDULE_DETAIL/${encodeRouteArg(scheduleId)}"
 
-fun scheduleEditRoute(scheduleId: String): String = "$ROUTE_SCHEDULE_EDIT/${encodeRouteArg(scheduleId)}"
+fun scheduleEditRoute(scheduleId: String): String =
+    "$ROUTE_SCHEDULE_EDIT?$SCHEDULE_EDIT_ARG_ID=${encodeRouteArg(scheduleId)}"
 
 fun codeViewerRoute(
     runtimeId: String,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -904,6 +904,11 @@
     <string name="schedule_exact_alarm_title">السماح بالمنبهات والتذكيرات</string>
     <string name="schedule_exact_alarm_body">بدون هذا الإذن يمنع Android بدء عمليات التشغيل المجدولة.</string>
     <string name="schedule_exact_alarm_action">السماح</string>
+    <string name="crash_report_title">تعطل التطبيق</string>
+    <string name="crash_report_body">انسخ هذا التقرير وأرسله إلى المطور.</string>
+    <string name="crash_report_copy">نسخ</string>
+    <string name="crash_report_dismiss">إغلاق</string>
+    <string name="diagnostics_section_last_crash">آخر تعطل</string>
     <string name="schedule_auto_accept_default">الافتراضي</string>
     <string name="schedule_timing_daily_label">يوميًا %1$s</string>
     <string name="schedule_timing_weekly_label">أسبوعيًا %1$s %2$s</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -901,6 +901,9 @@
     <string name="schedule_recurring">متكرر</string>
     <string name="schedule_run_now_started">الجدول قيد التشغيل.</string>
     <string name="schedule_edit_menu">تعديل</string>
+    <string name="schedule_exact_alarm_title">السماح بالمنبهات والتذكيرات</string>
+    <string name="schedule_exact_alarm_body">بدون هذا الإذن يمنع Android بدء عمليات التشغيل المجدولة.</string>
+    <string name="schedule_exact_alarm_action">السماح</string>
     <string name="schedule_auto_accept_default">الافتراضي</string>
     <string name="schedule_timing_daily_label">يوميًا %1$s</string>
     <string name="schedule_timing_weekly_label">أسبوعيًا %1$s %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -904,6 +904,11 @@
     <string name="schedule_exact_alarm_title">Permitir alarmas y recordatorios</string>
     <string name="schedule_exact_alarm_body">Sin este permiso, Android impide que se inicien las ejecuciones programadas.</string>
     <string name="schedule_exact_alarm_action">Permitir</string>
+    <string name="crash_report_title">La aplicación se ha cerrado</string>
+    <string name="crash_report_body">Copia este informe y envíaselo al desarrollador.</string>
+    <string name="crash_report_copy">Copiar</string>
+    <string name="crash_report_dismiss">Cerrar</string>
+    <string name="diagnostics_section_last_crash">Último fallo</string>
     <string name="schedule_auto_accept_default">Por defecto</string>
     <string name="schedule_timing_daily_label">Diario %1$s</string>
     <string name="schedule_timing_weekly_label">Semanal %1$s %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -901,6 +901,9 @@
     <string name="schedule_recurring">Recurrente</string>
     <string name="schedule_run_now_started">La programación se está ejecutando.</string>
     <string name="schedule_edit_menu">Editar</string>
+    <string name="schedule_exact_alarm_title">Permitir alarmas y recordatorios</string>
+    <string name="schedule_exact_alarm_body">Sin este permiso, Android impide que se inicien las ejecuciones programadas.</string>
+    <string name="schedule_exact_alarm_action">Permitir</string>
     <string name="schedule_auto_accept_default">Por defecto</string>
     <string name="schedule_timing_daily_label">Diario %1$s</string>
     <string name="schedule_timing_weekly_label">Semanal %1$s %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -901,6 +901,9 @@
     <string name="schedule_recurring">Récurrente</string>
     <string name="schedule_run_now_started">La planification est en cours d’exécution.</string>
     <string name="schedule_edit_menu">Modifier</string>
+    <string name="schedule_exact_alarm_title">Autoriser les alarmes et rappels</string>
+    <string name="schedule_exact_alarm_body">Sans cette autorisation, Android empêche le démarrage des exécutions planifiées.</string>
+    <string name="schedule_exact_alarm_action">Autoriser</string>
     <string name="schedule_auto_accept_default">Par défaut</string>
     <string name="schedule_timing_daily_label">Quotidien %1$s</string>
     <string name="schedule_timing_weekly_label">Hebdomadaire %1$s %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -904,6 +904,11 @@
     <string name="schedule_exact_alarm_title">Autoriser les alarmes et rappels</string>
     <string name="schedule_exact_alarm_body">Sans cette autorisation, Android empêche le démarrage des exécutions planifiées.</string>
     <string name="schedule_exact_alarm_action">Autoriser</string>
+    <string name="crash_report_title">L’application a planté</string>
+    <string name="crash_report_body">Copiez ce rapport et envoyez-le au développeur.</string>
+    <string name="crash_report_copy">Copier</string>
+    <string name="crash_report_dismiss">Fermer</string>
+    <string name="diagnostics_section_last_crash">Dernier plantage</string>
     <string name="schedule_auto_accept_default">Par défaut</string>
     <string name="schedule_timing_daily_label">Quotidien %1$s</string>
     <string name="schedule_timing_weekly_label">Hebdomadaire %1$s %2$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -917,6 +917,11 @@
     <string name="schedule_exact_alarm_title">「アラームとリマインダー」を許可</string>
     <string name="schedule_exact_alarm_body">許可しないと Android がスケジュール実行の開始をブロックします。</string>
     <string name="schedule_exact_alarm_action">許可</string>
+    <string name="crash_report_title">アプリがクラッシュしました</string>
+    <string name="crash_report_body">このレポートをコピーして開発者に送ってください。</string>
+    <string name="crash_report_copy">コピー</string>
+    <string name="crash_report_dismiss">閉じる</string>
+    <string name="diagnostics_section_last_crash">前回のクラッシュ</string>
 
     <string name="schedule_timing_daily_label">毎日 %1$s</string>
     <string name="schedule_timing_weekly_label">毎週%1$s %2$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -914,6 +914,9 @@
     <string name="schedule_recurring">繰り返し</string>
     <string name="schedule_run_now_started">スケジュールを実行しています。</string>
     <string name="schedule_edit_menu">編集</string>
+    <string name="schedule_exact_alarm_title">「アラームとリマインダー」を許可</string>
+    <string name="schedule_exact_alarm_body">許可しないと Android がスケジュール実行の開始をブロックします。</string>
+    <string name="schedule_exact_alarm_action">許可</string>
 
     <string name="schedule_timing_daily_label">毎日 %1$s</string>
     <string name="schedule_timing_weekly_label">毎週%1$s %2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -901,6 +901,9 @@
     <string name="schedule_recurring">Recorrente</string>
     <string name="schedule_run_now_started">O agendamento está em execução.</string>
     <string name="schedule_edit_menu">Editar</string>
+    <string name="schedule_exact_alarm_title">Permitir alarmes e lembretes</string>
+    <string name="schedule_exact_alarm_body">Sem essa permissão, o Android impede que as execuções agendadas iniciem.</string>
+    <string name="schedule_exact_alarm_action">Permitir</string>
     <string name="schedule_auto_accept_default">Padrão</string>
     <string name="schedule_timing_daily_label">Diário %1$s</string>
     <string name="schedule_timing_weekly_label">Semanal %1$s %2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -904,6 +904,11 @@
     <string name="schedule_exact_alarm_title">Permitir alarmes e lembretes</string>
     <string name="schedule_exact_alarm_body">Sem essa permissão, o Android impede que as execuções agendadas iniciem.</string>
     <string name="schedule_exact_alarm_action">Permitir</string>
+    <string name="crash_report_title">O app travou</string>
+    <string name="crash_report_body">Copie este relatório e envie ao desenvolvedor.</string>
+    <string name="crash_report_copy">Copiar</string>
+    <string name="crash_report_dismiss">Fechar</string>
+    <string name="diagnostics_section_last_crash">Última falha</string>
     <string name="schedule_auto_accept_default">Padrão</string>
     <string name="schedule_timing_daily_label">Diário %1$s</string>
     <string name="schedule_timing_weekly_label">Semanal %1$s %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -901,6 +901,9 @@
     <string name="schedule_recurring">Повторяющееся</string>
     <string name="schedule_run_now_started">Расписание выполняется.</string>
     <string name="schedule_edit_menu">Изменить</string>
+    <string name="schedule_exact_alarm_title">Разрешить будильники и напоминания</string>
+    <string name="schedule_exact_alarm_body">Без этого разрешения Android не даёт запускать задачи по расписанию.</string>
+    <string name="schedule_exact_alarm_action">Разрешить</string>
     <string name="schedule_auto_accept_default">По умолчанию</string>
     <string name="schedule_timing_daily_label">Ежедневно %1$s</string>
     <string name="schedule_timing_weekly_label">Еженедельно %1$s %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -904,6 +904,11 @@
     <string name="schedule_exact_alarm_title">Разрешить будильники и напоминания</string>
     <string name="schedule_exact_alarm_body">Без этого разрешения Android не даёт запускать задачи по расписанию.</string>
     <string name="schedule_exact_alarm_action">Разрешить</string>
+    <string name="crash_report_title">Приложение аварийно завершилось</string>
+    <string name="crash_report_body">Скопируйте этот отчёт и отправьте разработчику.</string>
+    <string name="crash_report_copy">Копировать</string>
+    <string name="crash_report_dismiss">Закрыть</string>
+    <string name="diagnostics_section_last_crash">Последний сбой</string>
     <string name="schedule_auto_accept_default">По умолчанию</string>
     <string name="schedule_timing_daily_label">Ежедневно %1$s</string>
     <string name="schedule_timing_weekly_label">Еженедельно %1$s %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -904,6 +904,11 @@
     <string name="schedule_exact_alarm_title">允许闹钟和提醒</string>
     <string name="schedule_exact_alarm_body">未授予该权限时，Android 会阻止计划运行启动。</string>
     <string name="schedule_exact_alarm_action">允许</string>
+    <string name="crash_report_title">应用已崩溃</string>
+    <string name="crash_report_body">请复制此报告并发送给开发者。</string>
+    <string name="crash_report_copy">复制</string>
+    <string name="crash_report_dismiss">关闭</string>
+    <string name="diagnostics_section_last_crash">上次崩溃</string>
     <string name="schedule_auto_accept_default">默认</string>
     <string name="schedule_timing_daily_label">每天 %1$s</string>
     <string name="schedule_timing_weekly_label">每周%1$s %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -901,6 +901,9 @@
     <string name="schedule_recurring">重复</string>
     <string name="schedule_run_now_started">计划正在运行。</string>
     <string name="schedule_edit_menu">编辑</string>
+    <string name="schedule_exact_alarm_title">允许闹钟和提醒</string>
+    <string name="schedule_exact_alarm_body">未授予该权限时，Android 会阻止计划运行启动。</string>
+    <string name="schedule_exact_alarm_action">允许</string>
     <string name="schedule_auto_accept_default">默认</string>
     <string name="schedule_timing_daily_label">每天 %1$s</string>
     <string name="schedule_timing_weekly_label">每周%1$s %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -914,6 +914,9 @@
     <string name="schedule_recurring">Recurring</string>
     <string name="schedule_run_now_started">The schedule is running.</string>
     <string name="schedule_edit_menu">Edit</string>
+    <string name="schedule_exact_alarm_title">Allow alarms &amp; reminders</string>
+    <string name="schedule_exact_alarm_body">Android blocks scheduled runs from starting without it.</string>
+    <string name="schedule_exact_alarm_action">Allow</string>
 
     <string name="schedule_timing_daily_label">Daily %1$s</string>
     <string name="schedule_timing_weekly_label">Weekly %1$s %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -917,6 +917,11 @@
     <string name="schedule_exact_alarm_title">Allow alarms &amp; reminders</string>
     <string name="schedule_exact_alarm_body">Android blocks scheduled runs from starting without it.</string>
     <string name="schedule_exact_alarm_action">Allow</string>
+    <string name="crash_report_title">The app crashed</string>
+    <string name="crash_report_body">Copy this report and send it to the developer.</string>
+    <string name="crash_report_copy">Copy</string>
+    <string name="crash_report_dismiss">Dismiss</string>
+    <string name="diagnostics_section_last_crash">Last crash</string>
 
     <string name="schedule_timing_daily_label">Daily %1$s</string>
     <string name="schedule_timing_weekly_label">Weekly %1$s %2$s</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivationTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeEnvironmentActivationTest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -201,6 +202,34 @@ class LocalRuntimeEnvironmentActivationTest {
         )
 
         normalizeRuntimeSymlinks(active)
+
+        assertFalse(Files.readSymbolicLink(executable.toPath()).isAbsolute)
+        assertEquals("binary", executable.readText())
+        assertTrue(active.resolve(".internal-symlinks-relative").isFile)
+    }
+
+    @Test
+    fun `normalization skips directories it cannot open`() {
+        val root = temporaryFolder.newFolder("runtime-unreadable")
+        val active = root.resolve("environment").apply { mkdirs() }
+        val rootfs = active.resolve("rootfs").apply { mkdirs() }
+        // PRoot's bind-mount points come out of the guest tarball with no permissions at all, and
+        // the app's own uid cannot open them either. Walking must skip them, not give up.
+        val mountPoint = rootfs.resolve("system").apply { mkdirs() }
+        assumeTrue(mountPoint.setReadable(false, false) && !mountPoint.canRead())
+        val bin = rootfs.resolve("usr/bin").apply { mkdirs() }
+        val backing = bin.resolve(".l2s.unzip.0002").apply { writeText("binary") }
+        val executable = bin.resolve("unzip")
+        Files.createSymbolicLink(
+            executable.toPath(),
+            root.resolve("environment.staging").toPath().toAbsolutePath().resolve("rootfs/usr/bin/${backing.name}"),
+        )
+
+        try {
+            normalizeRuntimeSymlinks(active)
+        } finally {
+            mountPoint.setReadable(true, false)
+        }
 
         assertFalse(Files.readSymbolicLink(executable.toPath()).isAbsolute)
         assertEquals("binary", executable.readText())

--- a/app/src/test/java/com/yugahashimoto/andcode/ui/navigation/ScheduleRoutesTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/ui/navigation/ScheduleRoutesTest.kt
@@ -1,0 +1,30 @@
+package com.yugahashimoto.andcode.ui.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScheduleRoutesTest {
+    @Test
+    fun `editor pattern keeps the schedule id optional`() {
+        // "New schedule" navigates to the bare route, which only matches the destination while the
+        // id stays a query parameter - as a path segment Navigation would require it and throw.
+        assertEquals(ROUTE_SCHEDULE_EDIT, SCHEDULE_EDIT_ROUTE_PATTERN.substringBefore('?'))
+        assertTrue(SCHEDULE_EDIT_ROUTE_PATTERN.contains("?$SCHEDULE_EDIT_ARG_ID={$SCHEDULE_EDIT_ARG_ID}"))
+    }
+
+    @Test
+    fun `editing an existing schedule carries the id through the route`() {
+        val route = scheduleEditRoute("schedule-1/with odd chars")
+        assertEquals(ROUTE_SCHEDULE_EDIT, route.substringBefore('?'))
+        val encoded = route.substringAfter("$SCHEDULE_EDIT_ARG_ID=")
+        assertEquals("schedule-1/with odd chars", decodeRouteArg(encoded))
+    }
+
+    @Test
+    fun `schedule detail route round trips its id`() {
+        val route = scheduleDetailRoute("schedule-2")
+        assertEquals(ROUTE_SCHEDULE_DETAIL, route.substringBefore('/'))
+        assertEquals("schedule-2", decodeRouteArg(route.substringAfter('/')))
+    }
+}


### PR DESCRIPTION
Hotfix for the crashes introduced with the scheduled agent runs feature (#168, shipped in v1.1.19).

## Crash 1 — the app dies as the runtime starts, with no user action

This is the one that hits users who never open the new screen. `RuntimeAutoStartInitializer` runs on **every process creation** and unconditionally starts the local runtime:

```
AndCodeApplication.onCreate → scheduleDeferredInitialization()
  → RuntimeAutoStartInitializer.create()
    → localRuntimeController.start()
      → LocalRuntimeService.send() → ContextCompat.startForegroundService()
```

Neither `send()` nor `LocalRuntimeService.onCreate()`'s `startForeground()` was guarded. That was survivable while every process start was user-driven — v1.1.19 added the first unattended one: a schedule's alarm creates the process even when the app is not running. Android 12+ then rejects the foreground-service start, `ForegroundServiceStartNotAllowedException` escapes into `Application.onCreate`, and the process dies right as the runtime comes up.

The exemption an alarm grants only comes with **exact** alarms, and `ScheduleManager` falls back to an inexact alarm whenever the permission is missing — which is the default on Android 14+ for apps targeting SDK 33 and up. So this is the normal path on current devices, not an edge case.

Fix: a refused start degrades to a logged refusal, and the service gives up instead of being killed when the platform rejects the foreground promotion itself. The runtime comes up on the next start that is allowed.

## Crash 2 — tapping "+" on the Schedules screen

`ScheduleEditorScreen` is registered under `"schedule-edit/{scheduleId}"`, so the id is a **required path segment**. The new-schedule button navigates to the bare route:

```kotlin
onNewSchedule = { navController.navigate(ROUTE_SCHEDULE_EDIT) { launchSingleTop = true } }  // "schedule-edit"
```

Nothing in the graph matches that URI → `IllegalArgumentException: Navigation destination that matches request … cannot be found`. `nullable = true` / `defaultValue = null` on the `navArgument` does not help: Navigation only treats **query** parameters as omittable, never path segments.

Fix: the pattern becomes `schedule-edit?scheduleId={scheduleId}` and `scheduleEditRoute()` emits the matching query form, so the bare route resolves to the same destination with a null id. The unused `ROUTE_SCHEDULE_EDIT_NEW` alias, which pointed at the route that did not exist, is gone.

## Crash 3 — a schedule firing in the background

Same root cause as crash 1, one layer up: `ScheduleAlarmReceiver` called `startForegroundService` for `ScheduleExecutionService` straight out of `onReceive`. `ScheduleExecutionService.start()` now reports the refusal instead of propagating it, the receiver records a skipped run so the history shows why nothing happened, and the service bails out if the foreground promotion is rejected in `onCreate`.

## Scheduled runs can now actually run

Guarding the starts stops the crashes but leaves every run refused. The Schedules screen now shows a banner when the alarms & reminders permission is missing and sends the user to the system screen that grants it, falling back to the app's settings page on builds that do not ship the dedicated one. Alarms armed while the permission was missing are inexact, so they are re-armed on the way back once it has been granted. Strings added for all eight locales.

## Broken alarm chain

A cron alarm is one-shot and the next one was only armed in the service's `finally` block, so a run that never started ended the whole series until the app was relaunched. The receiver now re-arms after every firing (`rescheduleAll` is idempotent, so the service's own call still stands).

## Frozen timing form

`TimingState` held its fields in plain `var`s while the editor reads them during composition, so the timing chips, the date/time buttons and the cron field never updated on screen. They are snapshot state now — without it, the screen crash 2 unblocks is unusable.

## Tests

Added `ScheduleRoutesTest` covering the route invariant that broke: the editor pattern's path must equal the bare route, and both schedule routes must round-trip their id.

## Still open (not part of this hotfix)

- The editor's **workspace button** sets `workspaceMenuExpanded` but no menu is ever shown, so a workspace can never be picked and every scheduled run uses the runtime's default directory.
- `ScheduleAlarmReceiver` is `exported="false"` while filtering `BOOT_COMPLETED` / `MY_PACKAGE_REPLACED`, which the system cannot deliver to a non-exported receiver — alarms are not re-armed after a reboot until the app is next opened (`AndCodeApplication.onCreate` re-arms them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014a9x8w54QyjXnsMQX32iKD