### PR TITLE
fix: clear every broken apk package before updating Claude Code

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
@@ -29,6 +29,77 @@ object ClaudeCodeInstaller {
     private const val REPOSITORY = "https://downloads.claude.ai/claude-code/apk/stable"
     private const val SIGNING_KEY_URL = "https://downloads.claude.ai/keys/claude-code.rsa.pub"
     private const val SIGNING_KEY_PATH = "/etc/apk/keys/claude-code.rsa.pub"
+    private const val APK = "/sbin/apk"
+    private const val INSTALLED_DB = "/lib/apk/db/installed"
+
+    /** `$` in a shell snippet, spelled out because these scripts live in Kotlin raw strings. */
+    private const val S = "$"
+
+    /**
+     * Reinstalls every package apk has flagged as broken, best effort.
+     *
+     * A package whose extraction failed keeps an `f:f` (broken files) or `f:s` (broken script) flag
+     * in [INSTALLED_DB], and apk then counts one error per flagged package in *every* transaction it
+     * commits afterwards — including ones that touch nothing else, and including `-s` simulations.
+     * The transaction exits non-zero having printed nothing but `1 error; <size> in <n> packages`,
+     * which is exactly the opaque failure updates were dying with in the field: the flag was left on
+     * a package broken by PRoot's hard-link emulation, and every later `apk add` inherited it.
+     *
+     * `apk fix` without arguments is the only form that clears this: it reinstalls precisely the
+     * packages carrying a flag. Naming one package instead (the previous `apk fix unzip`) reinstalls
+     * that package and still trips over every other package's flag, so it cannot succeed — and under
+     * `set -e` its exit code aborted the update before the upgrade was even attempted.
+     *
+     * Failure here is not fatal: a package that cannot be reinstalled must not block an upgrade that
+     * would otherwise work, so the verification below decides the outcome instead.
+     */
+    private fun repairBrokenPackages(apk: String) = "$apk fix || echo 'and-code: apk fix could not clear every broken package' >&2"
+
+    /**
+     * Package-manager half of the install, split out so tests can drive it with a stub `apk`.
+     *
+     * Both paths deliberately outlive a non-zero `apk` status: it covers the whole transaction, and a
+     * package flagged broken before this run fails that transaction even when everything asked for
+     * here succeeded. The requested packages, not the exit code, decide the outcome.
+     */
+    internal fun installPackageCommands(
+        apk: String = APK,
+        claude: String = CLAUDE_BINARY,
+    ) = """
+        $apk update
+        ${repairBrokenPackages(apk)}
+        if ! $apk add --no-cache claude-code util-linux; then
+          if [ -z "$S($apk info -e claude-code)" ] || [ -z "$S($apk info -e util-linux)" ]; then
+            echo 'and-code: apk failed and the requested packages are not installed' >&2
+            exit 1
+          fi
+          echo 'and-code: apk reported errors from unrelated packages; requested packages are installed' >&2
+        fi
+        $claude --version
+        """.trimIndent()
+
+    /**
+     * Package-manager half of the update.
+     *
+     * `apk version` reads the database without committing anything, so unlike `apk add` it is
+     * unaffected by broken-package flags: an empty result means the repository has nothing newer than
+     * what is installed, which is all this operation was asked to achieve.
+     */
+    internal fun updatePackageCommands(
+        apk: String = APK,
+        claude: String = CLAUDE_BINARY,
+    ) = """
+        $apk update
+        ${repairBrokenPackages(apk)}
+        if ! $apk add --no-cache --upgrade claude-code; then
+          if [ -n "$S($apk version -q -l '<' claude-code)" ]; then
+            echo 'and-code: apk failed and claude-code is still behind the repository' >&2
+            exit 1
+          fi
+          echo 'and-code: apk reported errors from unrelated packages; claude-code is up to date' >&2
+        fi
+        $claude --version
+        """.trimIndent()
 
     /**
      * Shell that adds the signing key and repository, then installs the package.
@@ -36,61 +107,63 @@ object ClaudeCodeInstaller {
      * Written so that a failure at any stage aborts instead of leaving a repository line the sandbox
      * cannot verify, and so that re-running it on an already-configured rootfs is a no-op.
      */
-    private val INSTALL_SCRIPT =
-        """
-        set -e
-        /usr/bin/wget -qO $SIGNING_KEY_PATH $SIGNING_KEY_URL
-        if ! grep -qxF '$REPOSITORY' /etc/apk/repositories; then
-          printf '%s\n' '$REPOSITORY' >> /etc/apk/repositories
-        fi
-        /sbin/apk update
-        /sbin/apk add --no-cache claude-code util-linux
-        $CLAUDE_BINARY --version
-        """.trimIndent()
+    internal val INSTALL_SCRIPT =
+        script(
+            """
+            set -e
+            /usr/bin/wget -qO $SIGNING_KEY_PATH $SIGNING_KEY_URL
+            if ! grep -qxF '$REPOSITORY' /etc/apk/repositories; then
+              printf '%s\n' '$REPOSITORY' >> /etc/apk/repositories
+            fi
+            """,
+            installPackageCommands(),
+        )
 
-    private val UPDATE_SCRIPT =
-        """
-        set -e
-        # Refresh the signing key on every update so a rotated or expired key cannot strand an
-        # upgrade behind an untrusted repository (every version then resolves as masked in: stable).
-        # If the download fails, keep the existing key so a transient outage does not block an
-        # otherwise-valid update; only abort when there is no key to fall back to.
-        if /usr/bin/wget -qO $SIGNING_KEY_PATH.new $SIGNING_KEY_URL; then
-          mv -f $SIGNING_KEY_PATH.new $SIGNING_KEY_PATH
-        elif [ ! -s $SIGNING_KEY_PATH ]; then
-          echo "claude-code signing key is missing and could not be downloaded" >&2
-          exit 1
-        fi
-        /sbin/apk update
-        # Older runtime activations left PRoot's emulated hard links for unzip pointing at the
-        # removed staging directory. The host repairs those links before this script runs; clear
-        # apk's persisted broken-files flag so it no longer makes every package operation exit 1.
-        /sbin/apk fix unzip
-        /sbin/apk add --no-cache --upgrade claude-code
-        $CLAUDE_BINARY --version
-        """.trimIndent()
+    internal val UPDATE_SCRIPT =
+        script(
+            """
+            set -e
+            # Refresh the signing key on every update so a rotated or expired key cannot strand an
+            # upgrade behind an untrusted repository (every version then resolves as masked in:
+            # stable). If the download fails, keep the existing key so a transient outage does not
+            # block an otherwise-valid update; only abort when there is no key to fall back to.
+            if /usr/bin/wget -qO $SIGNING_KEY_PATH.new $SIGNING_KEY_URL; then
+              mv -f $SIGNING_KEY_PATH.new $SIGNING_KEY_PATH
+            elif [ ! -s $SIGNING_KEY_PATH ]; then
+              echo "claude-code signing key is missing and could not be downloaded" >&2
+              exit 1
+            fi
+            """,
+            updatePackageCommands(),
+        )
 
-    private val INSTALL_DIAGNOSTICS_SCRIPT =
+    /** Joins script sections, trimming each so they can be indented to match their surroundings. */
+    private fun script(vararg sections: String) = sections.joinToString("\n") { it.trimIndent().trim() }
+
+    /**
+     * Diagnostics appended to the log when [simulation] — the failed operation, re-run with `-s` —
+     * is worth capturing alongside the sandbox's package state.
+     *
+     * The broken-package listing is here because apk names a package only when it breaks it, never
+     * when it later refuses to work because of the flag it left behind; without the listing that
+     * failure reads as a bare error count with nothing to act on.
+     */
+    private fun diagnosticsScript(simulation: String) =
         """
         echo '--- and-code apk diagnostics ---'
         echo '-- df -h / --'
         df -h / 2>&1 || true
-        echo '-- apk add -s claude-code util-linux --'
-        /sbin/apk add -s claude-code util-linux 2>&1 || true
+        echo '-- packages flagged broken in apk database --'
+        /usr/bin/awk '/^P:/{p=substr(${S}0,3)} /^f:/{print p, ${S}0}' $INSTALLED_DB 2>&1 || true
+        echo '-- apk $simulation --'
+        $APK $simulation 2>&1 || true
         echo '-- apk policy claude-code --'
-        /sbin/apk policy claude-code 2>&1 || true
+        $APK policy claude-code 2>&1 || true
         """.trimIndent()
 
-    private val UPDATE_DIAGNOSTICS_SCRIPT =
-        """
-        echo '--- and-code apk diagnostics ---'
-        echo '-- df -h / --'
-        df -h / 2>&1 || true
-        echo '-- apk add -s --upgrade claude-code --'
-        /sbin/apk add -s --upgrade claude-code 2>&1 || true
-        echo '-- apk policy claude-code --'
-        /sbin/apk policy claude-code 2>&1 || true
-        """.trimIndent()
+    private val INSTALL_DIAGNOSTICS_SCRIPT = diagnosticsScript("add -s claude-code util-linux")
+
+    private val UPDATE_DIAGNOSTICS_SCRIPT = diagnosticsScript("add -s --upgrade claude-code")
 
     /** Steps reported while [installInto] runs, so the UI can show more than a spinner. */
     enum class Step {
@@ -239,6 +312,8 @@ object ClaudeCodeInstaller {
         }
     }
 
+    private val APK_ERROR_SUMMARY_PATTERN = Regex("^\\d+ errors?;")
+
     private val APK_ERROR_PATTERN =
         Regex("(?i)\\b(error|warning|fatal|conflict|overwrite|unsatisfiable|masked|untrusted|denied|no space left|not found|failed to)\\b")
 
@@ -255,8 +330,11 @@ object ClaudeCodeInstaller {
         // `apk update` WARNING/ERROR lines (emitted early) out of view. Include the head, skipping it
         // only when the log is short enough that head and tail already overlap.
         val showHead = text.length > head.length + tail.length
+        // apk's `N errors; <size> in <n> packages` summary says nothing about what went wrong, so it
+        // is the headline only when the log holds no message that does.
         val primary =
-            errors.lineSequence().firstOrNull()
+            errors.lineSequence().firstOrNull { !APK_ERROR_SUMMARY_PATTERN.containsMatchIn(it) }
+                ?: errors.lineSequence().firstOrNull()
                 ?: tail.lineSequence().map(String::trim).firstOrNull { it.isNotBlank() }.orEmpty()
         return buildString {
             append("Claude Code ")

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
@@ -2,11 +2,18 @@ package com.yugahashimoto.andcode.runtime.local
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 class ClaudeCodeInstallerTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
     @Test
     fun `extractApkErrors keeps ERROR and WARNING and summary lines`() {
         val log =
@@ -58,5 +65,177 @@ class ClaudeCodeInstallerTest {
             firstLine.startsWith("Claude Code installation failed (exit 1): ERROR: unable to select packages:"),
         )
         assertTrue(message.contains("--- log tail ---"))
+    }
+
+    @Test
+    fun `failureMessage prefers a real error over apk's bare error count`() {
+        val log =
+            File.createTempFile("claude-update", ".log").apply {
+                deleteOnExit()
+                writeText(
+                    "1 error; 2322.8 MiB in 392 packages\nERROR: unable to select packages:\n",
+                )
+            }
+        val message = ClaudeCodeInstaller.failureMessage("update", 1, log)
+        assertTrue(
+            message.lineSequence().first().endsWith("ERROR: unable to select packages:"),
+        )
+    }
+
+    @Test
+    fun `assembled scripts abort on the first failure and end with the package work`() {
+        listOf(ClaudeCodeInstaller.INSTALL_SCRIPT, ClaudeCodeInstaller.UPDATE_SCRIPT).forEach { script ->
+            assertEquals("set -e", script.lineSequence().first())
+            assertEquals("${ClaudeCodeInstaller.CLAUDE_BINARY} --version", script.lineSequence().last())
+            assertTrue(script.contains("/sbin/apk fix ||"))
+        }
+    }
+
+    @Test
+    fun `update reinstalls every broken package rather than naming one`() {
+        val run = runPackageCommands(ClaudeCodeInstaller::updatePackageCommands)
+
+        assertEquals(0, run.exitCode)
+        // `apk fix <pkg>` reinstalls that package and still trips over every other package's broken
+        // flag, so the repair has to be the unqualified form.
+        assertTrue(run.apkInvocations.contains("fix"))
+    }
+
+    @Test
+    fun `update survives an apk exit code caused by an unrelated broken package`() {
+        // apk counts one error per package flagged broken in its database, in every transaction it
+        // commits -- so `apk add` exits non-zero even when claude-code itself upgraded cleanly.
+        val run =
+            runPackageCommands(ClaudeCodeInstaller::updatePackageCommands, "ADD_STATUS" to "1")
+
+        assertEquals(0, run.exitCode)
+        assertTrue(run.output.contains("claude-code is up to date"))
+        assertTrue(run.claudeRan)
+    }
+
+    @Test
+    fun `update fails when apk fails and claude-code is still behind the repository`() {
+        val run =
+            runPackageCommands(
+                ClaudeCodeInstaller::updatePackageCommands,
+                "ADD_STATUS" to "1",
+                "PENDING_UPGRADE" to "1",
+            )
+
+        assertNotEquals(0, run.exitCode)
+        assertTrue(run.output.contains("still behind the repository"))
+    }
+
+    @Test
+    fun `update still upgrades when the broken-package repair itself fails`() {
+        val run =
+            runPackageCommands(ClaudeCodeInstaller::updatePackageCommands, "FIX_STATUS" to "1")
+
+        assertEquals(0, run.exitCode)
+        assertTrue(run.apkInvocations.contains("add --no-cache --upgrade claude-code"))
+    }
+
+    @Test
+    fun `update fails when the installed binary cannot run`() {
+        val run =
+            runPackageCommands(ClaudeCodeInstaller::updatePackageCommands, "CLAUDE_STATUS" to "1")
+
+        assertNotEquals(0, run.exitCode)
+    }
+
+    @Test
+    fun `install survives an apk exit code once both packages are installed`() {
+        val run =
+            runPackageCommands(
+                ClaudeCodeInstaller::installPackageCommands,
+                "ADD_STATUS" to "1",
+                "INSTALLED" to "claude-code util-linux",
+            )
+
+        assertEquals(0, run.exitCode)
+        assertTrue(run.claudeRan)
+    }
+
+    @Test
+    fun `install fails when apk fails and a requested package is missing`() {
+        val run =
+            runPackageCommands(
+                ClaudeCodeInstaller::installPackageCommands,
+                "ADD_STATUS" to "1",
+                "INSTALLED" to "claude-code",
+            )
+
+        assertNotEquals(0, run.exitCode)
+        assertTrue(run.output.contains("requested packages are not installed"))
+    }
+
+    private class ScriptRun(val exitCode: Int, val output: String, val apkInvocations: List<String>) {
+        val claudeRan: Boolean get() = output.contains(CLAUDE_VERSION)
+    }
+
+    /**
+     * Runs the package-manager half of a script against stub `apk` and `claude` binaries.
+     *
+     * The stubs report whatever [variables] ask them to, which is the only way to exercise the
+     * branches that matter here: apk failing for reasons that have nothing to do with claude-code.
+     */
+    private fun runPackageCommands(
+        commands: (String, String) -> String,
+        vararg variables: Pair<String, String>,
+    ): ScriptRun {
+        val bin = temporaryFolder.newFolder("bin")
+        val apkLog = File(bin, "apk.log")
+        val apk = stub(bin, "apk", APK_STUB.replace("@LOG@", apkLog.absolutePath))
+        val claude = stub(bin, "claude", CLAUDE_STUB)
+        val process =
+            ProcessBuilder("sh", "-c", "set -e\n" + commands(apk.absolutePath, claude.absolutePath))
+                .redirectErrorStream(true)
+                .apply { environment().putAll(variables.toMap()) }
+                .start()
+        val output = process.inputStream.bufferedReader().readText()
+        assertTrue("stub script timed out", process.waitFor(60, TimeUnit.SECONDS))
+        return ScriptRun(
+            exitCode = process.exitValue(),
+            output = output,
+            apkInvocations = apkLog.takeIf(File::isFile)?.readLines().orEmpty(),
+        )
+    }
+
+    private fun stub(
+        directory: File,
+        name: String,
+        body: String,
+    ): File =
+        File(directory, name).apply {
+            writeText(body)
+            check(setExecutable(true))
+        }
+
+    private companion object {
+        const val CLAUDE_VERSION = "2.1.212 (Claude Code)"
+
+        val APK_STUB =
+            """
+            #!/bin/sh
+            echo "${'$'}*" >> '@LOG@'
+            case "${'$'}1" in
+              fix) exit "${'$'}{FIX_STATUS:-0}" ;;
+              add) exit "${'$'}{ADD_STATUS:-0}" ;;
+              info)
+                case " ${'$'}{INSTALLED:-} " in *" ${'$'}3 "*) echo "${'$'}3" ;; esac
+                ;;
+              version)
+                [ -z "${'$'}{PENDING_UPGRADE:-}" ] || echo claude-code
+                ;;
+            esac
+            exit 0
+            """.trimIndent()
+
+        val CLAUDE_STUB =
+            """
+            #!/bin/sh
+            echo '$CLAUDE_VERSION'
+            exit "${'$'}{CLAUDE_STATUS:-0}"
+            """.trimIndent()
     }
 }

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -25,6 +25,7 @@ existing rootfs, then installs the package:
 wget -qO /etc/apk/keys/claude-code.rsa.pub https://downloads.claude.ai/keys/claude-code.rsa.pub
 # https://downloads.claude.ai/claude-code/apk/stable appended to /etc/apk/repositories, once
 /sbin/apk update
+/sbin/apk fix
 /sbin/apk add --no-cache claude-code util-linux
 ```
 
@@ -38,6 +39,32 @@ Two details are load-bearing and were wrong in earlier revisions:
 
 Updates use `apk add --no-cache --upgrade claude-code`. `USE_BUILTIN_RIPGREP=0` is set because the
 bundled ripgrep is a glibc build that cannot run on musl; the sandbox provides Alpine's ripgrep.
+
+### Broken packages poison every later apk run
+
+A package whose files or scripts failed to extract keeps an `f:f` / `f:s` flag in
+`/lib/apk/db/installed` — which is how a package broken by PRoot's hard-link emulation was recorded.
+apk counts one error per flagged package in **every** transaction it commits afterwards, even a `-s`
+simulation and even when the flagged package has nothing to do with the request. The transaction then
+exits non-zero having printed only:
+
+```text
+1 error; 2322.8 MiB in 392 packages
+```
+
+That is why an up-to-date sandbox could still fail to update, with no error naming anything. Two
+consequences for these scripts:
+
+- **`apk fix` runs with no arguments**, so it reinstalls exactly the flagged packages. `apk fix <pkg>`
+  reinstalls that one and still trips over everybody else's flag, so it can never clear the failure —
+  and under `set -e` its own exit code aborted the update before the upgrade was attempted.
+- **A non-zero `apk` status is not by itself a failure.** The scripts verify what was asked for
+  instead: `apk info -e` for a fresh install, and `apk version -q -l '<' claude-code` (a read-only
+  query, so broken flags cannot skew it) for an update. Only if that check fails, or `claude
+  --version` does not run, is the operation reported as failed.
+
+The failure diagnostics list the flagged packages, since apk names a package when it breaks it but
+never when it later refuses to work because of the flag.
 
 ## Execution
 


### PR DESCRIPTION
## Symptom

Updating Claude Code in the app fails with nothing but an error count, on a sandbox that is already running the newest published version:

```text
Claude Code update failed (exit 1): 1 error; 2322.8 MiB in 392 packages
...
OK: 28595 distinct packages available
1 error; 2322.8 MiB in 392 packages
--- and-code apk diagnostics ---
-- apk add -s --upgrade claude-code --
1 error; 2322.8 MiB in 392 packages
```

The log ends right after `apk update`, so the upgrade never runs, and `apk policy` shows `2.1.212-r1` both installed and newest. No line names a package.

## Cause

apk records an `f:f` (broken files) / `f:s` (broken script) flag in `/lib/apk/db/installed` for any package whose extraction failed — how a package broken by PRoot's hard-link emulation is recorded. `apk_solver_commit_changeset` then counts one error for **every** flagged package in **every** transaction it commits afterwards, whether or not the request touches that package, and even under `-s`:

```c
r = change->old_pkg && (change->old_pkg->ipkg->broken_files ||
                        change->old_pkg->ipkg->broken_script);
...
errors += r;
```

Nothing is printed for those errors, so the transaction exits non-zero with only the summary line.

The previous mitigation, `apk fix unzip`, cannot clear this: naming a package reinstalls just that package and still trips over every other package's flag, so it fails too — and under `set -e` its exit code aborted the update before the upgrade was attempted, which is exactly where the log stops.

Reproduced against apk-tools 3.0.6 on an Alpine v3.24.1 rootfs by setting `f:f` on one unrelated installed package:

```text
$ apk add -s --upgrade busybox      # old path
1 error; 8196 KiB in 16 packages    (exit 1)
$ apk fix unzip
1 error; 8196 KiB in 16 packages    (exit 1)
$ apk fix                           # new path
(1/2) Reinstalling musl (1.2.6-r2)
(2/2) Reinstalling zlib (1.3.2-r0)
OK: 8196 KiB in 16 packages         (exit 0)
$ apk add -s --upgrade busybox
OK: 8196 KiB in 16 packages         (exit 0)
```

## Changes

- **`apk fix` with no arguments** in both the install and update scripts — the only form that reinstalls exactly the flagged packages. Its own failure is non-fatal so a package that cannot be reinstalled does not block an upgrade that would otherwise work.
- **apk's exit code is no longer the verdict.** When `apk add` fails, the scripts check what was asked for instead: `apk info -e` for the install, `apk version -q -l '<' claude-code` for the update (a read-only query, so broken flags cannot skew it). The operation is reported as failed only if that check fails or `claude --version` does not run.
- **Failure diagnostics list the flagged packages**, since apk names a package when it breaks it but never when it later refuses to work because of the flag.
- **`failureMessage` prefers a real error line** over apk's bare `N errors;` summary when both are in the log.
- Package-manager halves of both scripts are extracted so tests can drive them with a stub `apk`, and `docs/CLAUDE_CODE.md` documents the behaviour.

## Testing

- `./gradlew spotlessCheck detekt :app:testDebugUnitTest` — 534 tests, 0 failures.
- 9 new tests in `ClaudeCodeInstallerTest` covering the branches that matter: the repair must be unqualified (this one fails against the old `apk fix unzip`), an apk failure with nothing pending succeeds, an apk failure with an upgrade still pending fails, a failed repair still lets the upgrade run, and a binary that will not start fails.
- End-to-end shell behaviour verified against real apk-tools 3.0.6 on Alpine v3.24.1 as shown above.

---
_Generated by [Claude Code](https://claude.ai/code/session_017c3T2a8nzWuPtpz6AufmaZ)_