### PR TITLE
fix: make workspace folder deletion actually remove the folder

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
@@ -231,6 +231,27 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
                 .apply()
         }
 
+    /**
+     * Workspace folders the user removed from the list.
+     *
+     * Remembered because most rows are not registrations: the runtimes report a folder from their
+     * own chat history and from what is on disk, so a removal that only cleared [projectPaths] was
+     * undone by the next refresh. Registering a path again — importing or cloning into it — clears
+     * it from here.
+     */
+    var hiddenWorkspacePaths: List<String>
+        get() =
+            preferences.getString(KEY_HIDDEN_WORKSPACE_PATHS, null)
+                ?.split('\n')
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                .orEmpty()
+        set(value) {
+            preferences.edit()
+                .putString(KEY_HIDDEN_WORKSPACE_PATHS, value.joinToString("\n"))
+                .apply()
+        }
+
     /** True once the user has completed (or explicitly skipped) first-run onboarding. */
     var onboardingCompleted: Boolean
         get() = preferences.getBoolean(KEY_ONBOARDING_COMPLETED, false)
@@ -383,6 +404,7 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
         private const val KEY_ASSISTANT_WORKSPACE_PATH = "assistant_workspace_path"
         private const val KEY_SAF_WORKSPACE_URIS = "saf_workspace_uris"
         private const val KEY_PROJECT_PATHS = "project_paths"
