### PR TITLE
fix: repair the schedule editor layout and workspace picker

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
@@ -131,6 +131,20 @@ fun ScheduleEditorScreen(
     val selectedProvider = providers.firstOrNull { it.id == providerId }
     val selectedModelName = selectedProvider?.models?.get(modelId)?.name
 
+    /*
+     * Folders of the agent this schedule runs on, which is not necessarily the agent selected in
+     * the app: [workspaces] only ever holds the selected one's folders, so picking any other agent
+     * left the menu with nothing to offer. A target that is stopped or unreachable answers with
+     * nothing, and the app-wide list is used instead of an empty menu.
+     */
+    var targetWorkspaces by remember { mutableStateOf<List<WorkspaceRef>>(emptyList()) }
+    LaunchedEffect(selectedTarget?.id) {
+        val target = selectedTarget
+        targetWorkspaces =
+            if (target == null) emptyList() else runCatching { target.listWorkspaces() }.getOrDefault(emptyList())
+    }
+    val workspaceOptions = targetWorkspaces.ifEmpty { workspaces }
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -250,7 +264,7 @@ fun ScheduleEditorScreen(
 
             EditorSectionHeader(stringResource(R.string.schedule_workspace))
             val workspaceSummary =
-                workspaces
+                workspaceOptions
                     .firstOrNull { it.path == workspacePath }
                     ?.let { "${it.name} · ${it.path}" }
                     ?: workspacePath
@@ -278,7 +292,14 @@ fun ScheduleEditorScreen(
                             workspaceMenuExpanded = false
                         },
                     )
-                    workspaces.forEach { workspace ->
+                    if (workspaceOptions.isEmpty()) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.no_workspaces_title)) },
+                            onClick = {},
+                            enabled = false,
+                        )
+                    }
+                    workspaceOptions.forEach { workspace ->
                         DropdownMenuItem(
                             text = {
                                 Column {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
@@ -2,7 +2,10 @@ package com.yugahashimoto.andcode.feature.schedule
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,6 +24,8 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -30,6 +35,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -39,6 +46,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,7 +83,7 @@ private enum class TimingMode { ONCE, DAILY, WEEKLY, MONTHLY, CUSTOM }
 
 private enum class AutoAcceptMode { DEFAULT, ALWAYS }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun ScheduleEditorScreen(
     existing: Schedule?,
@@ -104,8 +112,20 @@ fun ScheduleEditorScreen(
     var showDatePicker by remember { mutableStateOf(false) }
     var showTimePicker by remember { mutableStateOf(false) }
     var invalidCron by remember { mutableStateOf(false) }
+    var saveError by remember { mutableStateOf<String?>(null) }
 
     val sheetState = rememberModalBottomSheetState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Saving used to fail silently whenever a required field was missing; surface the reason instead.
+    val promptRequiredMessage = stringResource(R.string.schedule_error_prompt_required)
+    val agentRequiredMessage = stringResource(R.string.schedule_error_agent_required)
+    val timingRequiredMessage = stringResource(R.string.schedule_error_timing_required)
+    LaunchedEffect(saveError) {
+        val message = saveError ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        saveError = null
+    }
 
     val selectedTarget = runtimeTargets.firstOrNull { it.id == runtimeId }
     val selectedProvider = providers.firstOrNull { it.id == providerId }
@@ -144,7 +164,16 @@ fun ScheduleEditorScreen(
                                     workspacePath,
                                     autoAcceptMode,
                                 )
-                            if (built != null) onSave(built)
+                            if (built != null) {
+                                onSave(built)
+                            } else {
+                                saveError =
+                                    when {
+                                        prompt.isBlank() -> promptRequiredMessage
+                                        runtimeId.isEmpty() -> agentRequiredMessage
+                                        else -> timingRequiredMessage
+                                    }
+                            }
                         },
                     ) {
                         Text(stringResource(R.string.schedule_save), fontWeight = FontWeight.SemiBold)
@@ -159,6 +188,7 @@ fun ScheduleEditorScreen(
                     ),
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
         Column(
@@ -224,17 +254,56 @@ fun ScheduleEditorScreen(
                     .firstOrNull { it.path == workspacePath }
                     ?.let { "${it.name} · ${it.path}" }
                     ?: workspacePath
-            OutlinedButton(
-                onClick = { workspaceMenuExpanded = true },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(Icons.Default.Folder, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    text = workspaceSummary.ifBlank { stringResource(R.string.schedule_workspace_unset) },
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+            Box(modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(
+                    onClick = { workspaceMenuExpanded = true },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(Icons.Default.Folder, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = workspaceSummary.ifBlank { stringResource(R.string.schedule_workspace_unset) },
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                DropdownMenu(
+                    expanded = workspaceMenuExpanded,
+                    onDismissRequest = { workspaceMenuExpanded = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.schedule_workspace_unset)) },
+                        onClick = {
+                            workspacePath = ""
+                            workspaceMenuExpanded = false
+                        },
+                    )
+                    workspaces.forEach { workspace ->
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(
+                                        text = workspace.name,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                    Text(
+                                        text = workspace.path,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            },
+                            onClick = {
+                                workspacePath = workspace.path
+                                workspaceMenuExpanded = false
+                            },
+                        )
+                    }
+                }
             }
 
             EditorSectionHeader(stringResource(R.string.schedule_prompt))
@@ -248,31 +317,37 @@ fun ScheduleEditorScreen(
             )
 
             EditorSectionHeader(stringResource(R.string.schedule_timing))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Flow layout: the chip labels are translated, and a plain Row squeezes long ones
+            // (e.g. "カスタム（cron）") down to a single character per line.
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 FilterChip(
                     selected = timingState.mode == TimingMode.ONCE,
                     onClick = { timingState.mode = TimingMode.ONCE },
-                    label = { Text(stringResource(R.string.schedule_timing_once)) },
+                    label = { Text(stringResource(R.string.schedule_timing_once), maxLines = 1) },
                 )
                 FilterChip(
                     selected = timingState.mode == TimingMode.DAILY,
                     onClick = { timingState.mode = TimingMode.DAILY },
-                    label = { Text(stringResource(R.string.schedule_timing_daily)) },
+                    label = { Text(stringResource(R.string.schedule_timing_daily), maxLines = 1) },
                 )
                 FilterChip(
                     selected = timingState.mode == TimingMode.WEEKLY,
                     onClick = { timingState.mode = TimingMode.WEEKLY },
-                    label = { Text(stringResource(R.string.schedule_timing_weekly)) },
+                    label = { Text(stringResource(R.string.schedule_timing_weekly), maxLines = 1) },
                 )
                 FilterChip(
                     selected = timingState.mode == TimingMode.MONTHLY,
                     onClick = { timingState.mode = TimingMode.MONTHLY },
-                    label = { Text(stringResource(R.string.schedule_timing_monthly)) },
+                    label = { Text(stringResource(R.string.schedule_timing_monthly), maxLines = 1) },
                 )
                 FilterChip(
                     selected = timingState.mode == TimingMode.CUSTOM,
                     onClick = { timingState.mode = TimingMode.CUSTOM },
-                    label = { Text(stringResource(R.string.schedule_timing_custom)) },
+                    label = { Text(stringResource(R.string.schedule_timing_custom), maxLines = 1) },
                 )
             }
 
@@ -303,9 +378,14 @@ fun ScheduleEditorScreen(
                     TimePickerButton(
                         label = timingState.dailyTime?.format(TIME_FORMAT) ?: stringResource(R.string.schedule_time),
                         onClick = { showTimePicker = true },
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 TimingMode.WEEKLY -> {
-                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
                         DayOfWeek.entries.forEach { day ->
                             FilterChip(
                                 selected = timingState.weeklyDay == day,
@@ -313,6 +393,7 @@ fun ScheduleEditorScreen(
                                 label = {
                                     Text(
                                         day.getDisplayName(TextStyle.NARROW, Locale.getDefault()),
+                                        maxLines = 1,
                                     )
                                 },
                             )
@@ -321,23 +402,34 @@ fun ScheduleEditorScreen(
                     TimePickerButton(
                         label = timingState.weeklyTime?.format(TIME_FORMAT) ?: stringResource(R.string.schedule_time),
                         onClick = { showTimePicker = true },
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
                 TimingMode.MONTHLY -> {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    // Both buttons are weighted: the time button used to ask for the full row width
+                    // and pushed the day-of-month button off screen.
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
                         OutlinedButton(
                             onClick = {
                                 timingState.monthlyDay = (timingState.monthlyDay ?: 1) % 31 + 1
                             },
+                            modifier = Modifier.weight(1f),
                         ) {
                             Icon(Icons.Default.Schedule, contentDescription = null, modifier = Modifier.size(16.dp))
                             Spacer(Modifier.width(6.dp))
-                            Text(stringResource(R.string.schedule_day_of_month) + ": " + (timingState.monthlyDay ?: 1))
+                            Text(
+                                text = stringResource(R.string.schedule_day_of_month) + ": " + (timingState.monthlyDay ?: 1),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
                         }
-                        Spacer(Modifier.width(12.dp))
                         TimePickerButton(
                             label = timingState.monthlyTime?.format(TIME_FORMAT) ?: stringResource(R.string.schedule_time),
                             onClick = { showTimePicker = true },
+                            modifier = Modifier.weight(1f),
                         )
                     }
                 }
@@ -375,16 +467,20 @@ fun ScheduleEditorScreen(
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f))
 
             EditorSectionHeader(stringResource(R.string.schedule_auto_accept))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 FilterChip(
                     selected = autoAcceptMode == AutoAcceptMode.DEFAULT,
                     onClick = { autoAcceptMode = AutoAcceptMode.DEFAULT },
-                    label = { Text(stringResource(R.string.schedule_auto_accept_default)) },
+                    label = { Text(stringResource(R.string.schedule_auto_accept_default), maxLines = 1) },
                 )
                 FilterChip(
                     selected = autoAcceptMode == AutoAcceptMode.ALWAYS,
                     onClick = { autoAcceptMode = AutoAcceptMode.ALWAYS },
-                    label = { Text(stringResource(R.string.always_allow)) },
+                    label = { Text(stringResource(R.string.always_allow), maxLines = 1) },
                 )
             }
             Text(
@@ -481,9 +577,10 @@ private fun EditorSectionHeader(text: String) {
 private fun TimePickerButton(
     label: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
-        Text(label)
+    OutlinedButton(onClick = onClick, modifier = modifier) {
+        Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis)
     }
 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -878,6 +878,9 @@
     <string name="schedule_run_now">تشغيل الآن</string>
     <string name="schedule_save">حفظ</string>
     <string name="schedule_cancel">إلغاء</string>
+    <string name="schedule_error_prompt_required">أدخل موجّهًا قبل الحفظ</string>
+    <string name="schedule_error_agent_required">اختر وكيلًا قبل الحفظ</string>
+    <string name="schedule_error_timing_required">أكمل إعدادات التوقيت قبل الحفظ</string>
     <string name="schedule_empty">لا توجد جداول بعد. اضغط + لإنشاء جدول.</string>
     <string name="schedule_next_run">التالي: %1$s</string>
     <string name="schedule_last_run">آخر تشغيل: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -878,6 +878,9 @@
     <string name="schedule_run_now">Ejecutar ahora</string>
     <string name="schedule_save">Guardar</string>
     <string name="schedule_cancel">Cancelar</string>
+    <string name="schedule_error_prompt_required">Escribe un prompt antes de guardar</string>
+    <string name="schedule_error_agent_required">Elige un agente antes de guardar</string>
+    <string name="schedule_error_timing_required">Completa la programación antes de guardar</string>
     <string name="schedule_empty">Aún no hay programaciones. Pulsa + para crear una.</string>
     <string name="schedule_next_run">Siguiente: %1$s</string>
     <string name="schedule_last_run">Última ejecución: %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -878,6 +878,9 @@
     <string name="schedule_run_now">Exécuter maintenant</string>
     <string name="schedule_save">Enregistrer</string>
     <string name="schedule_cancel">Annuler</string>
+    <string name="schedule_error_prompt_required">Saisissez une invite avant d\'enregistrer</string>
+    <string name="schedule_error_agent_required">Choisissez un agent avant d\'enregistrer</string>
+    <string name="schedule_error_timing_required">Complétez la planification avant d\'enregistrer</string>
     <string name="schedule_empty">Aucune planification. Appuyez sur + pour en créer une.</string>
     <string name="schedule_next_run">Prochaine : %1$s</string>
     <string name="schedule_last_run">Dernière exécution : %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -891,6 +891,9 @@
     <string name="schedule_run_now">今すぐ実行</string>
     <string name="schedule_save">保存</string>
     <string name="schedule_cancel">キャンセル</string>
+    <string name="schedule_error_prompt_required">保存する前にプロンプトを入力してください</string>
+    <string name="schedule_error_agent_required">保存する前にエージェントを選択してください</string>
+    <string name="schedule_error_timing_required">保存する前にタイミングを設定してください</string>
     <string name="schedule_empty">スケジュールはまだありません。＋を押して作成してください。</string>
     <string name="schedule_next_run">次回: %1$s</string>
     <string name="schedule_last_run">前回: %1$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -878,6 +878,9 @@
     <string name="schedule_run_now">Executar agora</string>
     <string name="schedule_save">Salvar</string>
     <string name="schedule_cancel">Cancelar</string>
+    <string name="schedule_error_prompt_required">Escreva um prompt antes de salvar</string>
+    <string name="schedule_error_agent_required">Escolha um agente antes de salvar</string>
+    <string name="schedule_error_timing_required">Conclua a programação antes de salvar</string>
     <string name="schedule_empty">Ainda não há agendamentos. Toque em + para criar um.</string>
     <string name="schedule_next_run">Próxima: %1$s</string>
     <string name="schedule_last_run">Última execução: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -878,6 +878,9 @@
     <string name="schedule_run_now">Запустить сейчас</string>
     <string name="schedule_save">Сохранить</string>
     <string name="schedule_cancel">Отмена</string>
+    <string name="schedule_error_prompt_required">Введите запрос перед сохранением</string>
+    <string name="schedule_error_agent_required">Выберите агента перед сохранением</string>
+    <string name="schedule_error_timing_required">Завершите настройку расписания перед сохранением</string>
     <string name="schedule_empty">Пока нет расписаний. Нажмите +, чтобы создать.</string>
     <string name="schedule_next_run">Следующий: %1$s</string>
     <string name="schedule_last_run">Последний запуск: %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -878,6 +878,9 @@
     <string name="schedule_run_now">立即运行</string>
     <string name="schedule_save">保存</string>
     <string name="schedule_cancel">取消</string>
+    <string name="schedule_error_prompt_required">保存前请输入提示词</string>
+    <string name="schedule_error_agent_required">保存前请选择智能体</string>
+    <string name="schedule_error_timing_required">保存前请完成时间设置</string>
     <string name="schedule_empty">暂无计划。点击 + 创建。</string>
     <string name="schedule_next_run">下次：%1$s</string>
     <string name="schedule_last_run">上次运行：%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -891,6 +891,9 @@
     <string name="schedule_run_now">Run now</string>
     <string name="schedule_save">Save</string>
     <string name="schedule_cancel">Cancel</string>
+    <string name="schedule_error_prompt_required">Enter a prompt before saving</string>
+    <string name="schedule_error_agent_required">Choose an agent before saving</string>
+    <string name="schedule_error_timing_required">Finish the timing settings before saving</string>
     <string name="schedule_empty">No schedules yet. Tap + to create one.</string>
     <string name="schedule_next_run">Next: %1$s</string>
     <string name="schedule_last_run">Last run: %1$s</string>


### PR DESCRIPTION
## What was broken

Reported from the "新しいスケジュール" screen on a phone in Japanese:

- **Timing chips overflowed.** The five timing `FilterChip`s sat in a plain `Row`, so the label that did not fit — `カスタム（cron）` — was compressed to a single character per line. The row grew to about a third of the screen and the date/time buttons ended up below a large blank gap.
- **Weekly chips had the same problem.** Seven day-of-week chips need more than a phone's width (7 × 48dp minimum + spacing).
- **Monthly row could not fit.** The time button asked for the full row width (`fillMaxWidth`) while sitting next to the unweighted day-of-month button.
- **The workspace button did nothing.** It set `workspaceMenuExpanded = true`, but nothing in the screen ever read that state — no menu was ever rendered, so a workspace could not be chosen at all.
- **Saving failed silently.** `buildSchedule` returns null when the prompt is empty, no agent is picked, or the timing is incomplete; the null was dropped and 保存 simply did nothing, with no feedback.

## Changes

- `ScheduleEditorScreen.kt`
  - Timing, weekly day-of-week and auto-approve chip rows are now `FlowRow`s that wrap, with single-line chip labels.
  - The monthly row weights both buttons; `TimePickerButton` takes a `Modifier` instead of hard-coding `fillMaxWidth`, and its callers pass the width they want.
  - The workspace button is wrapped in a `Box` with a `DropdownMenu` listing every known workspace (name + path) plus an entry that clears the selection.
  - Failing to save now sets a message that a `Snackbar` shows, saying which field is missing.
- `values*/strings.xml`: three new strings (`schedule_error_prompt_required`, `schedule_error_agent_required`, `schedule_error_timing_required`) added to the source locale and all seven translations.

## Testing

Not built or run: this environment has no Android SDK and Google's Maven host is unreachable from it, so `./gradlew` cannot resolve the Compose dependencies. The translation-completeness check from `.github/workflows/i18n-check.yml` was run locally and passes; the rest is left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxDzbCbU6EVirmGSsgGnJV)_