+        private const val KEY_HIDDEN_WORKSPACE_PATHS = "hidden_workspace_paths"
         private const val KEY_ONBOARDING_COMPLETED = "onboarding_completed"
         private const val KEY_UNREAD_SESSIONS = "unread_sessions"
         private const val KEY_GITHUB_TOKEN = "github_token"

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/RuntimeFolderBrowser.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/RuntimeFolderBrowser.kt
@@ -1,0 +1,40 @@
+package com.yugahashimoto.andcode.feature.workspace
+
+import java.io.File
+
+/**
+ * Walks the on-device Linux environment so the user can point a workspace at a folder that is
+ * already there.
+ *
+ * Importing a folder and cloning a repository both create something new under `/workspace`. Neither
+ * helps with a directory the environment already has — a repository cloned from the terminal, or
+ * anything under `/root` — so those were unreachable from the settings screen.
+ *
+ * The listing is read from the host filesystem rather than through an agent: the rootfs is a plain
+ * directory tree inside the app's own storage, so this works while the runtime is stopped, which is
+ * exactly when a user is setting a workspace up.
+ */
+class RuntimeFolderBrowser(
+    private val rootfsHostDir: File,
+    private val workspaceHostDir: File,
+) {
+    /** False before the runtime is installed, when there is no filesystem to walk yet. */
+    fun isAvailable(): Boolean = rootfsHostDir.isDirectory
+
+    fun children(path: String): List<String> {
+        val host = WorkspaceFolders.hostDirectory(rootfsHostDir, workspaceHostDir, path) ?: return emptyList()
+        val names =
+            host.listFiles().orEmpty()
+                .filter { it.isDirectory }
+                .map { it.name }
+        // `/workspace` is a bind mount, so the rootfs usually has no entry for it and the folder
+        // holding every imported and cloned project would be missing from the top level.
+        val merged =
+            if (WorkspaceFolders.normalize(path) == WorkspaceFolders.GUEST_ROOT) {
+                names + WorkspaceFolders.displayName(WorkspaceFolders.WORKSPACE_ROOT)
+            } else {
+                names
+            }
+        return merged.distinct().sortedWith(compareBy({ it.startsWith(".") }, { it.lowercase() }))
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceFolders.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceFolders.kt
@@ -1,0 +1,111 @@
+package com.yugahashimoto.andcode.feature.workspace
+
+import com.yugahashimoto.andcode.runtime.WorkspaceRef
+import java.io.File
+
+/**
+ * Path bookkeeping for the workspace list.
+ *
+ * Kept out of [WorkspaceViewModel] so it can be tested without Android's encrypted preferences,
+ * which is where the deletion rules belong: they decide what gets erased from the device.
+ */
+object WorkspaceFolders {
+    /** The sandbox path every runtime mounts the app's workspace directory at. */
+    const val WORKSPACE_ROOT = "/workspace"
+
+    const val GUEST_ROOT = "/"
+
+    fun displayName(path: String): String = path.trimEnd('/').substringAfterLast('/').ifBlank { path }
+
+    /** Leading slash, no trailing slash, no empty segments — `/` stays `/`. */
+    fun normalize(path: String): String {
+        val segments = path.trim().split('/').filter { it.isNotEmpty() && it != "." }
+        return if (segments.isEmpty()) GUEST_ROOT else "/" + segments.joinToString("/")
+    }
+
+    fun parentOf(path: String): String {
+        val normalized = normalize(path)
+        if (normalized == GUEST_ROOT) return GUEST_ROOT
+        return normalize(normalized.substringBeforeLast('/'))
+    }
+
+    fun childOf(
+        path: String,
+        name: String,
+    ): String = normalize("${normalize(path)}/$name")
+
+    fun isInsideWorkspaceRoot(path: String): Boolean {
+        val normalized = normalize(path)
+        return normalized != WORKSPACE_ROOT && normalized.startsWith("$WORKSPACE_ROOT/")
+    }
+
+    /**
+     * The folders to show: what the runtime reports, plus the ones this device registered, minus
+     * the ones the user removed.
+     *
+     * Removals have to be remembered rather than just unregistered. Most rows are not registrations
+     * at all — the runtimes report a folder because a past chat ran there or because it sits on
+     * disk — so dropping the registration left the row exactly where it was, which is what made
+     * "remove from list" and "delete files" both look like they had done nothing.
+     */
+    fun visibleWorkspaces(
+        runtimeWorkspaces: List<WorkspaceRef>,
+        registered: List<WorkspaceRef>,
+        hidden: Set<String>,
+    ): List<WorkspaceRef> {
+        val byPath = linkedMapOf<String, WorkspaceRef>()
+        registered.forEach { byPath[it.path] = it }
+        runtimeWorkspaces.forEach { byPath.putIfAbsent(it.path, it) }
+        hidden.forEach { byPath.remove(it) }
+        return byPath.values.toList()
+    }
+
+    /**
+     * The on-device folder holding a workspace's files, or null when there is nothing to delete.
+     *
+     * Only folders under [WORKSPACE_ROOT] answer: that mount is the app's own directory, so it is
+     * the one place a "delete files" is unambiguously about files this app put there. The whole
+     * relative path is used — resolving by basename alone, as this once did, pointed at a
+     * same-named folder directly under the mount whenever the workspace was nested.
+     */
+    fun deletableHostDirectory(
+        workspaceHostDir: File,
+        path: String,
+    ): File? {
+        if (!isInsideWorkspaceRoot(path)) return null
+        val relative = normalize(path).removePrefix(WORKSPACE_ROOT).trim('/')
+        if (relative.isEmpty()) return null
+        return containedIn(workspaceHostDir, relative)
+    }
+
+    /**
+     * The host directory behind a sandbox path, for browsing.
+     *
+     * `/workspace` is a bind mount of the app's workspace directory; everything else lives in the
+     * Linux rootfs the runtimes are unpacked into, which is a plain directory tree this app owns.
+     */
+    fun hostDirectory(
+        rootfsHostDir: File?,
+        workspaceHostDir: File,
+        path: String,
+    ): File? {
+        val normalized = normalize(path)
+        if (normalized == WORKSPACE_ROOT) return workspaceHostDir
+        if (isInsideWorkspaceRoot(normalized)) {
+            return containedIn(workspaceHostDir, normalized.removePrefix(WORKSPACE_ROOT).trim('/'))
+        }
+        val rootfs = rootfsHostDir ?: return null
+        val relative = normalized.trim('/')
+        return if (relative.isEmpty()) rootfs.absoluteFile.normalize() else containedIn(rootfs, relative)
+    }
+
+    /** [relative] resolved under [root], or null when it climbs back out of it. */
+    private fun containedIn(
+        root: File,
+        relative: String,
+    ): File? {
+        val base = root.absoluteFile.normalize()
+        val resolved = File(base, relative).absoluteFile.normalize()
+        return resolved.takeIf { it.path.startsWith(base.path + File.separator) }
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
@@ -85,8 +85,7 @@ class WorkspaceViewModel(
     private val workspaceHostDir: File,
     private val claudeCode: ClaudeCodeController? = null,
     private val folderBrowser: RuntimeFolderBrowser =
-        // The workspace directory sits beside the installed environment inside the runtime folder.
-        RuntimeFolderBrowser(File(workspaceHostDir.absoluteFile.parentFile, "environment/rootfs"), workspaceHostDir),
+        RuntimeFolderBrowser(File(workspaceHostDir.absoluteFile.parentFile, RUNTIME_ROOTFS_PATH), workspaceHostDir),
 ) : ViewModel() {
     private val registeredTick = MutableStateFlow(0)
     private val claudeState: StateFlow<ClaudeCodeUiState> =
@@ -346,5 +345,8 @@ class WorkspaceViewModel(
 
     private companion object {
         const val LOCAL_RUNTIME_ID = "local-android"
+
+        /** The installed Linux environment, which sits beside the workspace directory. */
+        const val RUNTIME_ROOTFS_PATH = "environment/rootfs"
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
@@ -19,6 +19,7 @@ import com.yugahashimoto.andcode.runtime.local.ClaudeCodeUiState
 import com.yugahashimoto.andcode.runtime.local.ClaudePermissionMode
 import com.yugahashimoto.andcode.runtime.local.LocalRuntimeManager
 import com.yugahashimoto.andcode.runtime.local.LocalRuntimeServiceController
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 data class RuntimeSummary(
@@ -49,6 +51,29 @@ data class WorkspaceUiState(
     val isRefreshing: Boolean = false,
     val error: String? = null,
     val claude: ClaudeCodeUiState = ClaudeCodeUiState(),
+    val folders: WorkspaceFolderActions = WorkspaceFolderActions(),
+    val folderPicker: FolderPickerState = FolderPickerState(),
+)
+
+/**
+ * Which folders are being erased right now, and which ones failed.
+ *
+ * Deleting a project folder is not instant — a repository with its history and dependencies is tens
+ * of thousands of files — so the row and its dialog stay on screen reporting progress until the
+ * folder is actually gone, instead of returning immediately and leaving the entry sitting there.
+ */
+data class WorkspaceFolderActions(
+    val deleting: Set<String> = emptySet(),
+    val failed: Set<String> = emptySet(),
+)
+
+/** Browsing state for picking an existing folder out of the on-device Linux environment. */
+data class FolderPickerState(
+    val visible: Boolean = false,
+    val path: String = WorkspaceFolders.GUEST_ROOT,
+    val directories: List<String> = emptyList(),
+    val isLoading: Boolean = false,
+    val unavailable: Boolean = false,
 )
 
 class WorkspaceViewModel(
@@ -59,10 +84,15 @@ class WorkspaceViewModel(
     private val settings: SecureSettingsRepository,
     private val workspaceHostDir: File,
     private val claudeCode: ClaudeCodeController? = null,
+    private val folderBrowser: RuntimeFolderBrowser =
+        // The workspace directory sits beside the installed environment inside the runtime folder.
+        RuntimeFolderBrowser(File(workspaceHostDir.absoluteFile.parentFile, "environment/rootfs"), workspaceHostDir),
 ) : ViewModel() {
     private val registeredTick = MutableStateFlow(0)
     private val claudeState: StateFlow<ClaudeCodeUiState> =
         claudeCode?.state ?: MutableStateFlow(ClaudeCodeUiState())
+    private val folderActions = MutableStateFlow(WorkspaceFolderActions())
+    private val folderPicker = MutableStateFlow(FolderPickerState())
 
     val state: StateFlow<WorkspaceUiState> =
         combine(
@@ -70,8 +100,8 @@ class WorkspaceViewModel(
             registry.selected,
             catalog.state,
             localRuntimeManager.state,
-            combine(registeredTick, claudeState) { _, claude -> claude },
-        ) { targets, selected, runtime, localStatus, claude ->
+            combine(registeredTick, claudeState, folderActions, folderPicker, ::LocalState),
+        ) { targets, selected, runtime, localStatus, local ->
             val profiles = registry.remoteProfiles()
             // Read imperatively: the registry recomputes this set while building the target list, so
             // it is already up to date by the time `targets` emits.
@@ -91,11 +121,18 @@ class WorkspaceViewModel(
                 connections = profiles,
                 unusableConnections = profiles.filter { it.id in unusableIds },
                 selectedRuntimeId = selected?.id,
-                workspaces = mergeWorkspaces(runtime.workspaces, registeredProjects(selected)),
+                workspaces =
+                    WorkspaceFolders.visibleWorkspaces(
+                        runtimeWorkspaces = runtime.workspaces,
+                        registered = registeredProjects(selected),
+                        hidden = settings.hiddenWorkspacePaths.toSet(),
+                    ),
                 localStatus = localStatus,
                 isRefreshing = runtime.isRefreshing,
                 error = runtime.error,
-                claude = claude,
+                claude = local.claude,
+                folders = local.folders,
+                folderPicker = local.picker,
             )
         }.stateIn(viewModelScope, SharingStarted.Eagerly, WorkspaceUiState())
 
@@ -120,49 +157,118 @@ class WorkspaceViewModel(
     private fun registeredProjects(selected: RuntimeTarget?): List<WorkspaceRef> {
         if (selected != null && selected.type != RuntimeType.LOCAL) return emptyList()
         return settings.projectPaths.map { path ->
-            WorkspaceRef(id = path, name = displayName(path), path = path)
+            WorkspaceRef(id = path, name = WorkspaceFolders.displayName(path), path = path)
         }
     }
 
-    private fun mergeWorkspaces(
-        server: List<WorkspaceRef>,
-        registered: List<WorkspaceRef>,
-    ): List<WorkspaceRef> {
-        val byPath = linkedMapOf<String, WorkspaceRef>()
-        registered.forEach { byPath[it.path] = it }
-        server.forEach { byPath.putIfAbsent(it.path, it) }
-        return byPath.values.toList()
-    }
-
-    private fun displayName(serverPath: String): String = serverPath.trimEnd('/').substringAfterLast('/').ifBlank { serverPath }
-
     fun addProject(serverPath: String) {
+        // Registering a folder again is how a removal is undone: the user pointed at this path, so
+        // it belongs back on the list even if they had hidden it earlier.
+        settings.hiddenWorkspacePaths = settings.hiddenWorkspacePaths.filter { it != serverPath }
         val current = settings.projectPaths.toMutableList()
         if (serverPath !in current) {
             current += serverPath
             settings.projectPaths = current
-            registeredTick.update { it + 1 }
         }
+        registeredTick.update { it + 1 }
     }
 
     fun removeProject(serverPath: String) {
         settings.projectPaths = settings.projectPaths.filter { it != serverPath }
+        settings.hiddenWorkspacePaths = (settings.hiddenWorkspacePaths + serverPath).distinct()
+        folderActions.update { it.copy(failed = it.failed - serverPath) }
         registeredTick.update { it + 1 }
     }
 
+    /**
+     * Erases a workspace folder from the device, then drops it from the list.
+     *
+     * Runs off the main thread and reports progress: a project folder holds a repository's history
+     * and its dependencies, so the delete takes long enough that doing it inline froze the screen
+     * and returned before the folder was gone.
+     */
     fun deleteProjectFiles(serverPath: String) {
-        // Only folders this device registered live under the Android runtime. A folder listed by a
-        // PC connection just happens to share a basename with one of ours, and deleting on that
-        // resemblance would wipe unrelated local files.
-        if (serverPath !in settings.projectPaths) {
+        if (serverPath in folderActions.value.deleting) return
+        val hostDir =
+            if (registry.selected.value?.type == RuntimeType.LOCAL) {
+                // Only the workspace mount is this app's own storage. A folder listed by a PC
+                // connection just happens to share a path with one of ours, and deleting on that
+                // resemblance would wipe unrelated local files.
+                WorkspaceFolders.deletableHostDirectory(workspaceHostDir, serverPath)
+            } else {
+                null
+            }
+        if (hostDir == null) {
             removeProject(serverPath)
             refresh()
             return
         }
-        val hostDir = File(workspaceHostDir, displayName(serverPath))
-        if (hostDir.exists()) hostDir.deleteRecursively()
-        removeProject(serverPath)
+        folderActions.update { it.copy(deleting = it.deleting + serverPath, failed = it.failed - serverPath) }
+        viewModelScope.launch {
+            val deleted = withContext(Dispatchers.IO) { deleteFolder(hostDir) }
+            if (deleted) {
+                removeProject(serverPath)
+                refresh()
+            }
+            folderActions.update {
+                it.copy(
+                    deleting = it.deleting - serverPath,
+                    failed = if (deleted) it.failed else it.failed + serverPath,
+                )
+            }
+        }
+    }
+
+    /** Clears the failure shown on a row, so its dialog can be dismissed. */
+    fun dismissDeleteFailure(serverPath: String) {
+        folderActions.update { it.copy(failed = it.failed - serverPath) }
+    }
+
+    private fun deleteFolder(hostDir: File): Boolean {
+        if (!hostDir.exists()) return true
+        hostDir.deleteRecursively()
+        // What is left on disk is the answer, not the return value: the row is claiming the folder
+        // is gone, so it has to be gone.
+        return !hostDir.exists()
+    }
+
+    fun openFolderPicker() {
+        if (!folderBrowser.isAvailable()) {
+            folderPicker.value = FolderPickerState(visible = true, unavailable = true)
+            return
+        }
+        folderPicker.value = FolderPickerState(visible = true, path = WorkspaceFolders.GUEST_ROOT)
+        browseFolder(WorkspaceFolders.GUEST_ROOT)
+    }
+
+    fun browseFolder(path: String) {
+        val normalized = WorkspaceFolders.normalize(path)
+        folderPicker.update { it.copy(path = normalized, isLoading = true) }
+        viewModelScope.launch {
+            val children = withContext(Dispatchers.IO) { folderBrowser.children(normalized) }
+            folderPicker.update { current ->
+                // A slower listing must not overwrite the folder the user has since moved to.
+                if (current.path != normalized) current else current.copy(directories = children, isLoading = false)
+            }
+        }
+    }
+
+    fun browseFolderUp() = browseFolder(WorkspaceFolders.parentOf(folderPicker.value.path))
+
+    fun browseFolderInto(name: String) = browseFolder(WorkspaceFolders.childOf(folderPicker.value.path, name))
+
+    /** Registers the folder currently open in the picker and closes it. */
+    fun confirmFolderPicker(): String? {
+        val path = folderPicker.value.path
+        if (path == WorkspaceFolders.GUEST_ROOT) return null
+        addProject(path)
         refresh()
+        dismissFolderPicker()
+        return path
+    }
+
+    fun dismissFolderPicker() {
+        folderPicker.value = FolderPickerState()
     }
 
     fun selectRuntime(id: String) {
@@ -229,6 +335,14 @@ class WorkspaceViewModel(
         catalog.refresh()
         claudeCode?.refresh()
     }
+
+    /** The four app-local flows, folded into one so [combine] stays within its arity. */
+    private data class LocalState(
+        val tick: Int,
+        val claude: ClaudeCodeUiState,
+        val folders: WorkspaceFolderActions,
+        val picker: FolderPickerState,
+    )
 
     private companion object {
         const val LOCAL_RUNTIME_ID = "local-android"

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspacesScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspacesScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -20,17 +21,20 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.DriveFolderUpload
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.WifiFind
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -45,6 +49,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,6 +57,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -87,8 +93,14 @@ fun WorkspacesScreen(
     onOpenWorkspace: (WorkspaceRef) -> Unit,
     onImportFolder: () -> Unit = {},
     onCloneGithub: () -> Unit = {},
+    onChooseFolder: () -> Unit = {},
+    onBrowseFolderInto: (String) -> Unit = {},
+    onBrowseFolderUp: () -> Unit = {},
+    onConfirmFolder: () -> Unit = {},
+    onDismissFolderPicker: () -> Unit = {},
     onRemoveProject: (String) -> Unit = {},
     onDeleteProjectFiles: (String) -> Unit = {},
+    onDismissDeleteFailure: (String) -> Unit = {},
     onBack: () -> Unit = {},
 ) {
     val localRuntimeActive =
@@ -359,6 +371,22 @@ fun WorkspacesScreen(
                             Text(stringResource(R.string.workspace_clone_github))
                         }
                     }
+                    Spacer(Modifier.height(8.dp))
+                    // Neither of the two above reaches a folder the environment already has — one
+                    // cloned from the terminal, or anything outside /workspace — so those could not
+                    // be made a working folder at all.
+                    OutlinedButton(
+                        onClick = onChooseFolder,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(
+                            Icons.Default.FolderOpen,
+                            contentDescription = stringResource(R.string.cd_choose_folder),
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(stringResource(R.string.workspace_choose_folder))
+                    }
                 }
             }
 
@@ -383,9 +411,15 @@ fun WorkspacesScreen(
                 items(state.workspaces, key = { it.id }) { workspace ->
                     WorkspaceProjectRow(
                         workspace = workspace,
+                        isDeleting = workspace.path in state.folders.deleting,
+                        deleteFailed = workspace.path in state.folders.failed,
+                        // Only the /workspace mount is this app's own storage; a folder elsewhere in
+                        // the environment can be dropped from the list but is not ours to erase.
+                        canDeleteFiles = localRuntimeActive && WorkspaceFolders.isInsideWorkspaceRoot(workspace.path),
                         onOpen = { onOpenWorkspace(workspace) },
                         onRemove = { onRemoveProject(workspace.path) },
                         onDeleteFiles = { onDeleteProjectFiles(workspace.path) },
+                        onDismissDeleteFailure = { onDismissDeleteFailure(workspace.path) },
                     )
                 }
             }
@@ -484,19 +518,140 @@ fun WorkspacesScreen(
             },
         )
     }
+
+    if (state.folderPicker.visible) {
+        FolderPickerDialog(
+            picker = state.folderPicker,
+            onOpenChild = onBrowseFolderInto,
+            onUp = onBrowseFolderUp,
+            onConfirm = onConfirmFolder,
+            onDismiss = onDismissFolderPicker,
+        )
+    }
+}
+
+/**
+ * Walks the on-device environment so an existing directory can be made a working folder.
+ *
+ * Selects the folder that is open, not one highlighted in the list: the user has to be able to pick
+ * a directory whose own contents they just looked at, and that is also how they reach a folder with
+ * no subfolders at all.
+ */
+@Composable
+private fun FolderPickerDialog(
+    picker: FolderPickerState,
+    onOpenChild: (String) -> Unit,
+    onUp: () -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val atRoot = picker.path == WorkspaceFolders.GUEST_ROOT
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.workspace_choose_folder)) },
+        text = {
+            Column {
+                if (picker.unavailable) {
+                    Text(
+                        stringResource(R.string.workspace_folder_picker_unavailable),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    return@Column
+                }
+                Text(
+                    picker.path,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                if (picker.isLoading) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+                    if (!atRoot) {
+                        item {
+                            FolderPickerRow(
+                                icon = Icons.Default.ArrowUpward,
+                                label = stringResource(R.string.workspace_folder_picker_up),
+                                onClick = onUp,
+                            )
+                        }
+                    }
+                    items(picker.directories, key = { it }) { name ->
+                        FolderPickerRow(
+                            icon = Icons.Default.Folder,
+                            label = name,
+                            onClick = { onOpenChild(name) },
+                        )
+                    }
+                    if (picker.directories.isEmpty() && !picker.isLoading) {
+                        item {
+                            Text(
+                                stringResource(R.string.workspace_folder_picker_empty),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(vertical = 8.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            // The environment root itself is not a project; anything below it can be one.
+            Button(onClick = onConfirm, enabled = !picker.unavailable && !atRoot) {
+                Text(stringResource(R.string.workspace_folder_picker_select))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun FolderPickerRow(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable { onClick() }
+                .padding(vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
+        Text(label, maxLines = 1)
+    }
 }
 
 @Composable
 private fun WorkspaceProjectRow(
     workspace: WorkspaceRef,
+    isDeleting: Boolean,
+    deleteFailed: Boolean,
+    canDeleteFiles: Boolean,
     onOpen: () -> Unit,
     onRemove: () -> Unit,
     onDeleteFiles: () -> Unit,
+    onDismissDeleteFailure: () -> Unit,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
     var confirmDelete by remember { mutableStateOf(false) }
 
-    SectionCard(modifier = Modifier.clickable { onOpen() }) {
+    // The dialog is the thing that reports progress, so a failure has to bring it back even if the
+    // user closed it while the delete was running.
+    LaunchedEffect(deleteFailed) {
+        if (deleteFailed) confirmDelete = true
+    }
+
+    SectionCard(modifier = Modifier.clickable(enabled = !isDeleting) { onOpen() }) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -510,50 +665,98 @@ private fun WorkspaceProjectRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 2,
                 )
-            }
-            Box {
-                IconButton(onClick = { menuOpen = true }) {
-                    Icon(
-                        Icons.Default.MoreVert,
-                        contentDescription = stringResource(R.string.workspace_more_options),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                if (isDeleting) {
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        stringResource(R.string.workspace_deleting),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    Spacer(Modifier.height(4.dp))
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                 }
-                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.workspace_remove_from_list)) },
-                        onClick = {
-                            menuOpen = false
-                            onRemove()
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.workspace_delete_files)) },
-                        onClick = {
-                            menuOpen = false
-                            confirmDelete = true
-                        },
-                    )
+            }
+            if (isDeleting) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            } else {
+                Box {
+                    IconButton(onClick = { menuOpen = true }) {
+                        Icon(
+                            Icons.Default.MoreVert,
+                            contentDescription = stringResource(R.string.workspace_more_options),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.workspace_remove_from_list)) },
+                            onClick = {
+                                menuOpen = false
+                                onRemove()
+                            },
+                        )
+                        if (canDeleteFiles) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.workspace_delete_files)) },
+                                onClick = {
+                                    menuOpen = false
+                                    confirmDelete = true
+                                },
+                            )
+                        }
+                    }
                 }
             }
         }
     }
 
     if (confirmDelete) {
+        // Stays up for the whole delete: this used to close on the tap and leave the row behind
+        // until some later refresh happened to drop it, which read as the delete having failed.
         AlertDialog(
-            onDismissRequest = { confirmDelete = false },
-            title = { Text(stringResource(R.string.workspace_delete_files)) },
-            text = { Text(stringResource(R.string.workspace_delete_files_confirm, workspace.name)) },
-            confirmButton = {
-                Button(onClick = {
+            onDismissRequest = {
+                if (!isDeleting) {
                     confirmDelete = false
-                    onDeleteFiles()
-                }) {
-                    Text(stringResource(R.string.delete))
+                    onDismissDeleteFailure()
+                }
+            },
+            title = { Text(stringResource(R.string.workspace_delete_files)) },
+            text = {
+                Column {
+                    Text(stringResource(R.string.workspace_delete_files_confirm, workspace.name))
+                    if (isDeleting) {
+                        Spacer(Modifier.height(12.dp))
+                        Text(
+                            stringResource(R.string.workspace_deleting),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(6.dp))
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    }
+                    if (deleteFailed) {
+                        Spacer(Modifier.height(12.dp))
+                        Text(
+                            stringResource(R.string.workspace_delete_failed),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(onClick = onDeleteFiles, enabled = !isDeleting) {
+                    Text(stringResource(if (deleteFailed) R.string.workspace_delete_retry else R.string.delete))
                 }
             },
             dismissButton = {
-                TextButton(onClick = { confirmDelete = false }) {
+                TextButton(
+                    onClick = {
+                        confirmDelete = false
+                        onDismissDeleteFailure()
+                    },
+                    enabled = !isDeleting,
+                ) {
                     Text(stringResource(R.string.cancel))
                 }
             },

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
@@ -32,7 +32,11 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
         RuntimeCapabilities(toolEvents = true, forcesQueue = true)
     private val mutableState = MutableStateFlow<RuntimeState>(RuntimeState.Disconnected)
     override val state: StateFlow<RuntimeState> = mutableState.asStateFlow()
-    private val files = ClaudeWorkspaceFiles(File(runtime.runtimeDirectory, "workspace"))
+    private val files =
+        ClaudeWorkspaceFiles(
+            workspaceHostDir = File(runtime.runtimeDirectory, "workspace"),
+            rootfsHostDir = File(runtime.runtimeDirectory, "environment/rootfs"),
+        )
     private val titleScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     val auth get() = runtime.auth()
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
@@ -123,7 +123,11 @@ class ClaudeCodeTarget(
     }
 
     private val titleScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val files = ClaudeWorkspaceFiles(File(runtime.runtimeDirectory, "workspace"))
+    private val files =
+        ClaudeWorkspaceFiles(
+            workspaceHostDir = File(runtime.runtimeDirectory, "workspace"),
+            rootfsHostDir = File(runtime.runtimeDirectory, "environment/rootfs"),
+        )
 
     val auth: ClaudeAuthCoordinator get() = runtime.auth
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeWorkspaceFiles.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeWorkspaceFiles.kt
@@ -14,7 +14,11 @@ import java.io.File
  * not need one: `/workspace` inside the sandbox is a plain directory on the device, so these read it
  * directly. Without this the explorer throws "unsupported" the moment a Claude session is open.
  */
-class ClaudeWorkspaceFiles(private val workspaceHostDir: File) {
+class ClaudeWorkspaceFiles(
+    private val workspaceHostDir: File,
+    /** The Linux rootfs, for workspaces that sit outside the `/workspace` mount. */
+    private val rootfsHostDir: File? = null,
+) {
     fun list(
         directory: String,
         path: String,
@@ -123,11 +127,20 @@ class ClaudeWorkspaceFiles(private val workspaceHostDir: File) {
      * Host directory backing [directory].
      *
      * Sessions record sandbox paths such as `/workspace/project`; everything under `/workspace` maps
-     * into the app's own workspace directory.
+     * into the app's own workspace directory. A workspace can also be set to a folder the Linux
+     * environment already has — `/root/project`, say — and those live in the rootfs instead; without
+     * [rootfsHostDir] they were resolved under the workspace mount, which is a different folder
+     * entirely.
      */
     private fun resolveRoot(directory: String): File {
-        val relative = directory.removePrefix("/workspace").trim('/')
-        return if (relative.isEmpty()) workspaceHostDir else File(workspaceHostDir, relative)
+        val trimmed = directory.trim().trimEnd('/')
+        if (trimmed == WORKSPACE_MOUNT || trimmed.startsWith("$WORKSPACE_MOUNT/")) {
+            val relative = trimmed.removePrefix(WORKSPACE_MOUNT).trim('/')
+            return if (relative.isEmpty()) workspaceHostDir else File(workspaceHostDir, relative)
+        }
+        val rootfs = rootfsHostDir ?: return File(workspaceHostDir, trimmed.trim('/'))
+        val relative = trimmed.trim('/')
+        return if (relative.isEmpty()) rootfs else File(rootfs, relative)
     }
 
     private fun sandboxPath(
@@ -148,6 +161,7 @@ class ClaudeWorkspaceFiles(private val workspaceHostDir: File) {
     }
 
     private companion object {
+        const val WORKSPACE_MOUNT = "/workspace"
         const val MAX_READ_BYTES = 2L * 1024 * 1024
         const val BINARY_SNIFF_BYTES = 1024
         const val DEFAULT_LIMIT = 200

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeWorkspaceFiles.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeWorkspaceFiles.kt
@@ -13,10 +13,11 @@ import java.io.File
  * OpenCode answers the explorer's file questions over HTTP; Claude Code has no such server. It does
  * not need one: `/workspace` inside the sandbox is a plain directory on the device, so these read it
  * directly. Without this the explorer throws "unsupported" the moment a Claude session is open.
+ *
+ * [rootfsHostDir] is the Linux rootfs, for workspaces set to a folder outside the `/workspace` mount.
  */
 class ClaudeWorkspaceFiles(
     private val workspaceHostDir: File,
-    /** The Linux rootfs, for workspaces that sit outside the `/workspace` mount. */
     private val rootfsHostDir: File? = null,
 ) {
     fun list(

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
@@ -70,8 +70,14 @@ fun NavGraphBuilder.workspaceNavGraph(
             },
             onImportFolder = onImportFolder,
             onCloneGithub = onShowCloneDialog,
+            onChooseFolder = workspaceViewModel::openFolderPicker,
+            onBrowseFolderInto = workspaceViewModel::browseFolderInto,
+            onBrowseFolderUp = workspaceViewModel::browseFolderUp,
+            onConfirmFolder = { workspaceViewModel.confirmFolderPicker() },
+            onDismissFolderPicker = workspaceViewModel::dismissFolderPicker,
             onRemoveProject = workspaceViewModel::removeProject,
             onDeleteProjectFiles = workspaceViewModel::deleteProjectFiles,
+            onDismissDeleteFailure = workspaceViewModel::dismissDeleteFailure,
             onBack = { navController.popBackStack() },
         )
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">إزالة من القائمة</string>
     <string name="workspace_delete_files">حذف الملفات</string>
     <string name="workspace_delete_files_confirm">حذف \"%1$s\" وجميع ملفاته؟ لا يمكن التراجع عن هذا.</string>
+    <string name="workspace_deleting">جارٍ الحذف…</string>
+    <string name="workspace_delete_failed">تعذر حذف هذا المجلد. أوقف بيئة التشغيل إذا كانت قيد التشغيل ثم حاول مرة أخرى.</string>
+    <string name="workspace_delete_retry">إعادة المحاولة</string>
+    <string name="workspace_choose_folder">اختيار مجلد موجود</string>
+    <string name="cd_choose_folder">اختيار مجلد موجود</string>
+    <string name="workspace_folder_picker_up">مستوى للأعلى</string>
+    <string name="workspace_folder_picker_empty">لا توجد مجلدات فرعية هنا.</string>
+    <string name="workspace_folder_picker_select">استخدام هذا المجلد</string>
+    <string name="workspace_folder_picker_unavailable">قم بإعداد بيئة التشغيل على الجهاز أولاً — لا توجد بيئة لاستعراضها بعد.</string>
 
     <string name="recent_sessions">الجلسات الأخيرة</string>
     <string name="view_all">عرض الكل</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">Quitar de la lista</string>
     <string name="workspace_delete_files">Eliminar archivos</string>
     <string name="workspace_delete_files_confirm">¿Eliminar \"%1$s\" y todos sus archivos? Esta acción no se puede deshacer.</string>
+    <string name="workspace_deleting">Eliminando…</string>
+    <string name="workspace_delete_failed">No se pudo eliminar esta carpeta. Detén el entorno de ejecución si está activo e inténtalo de nuevo.</string>
+    <string name="workspace_delete_retry">Reintentar</string>
+    <string name="workspace_choose_folder">Elegir carpeta existente</string>
+    <string name="cd_choose_folder">Elegir una carpeta existente</string>
+    <string name="workspace_folder_picker_up">Subir un nivel</string>
+    <string name="workspace_folder_picker_empty">Aquí no hay subcarpetas.</string>
+    <string name="workspace_folder_picker_select">Usar esta carpeta</string>
+    <string name="workspace_folder_picker_unavailable">Configura primero el entorno en el dispositivo: aún no hay nada que explorar.</string>
 
     <string name="recent_sessions">Sesiones recientes</string>
     <string name="view_all">Ver todo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">Retirer de la liste</string>
     <string name="workspace_delete_files">Supprimer les fichiers</string>
     <string name="workspace_delete_files_confirm">Supprimer « %1$s » et tous ses fichiers ? Cette action est irréversible.</string>
+    <string name="workspace_deleting">Suppression…</string>
+    <string name="workspace_delete_failed">Impossible de supprimer ce dossier. Arrêtez l\'environnement s\'il est en cours d\'exécution, puis réessayez.</string>
+    <string name="workspace_delete_retry">Réessayer</string>
+    <string name="workspace_choose_folder">Choisir un dossier existant</string>
+    <string name="cd_choose_folder">Choisir un dossier existant</string>
+    <string name="workspace_folder_picker_up">Remonter d\'un niveau</string>
+    <string name="workspace_folder_picker_empty">Aucun sous-dossier ici.</string>
+    <string name="workspace_folder_picker_select">Utiliser ce dossier</string>
+    <string name="workspace_folder_picker_unavailable">Configurez d\'abord l\'environnement sur l\'appareil : il n\'y a encore rien à parcourir.</string>
 
     <string name="recent_sessions">Sessions récentes</string>
     <string name="view_all">Voir tout</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">一覧から削除</string>
     <string name="workspace_delete_files">ファイルを削除</string>
     <string name="workspace_delete_files_confirm">「%1$s」とすべてのファイルを削除しますか？元に戻せません。</string>
+    <string name="workspace_deleting">削除しています…</string>
+    <string name="workspace_delete_failed">このフォルダを削除できませんでした。実行環境が動作中の場合は停止してから、もう一度お試しください。</string>
+    <string name="workspace_delete_retry">再試行</string>
+    <string name="workspace_choose_folder">既存のフォルダを選択</string>
+    <string name="cd_choose_folder">既存のフォルダを選択</string>
+    <string name="workspace_folder_picker_up">一つ上の階層へ</string>
+    <string name="workspace_folder_picker_empty">サブフォルダはありません。</string>
+    <string name="workspace_folder_picker_select">このフォルダを使う</string>
+    <string name="workspace_folder_picker_unavailable">先にオンデバイス実行環境をセットアップしてください。参照できる環境がまだありません。</string>
 
     <string name="recent_sessions">最近のセッション</string>
     <string name="view_all">すべて表示</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">Remover da lista</string>
     <string name="workspace_delete_files">Excluir arquivos</string>
     <string name="workspace_delete_files_confirm">Excluir \"%1$s\" e todos os seus arquivos? Isso não pode ser desfeito.</string>
+    <string name="workspace_deleting">Excluindo…</string>
+    <string name="workspace_delete_failed">Não foi possível excluir esta pasta. Pare o ambiente de execução, se estiver ativo, e tente novamente.</string>
+    <string name="workspace_delete_retry">Tentar novamente</string>
+    <string name="workspace_choose_folder">Escolher pasta existente</string>
+    <string name="cd_choose_folder">Escolher uma pasta existente</string>
+    <string name="workspace_folder_picker_up">Um nível acima</string>
+    <string name="workspace_folder_picker_empty">Nenhuma subpasta aqui.</string>
+    <string name="workspace_folder_picker_select">Usar esta pasta</string>
+    <string name="workspace_folder_picker_unavailable">Configure primeiro o ambiente no dispositivo — ainda não há nada para navegar.</string>
 
     <string name="recent_sessions">Sessões recentes</string>
     <string name="view_all">Ver tudo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">Удалить из списка</string>
     <string name="workspace_delete_files">Удалить файлы</string>
     <string name="workspace_delete_files_confirm">Удалить \"%1$s\" и все его файлы? Это действие нельзя отменить.</string>
+    <string name="workspace_deleting">Удаление…</string>
+    <string name="workspace_delete_failed">Не удалось удалить эту папку. Остановите среду выполнения, если она запущена, и повторите попытку.</string>
+    <string name="workspace_delete_retry">Повторить</string>
+    <string name="workspace_choose_folder">Выбрать существующую папку</string>
+    <string name="cd_choose_folder">Выбрать существующую папку</string>
+    <string name="workspace_folder_picker_up">На уровень вверх</string>
+    <string name="workspace_folder_picker_empty">Здесь нет вложенных папок.</string>
+    <string name="workspace_folder_picker_select">Использовать эту папку</string>
+    <string name="workspace_folder_picker_unavailable">Сначала настройте среду на устройстве — просматривать пока нечего.</string>
 
     <string name="recent_sessions">Недавние сессии</string>
     <string name="view_all">Показать все</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">从列表中移除</string>
     <string name="workspace_delete_files">删除文件</string>
     <string name="workspace_delete_files_confirm">删除\"%1$s\"及其所有文件？此操作无法撤消。</string>
+    <string name="workspace_deleting">正在删除…</string>
+    <string name="workspace_delete_failed">无法删除此文件夹。如果运行环境正在运行，请先停止后重试。</string>
+    <string name="workspace_delete_retry">重试</string>
+    <string name="workspace_choose_folder">选择已有文件夹</string>
+    <string name="cd_choose_folder">选择已有文件夹</string>
+    <string name="workspace_folder_picker_up">返回上一级</string>
+    <string name="workspace_folder_picker_empty">此处没有子文件夹。</string>
+    <string name="workspace_folder_picker_select">使用此文件夹</string>
+    <string name="workspace_folder_picker_unavailable">请先设置设备端运行环境——目前还没有可浏览的环境。</string>
 
     <string name="recent_sessions">最近的会话</string>
     <string name="view_all">查看全部</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,15 @@
     <string name="workspace_remove_from_list">Remove from list</string>
     <string name="workspace_delete_files">Delete files</string>
     <string name="workspace_delete_files_confirm">Delete \"%1$s\" and all its files? This cannot be undone.</string>
+    <string name="workspace_deleting">Deleting…</string>
+    <string name="workspace_delete_failed">Could not delete this folder. Stop the runtime if it is running, then try again.</string>
+    <string name="workspace_delete_retry">Try again</string>
+    <string name="workspace_choose_folder">Choose existing folder</string>
+    <string name="cd_choose_folder">Choose an existing folder</string>
+    <string name="workspace_folder_picker_up">Up one level</string>
+    <string name="workspace_folder_picker_empty">No subfolders here.</string>
+    <string name="workspace_folder_picker_select">Use this folder</string>
+    <string name="workspace_folder_picker_unavailable">Set up the on-device runtime first — there is no environment to browse yet.</string>
 
     <string name="recent_sessions">Recent sessions</string>
     <string name="view_all">View all</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/RuntimeFolderBrowserTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/RuntimeFolderBrowserTest.kt
@@ -1,0 +1,68 @@
+package com.yugahashimoto.andcode.feature.workspace
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class RuntimeFolderBrowserTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var rootfs: File
+    private lateinit var workspace: File
+
+    private fun browser(): RuntimeFolderBrowser {
+        rootfs = temporaryFolder.newFolder("rootfs")
+        workspace = temporaryFolder.newFolder("workspace")
+        return RuntimeFolderBrowser(rootfs, workspace)
+    }
+
+    @Test
+    fun `the root lists the rootfs plus the workspace mount that is not part of it`() {
+        val browser = browser()
+        File(rootfs, "root").mkdirs()
+        File(rootfs, "etc").mkdirs()
+        File(rootfs, "init").writeText("not a directory")
+
+        assertEquals(listOf("etc", "root", "workspace"), browser.children("/"))
+    }
+
+    @Test
+    fun `descending into the mount lists imported and cloned projects`() {
+        val browser = browser()
+        File(workspace, "and-code").mkdirs()
+        File(workspace, "Notes").mkdirs()
+
+        assertEquals(listOf("and-code", "Notes"), browser.children("/workspace"))
+    }
+
+    @Test
+    fun `hidden folders sort last so real projects are seen first`() {
+        val browser = browser()
+        File(rootfs, "root/.cache").mkdirs()
+        File(rootfs, "root/project").mkdirs()
+
+        assertEquals(listOf("project", ".cache"), browser.children("/root"))
+    }
+
+    @Test
+    fun `a path that climbs out of the environment lists nothing`() {
+        val browser = browser()
+        File(rootfs, "root").mkdirs()
+
+        assertEquals(emptyList<String>(), browser.children("/../../etc"))
+    }
+
+    @Test
+    fun `browsing is unavailable until the runtime is installed`() {
+        val installed = browser()
+        val missing = File(temporaryFolder.root, "not-installed")
+
+        assertFalse(RuntimeFolderBrowser(missing, workspace).isAvailable())
+        assertTrue(installed.isAvailable())
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceFoldersTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceFoldersTest.kt
@@ -1,0 +1,101 @@
+package com.yugahashimoto.andcode.feature.workspace
+
+import com.yugahashimoto.andcode.runtime.WorkspaceRef
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class WorkspaceFoldersTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private fun ref(path: String) = WorkspaceRef(id = path, name = WorkspaceFolders.displayName(path), path = path)
+
+    @Test
+    fun `removed folder stays out of the list even when the runtime keeps reporting it`() {
+        val visible =
+            WorkspaceFolders.visibleWorkspaces(
+                runtimeWorkspaces = listOf(ref("/workspace/app"), ref("/workspace/notes")),
+                registered = emptyList(),
+                hidden = setOf("/workspace/app"),
+            )
+
+        assertEquals(listOf("/workspace/notes"), visible.map { it.path })
+    }
+
+    @Test
+    fun `registered folders come first and are not duplicated by the runtime listing`() {
+        val visible =
+            WorkspaceFolders.visibleWorkspaces(
+                runtimeWorkspaces = listOf(ref("/workspace/app"), ref("/root/scratch")),
+                registered = listOf(ref("/workspace/app")),
+                hidden = emptySet(),
+            )
+
+        assertEquals(listOf("/workspace/app", "/root/scratch"), visible.map { it.path })
+    }
+
+    @Test
+    fun `nested workspace resolves to its own folder rather than a same-named one at the top`() {
+        val root = temporaryFolder.newFolder("workspace")
+        val nested = File(root, "team/app").apply { mkdirs() }
+        File(root, "app").mkdirs()
+
+        val resolved = WorkspaceFolders.deletableHostDirectory(root, "/workspace/team/app")
+
+        assertEquals(nested.canonicalFile, resolved?.canonicalFile)
+    }
+
+    @Test
+    fun `nothing outside the workspace mount is deletable`() {
+        val root = temporaryFolder.newFolder("workspace")
+
+        assertNull(WorkspaceFolders.deletableHostDirectory(root, "/workspace"))
+        assertNull(WorkspaceFolders.deletableHostDirectory(root, "/"))
+        assertNull(WorkspaceFolders.deletableHostDirectory(root, "/root/project"))
+        assertNull(WorkspaceFolders.deletableHostDirectory(root, "/workspace/../../secrets"))
+        assertNull(WorkspaceFolders.deletableHostDirectory(root, "/home/user/and-code"))
+    }
+
+    @Test
+    fun `browsing maps the workspace mount and the rootfs to their own directories`() {
+        val rootfs = temporaryFolder.newFolder("rootfs")
+        val workspace = temporaryFolder.newFolder("workspace")
+
+        assertEquals(
+            File(workspace, "app").canonicalFile,
+            WorkspaceFolders.hostDirectory(rootfs, workspace, "/workspace/app")?.canonicalFile,
+        )
+        assertEquals(workspace.canonicalFile, WorkspaceFolders.hostDirectory(rootfs, workspace, "/workspace")?.canonicalFile)
+        assertEquals(
+            File(rootfs, "root/project").canonicalFile,
+            WorkspaceFolders.hostDirectory(rootfs, workspace, "/root/project")?.canonicalFile,
+        )
+        assertEquals(rootfs.canonicalFile, WorkspaceFolders.hostDirectory(rootfs, workspace, "/")?.canonicalFile)
+        assertNull(WorkspaceFolders.hostDirectory(rootfs, workspace, "/../outside"))
+    }
+
+    @Test
+    fun `paths are normalised so the same folder is never two entries`() {
+        assertEquals("/workspace/app", WorkspaceFolders.normalize("/workspace/app/"))
+        assertEquals("/workspace/app", WorkspaceFolders.normalize("//workspace//app"))
+        assertEquals("/", WorkspaceFolders.normalize(""))
+        assertEquals("/workspace", WorkspaceFolders.parentOf("/workspace/app"))
+        assertEquals("/", WorkspaceFolders.parentOf("/workspace"))
+        assertEquals("/", WorkspaceFolders.parentOf("/"))
+        assertEquals("/workspace/app", WorkspaceFolders.childOf("/workspace", "app"))
+    }
+
+    @Test
+    fun `only folders under the mount count as inside it`() {
+        assertTrue(WorkspaceFolders.isInsideWorkspaceRoot("/workspace/app"))
+        assertFalse(WorkspaceFolders.isInsideWorkspaceRoot("/workspace"))
+        assertFalse(WorkspaceFolders.isInsideWorkspaceRoot("/workspaces/app"))
+        assertFalse(WorkspaceFolders.isInsideWorkspaceRoot("/root/app"))
+    }
+}


### PR DESCRIPTION
## What was wrong

設定 → ワークスペースで作業フォルダを削除しても、行が消えませんでした。「一覧から削除」も「ファイルを削除」も同じで、しばらく経ってから消えたように見えることもあり（時差）、UX として壊れていました。

原因は 2 つあります。

1. **一覧はランタイムが報告するフォルダと、この端末が登録したフォルダの和集合**で、行のほとんどは前者です（過去のチャットが動いたディレクトリ、ディスク上にあるディレクトリをエージェントが列挙する）。`removeProject` は登録リストから消すだけだったので、次のリフレッシュでそのまま戻ってきていました。
2. **「ファイルを削除」は登録済みパスのときしか削除していませんでした。** しかも削除先を basename で解決していたため、`/workspace/team/app` はマウント直下の `app` を指してしまいます。さらにメインスレッドで同期削除し、削除完了を待たずに戻っていました。

## What changed

- 削除を記憶する（`hiddenWorkspacePaths`）。ランタイム由来の行も消えたままになり、同じパスを再度インポート／クローンすると復活します。
- 削除はパスが実際に指すフォルダに対して、`Dispatchers.IO` 上で実行。**完了するまで行とダイアログが画面に残り、進捗を表示します。** 失敗した場合はその場でエラーと「再試行」を出します（無言の no-op をやめました）。
- 「ファイルを削除」は `/workspace` マウント配下（このアプリ自身のストレージ）のフォルダにのみ表示。他所のフォルダは一覧から外すだけで、ファイルには触れません。
- **既存フォルダを選択**をインポート／クローンに追加。オンデバイス環境のルート `/` から辿って、すでにある任意のディレクトリ（ターミナルでクローンしたもの、`/workspace` 外のもの）をワークスペースにできます。ランタイム停止中でも参照できます。
- `/workspace` 外のワークスペースは、ファイルエクスプローラでも rootfs 側に解決するよう修正（従来はワークスペースマウント配下を探しに行っていました）。

## Files

| File | Why |
| --- | --- |
| `WorkspaceFolders.kt` (new) | パス正規化・可視フォルダの合成・削除可能なホストディレクトリの解決。Android 依存なしでテスト可能 |
| `RuntimeFolderBrowser.kt` (new) | rootfs と `/workspace` マウントをまたいでディレクトリを列挙 |
| `WorkspaceViewModel.kt` | 削除の非同期化と進捗／失敗状態、非表示パス、フォルダピッカー |
| `WorkspacesScreen.kt` | 削除中の表示、失敗時の再試行、フォルダピッカーのダイアログ |
| `ClaudeWorkspaceFiles.kt` | `/workspace` 外のパスを rootfs に解決 |
| `SecureSettingsRepository.kt` | `hiddenWorkspacePaths` |
| `strings.xml` × 8 | 新規文言（en / ja / ar / es / fr / pt-BR / ru / zh-CN） |

## Tests

新規: `WorkspaceFoldersTest`（非表示パス、ネストしたフォルダの解決、マウント外・`..` の拒否）、`RuntimeFolderBrowserTest`（ルート列挙、マウントの合成、隠しフォルダの並び、脱出パス、未インストール時）。

ローカル実行:

- `./gradlew :app:testDebugUnitTest` — 全 86 テストクラス green
- `./gradlew detekt spotlessCheck` — green
- `./gradlew :app:lintDebug` — green

実機での動作確認は未実施です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzSHgYpVmxXtVc6dybvFGG)_