### PR TITLE
feat: show agent versions and what an update actually did

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
@@ -860,6 +860,7 @@ private fun SignInStep(
                     com.yugahashimoto.andcode.feature.workspace.AntigravityCard(
                         antigravity = antigravity,
                         onInstall = {},
+                        onUpdate = {},
                         onSelectPermissionMode = onSelectAntigravityPermissionMode,
                         onSignIn = onBeginAntigravitySignIn,
                         onSubmitCode = onSubmitAntigravitySignInCode,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/AgentSettingsScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/AgentSettingsScreen.kt
@@ -62,6 +62,7 @@ fun AgentSettingsScreen(
 fun AntigravityAgentSettingsScreen(
     antigravity: com.yugahashimoto.andcode.runtime.local.AntigravityControllerState,
     onInstall: () -> Unit,
+    onUpdate: () -> Unit,
     onSelectPermissionMode: (com.yugahashimoto.andcode.runtime.local.AntigravityPermissionMode) -> Unit,
     onSignIn: () -> Unit,
     onSubmitCode: (String) -> Unit,
@@ -78,6 +79,7 @@ fun AntigravityAgentSettingsScreen(
                 com.yugahashimoto.andcode.feature.workspace.AntigravityCard(
                     antigravity = antigravity,
                     onInstall = onInstall,
+                    onUpdate = onUpdate,
                     onSelectPermissionMode = onSelectPermissionMode,
                     onSignIn = onSignIn,
                     onSubmitCode = onSubmitCode,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/AntigravityCard.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/AntigravityCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -26,12 +27,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.runtime.local.AntigravityAuthCoordinator
 import com.yugahashimoto.andcode.runtime.local.AntigravityControllerState
 import com.yugahashimoto.andcode.runtime.local.AntigravityInstallStatus
 import com.yugahashimoto.andcode.runtime.local.AntigravityPermissionMode
+import com.yugahashimoto.andcode.runtime.local.AntigravityUpdateResult
 
 /**
  * Install, sign-in and permission controls for the official Antigravity agent.
@@ -43,6 +46,7 @@ import com.yugahashimoto.andcode.runtime.local.AntigravityPermissionMode
 fun AntigravityCard(
     antigravity: AntigravityControllerState,
     onInstall: () -> Unit,
+    onUpdate: () -> Unit,
     onSelectPermissionMode: (AntigravityPermissionMode) -> Unit,
     onSignIn: () -> Unit,
     onSubmitCode: (String) -> Unit,
@@ -82,16 +86,28 @@ fun AntigravityCard(
             is AntigravityInstallStatus.Ready ->
                 InstalledSection(
                     antigravity,
+                    onUpdate,
                     onSelectPermissionMode,
                     onSignIn,
                     onSubmitCode,
                     onCancelSignIn,
                     onSignOut,
                     onOpenUrl,
+                    showInstallActions,
                 )
             AntigravityInstallStatus.Idle ->
                 if (antigravity.installed) {
-                    InstalledSection(antigravity, onSelectPermissionMode, onSignIn, onSubmitCode, onCancelSignIn, onSignOut, onOpenUrl)
+                    InstalledSection(
+                        antigravity,
+                        onUpdate,
+                        onSelectPermissionMode,
+                        onSignIn,
+                        onSubmitCode,
+                        onCancelSignIn,
+                        onSignOut,
+                        onOpenUrl,
+                        showInstallActions,
+                    )
                 } else if (showInstallActions) {
                     Button(
                         onClick = onInstall,
@@ -105,13 +121,22 @@ fun AntigravityCard(
 @Composable
 private fun InstalledSection(
     antigravity: AntigravityControllerState,
+    onUpdate: () -> Unit,
     onSelectPermissionMode: (AntigravityPermissionMode) -> Unit,
     onSignIn: () -> Unit,
     onSubmitCode: (String) -> Unit,
     onCancelSignIn: () -> Unit,
     onSignOut: () -> Unit,
     onOpenUrl: (String) -> Unit,
+    showInstallActions: Boolean,
 ) {
+    antigravity.version?.takeIf(String::isNotBlank)?.let { version ->
+        Text(
+            text = stringResource(R.string.antigravity_installed_version, version),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
     when (val auth = antigravity.auth) {
         AntigravityAuthCoordinator.State.Idle -> {
             Text(stringResource(R.string.antigravity_status_signed_out), style = MaterialTheme.typography.bodySmall)
@@ -143,6 +168,45 @@ private fun InstalledSection(
         }
     }
     PermissionModePicker(selected = antigravity.permissionMode, onSelect = onSelectPermissionMode)
+    if (showInstallActions) UpdateSection(antigravity, onUpdate)
+}
+
+/**
+ * Offers the release this build of the app carries, and says what the last attempt did.
+ *
+ * Antigravity comes from a version pinned in the app rather than a package repository, so whether an
+ * update exists is already known here — no check button, and no network needed to answer it.
+ */
+@Composable
+private fun UpdateSection(
+    antigravity: AntigravityControllerState,
+    onUpdate: () -> Unit,
+) {
+    antigravity.lastUpdate?.let { result ->
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            Text(
+                text =
+                    when (result) {
+                        is AntigravityUpdateResult.Updated ->
+                            stringResource(R.string.agent_update_result_updated, result.fromVersion, result.version)
+                        is AntigravityUpdateResult.AlreadyLatest ->
+                            stringResource(R.string.agent_update_result_latest, result.version)
+                    },
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+    if (antigravity.updateAvailable) {
+        Text(
+            text = stringResource(R.string.antigravity_update_available, antigravity.bundledVersion),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedButton(onClick = onUpdate, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.antigravity_update_button))
+        }
+    }
 }
 
 /** Mirrors Claude Code's picker: agy's own `default` mode expects a live TUI, so it is not offered. */

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/ClaudeCodeCard.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/ClaudeCodeCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -36,6 +37,7 @@ import com.yugahashimoto.andcode.runtime.local.ClaudeAuthCoordinator
 import com.yugahashimoto.andcode.runtime.local.ClaudeCodeUiState
 import com.yugahashimoto.andcode.runtime.local.ClaudeInstallStatus
 import com.yugahashimoto.andcode.runtime.local.ClaudePermissionMode
+import com.yugahashimoto.andcode.runtime.local.ClaudeUpdateResult
 
 /**
  * Install and sign-in controls for the Android-local Claude Code agent.
@@ -129,6 +131,7 @@ private fun InstalledSection(
     onOpenUrl: (String) -> Unit,
     showInstallActions: Boolean,
 ) {
+    claude.version?.takeIf(String::isNotBlank)?.let { InstalledVersionRow(it) }
     when (val auth = claude.auth) {
         ClaudeAuthCoordinator.State.Starting -> {
             Text(stringResource(R.string.claude_auth_starting), style = MaterialTheme.typography.bodySmall)
@@ -164,9 +167,47 @@ private fun InstalledSection(
     }
     PermissionModePicker(selected = claude.permissionMode, onSelect = onSelectPermissionMode)
     if (showInstallActions) {
+        claude.lastUpdate?.let { UpdateResultRow(it) }
         OutlinedButton(onClick = onUpdate, modifier = Modifier.fillMaxWidth()) {
             Text(stringResource(R.string.claude_update_button))
         }
+    }
+}
+
+/**
+ * States which version is installed.
+ *
+ * The update button lives on this card, so without the version here there was no way to tell what
+ * an update started from or arrived at.
+ */
+@Composable
+private fun InstalledVersionRow(version: String) {
+    Text(
+        text = stringResource(R.string.claude_installed_version, version),
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Medium,
+    )
+}
+
+/** Says whether the last update moved the version or found nothing newer. */
+@Composable
+private fun UpdateResultRow(result: ClaudeUpdateResult) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            Icons.Default.CheckCircle,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text =
+                when (result) {
+                    is ClaudeUpdateResult.Updated ->
+                        stringResource(R.string.agent_update_result_updated, result.fromVersion, result.version)
+                    is ClaudeUpdateResult.AlreadyLatest ->
+                        stringResource(R.string.agent_update_result_latest, result.version)
+                },
+            style = MaterialTheme.typography.bodySmall,
+        )
     }
 }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
@@ -22,10 +22,45 @@ sealed interface AntigravityInstallStatus {
     data class Failed(val message: String) : AntigravityInstallStatus
 }
 
+/**
+ * What an update attempt did to the installed release.
+ *
+ * The mirror of `ClaudeUpdateResult`: an update that had nothing to do and one that installed a new
+ * binary are indistinguishable unless the version is read on both sides of the attempt.
+ */
+sealed interface AntigravityUpdateResult {
+    /** The version now installed, whether or not this attempt changed it. */
+    val version: String
+
+    data class Updated(val fromVersion: String, override val version: String) : AntigravityUpdateResult
+
+    data class AlreadyLatest(override val version: String) : AntigravityUpdateResult
+}
+
+/** Classifies an update by what it did to the installed version. */
+internal fun antigravityUpdateResult(
+    before: String?,
+    after: String,
+): AntigravityUpdateResult =
+    if (before.isNullOrBlank() || before == after) {
+        AntigravityUpdateResult.AlreadyLatest(after)
+    } else {
+        AntigravityUpdateResult.Updated(before, after)
+    }
+
 data class AntigravityControllerState(
     val installed: Boolean = false,
     val version: String? = null,
+    /**
+     * The release this build of the app pins.
+     *
+     * Antigravity is not fetched from a package repository, so the newest version available to the
+     * user is whatever the installed app carries — comparing it against [version] is the whole
+     * update check, and it needs no network.
+     */
+    val bundledVersion: String = AntigravityManifest.VERSION,
     val install: AntigravityInstallStatus = AntigravityInstallStatus.Idle,
+    val lastUpdate: AntigravityUpdateResult? = null,
     val auth: AntigravityAuthCoordinator.State = AntigravityAuthCoordinator.State.Idle,
     val permissionMode: AntigravityPermissionMode = AntigravityPermissionMode.DEFAULT,
 ) {
@@ -34,6 +69,15 @@ data class AntigravityControllerState(
 
     /** Kept for call sites that only care about the last failure message. */
     val error: String? get() = (install as? AntigravityInstallStatus.Failed)?.message
+
+    /**
+     * True when the installed release differs from the one this app carries.
+     *
+     * An install whose version was never recorded reports the pinned version (see
+     * [AntigravityRuntime.version]), so it reads as up to date rather than prompting an update on a
+     * guess.
+     */
+    val updateAvailable: Boolean get() = installed && version != null && version != bundledVersion
 }
 
 /** Single owner for install/update/auth state; UI can observe this without owning a process. */
@@ -124,6 +168,45 @@ class AntigravityController(
                     mutableState.value =
                         AntigravityControllerState(install = AntigravityInstallStatus.Failed(error.message ?: "Install failed"))
                 }
+        }
+    }
+
+    /**
+     * Installs the release this build of the app pins, over whatever is in the guest.
+     *
+     * Deliberately not [install]: that provisions a whole new environment directory, while an
+     * Antigravity update only ever replaces one verified binary. The version is read on both sides
+     * so the card can say which release the update landed on instead of just going quiet.
+     */
+    fun update() {
+        if (mutableState.value.install is AntigravityInstallStatus.Installing) return
+        val before = mutableState.value.version
+        mutableState.value =
+            mutableState.value.copy(
+                install = AntigravityInstallStatus.Installing(0f, ""),
+                lastUpdate = null,
+            )
+        scope.launch {
+            runCatching {
+                installer.updateAntigravity { progress ->
+                    mutableState.value =
+                        mutableState.value.copy(install = AntigravityInstallStatus.Installing(progress, ""))
+                }
+            }.onSuccess { version ->
+                target.runtime.invalidateVersion()
+                mutableState.value =
+                    mutableState.value.copy(
+                        installed = true,
+                        version = version,
+                        install = AntigravityInstallStatus.Ready(version),
+                        lastUpdate = antigravityUpdateResult(before, version),
+                    )
+            }.onFailure { error ->
+                mutableState.value =
+                    mutableState.value.copy(
+                        install = AntigravityInstallStatus.Failed(error.message ?: "Update failed"),
+                    )
+            }
         }
     }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityInstaller.kt
@@ -50,6 +50,9 @@ class AntigravityInstaller(
                     if (!destination.exists() && backup.exists()) backup.renameTo(destination)
                     throw error
                 }
+                // Written only once the swap succeeded, so the marker can never claim a version the
+                // guest is not actually running.
+                writeInstalledVersion(rootfs, AntigravityManifest.VERSION)
                 onProgress(1f)
                 archive.delete()
                 destination
@@ -57,4 +60,39 @@ class AntigravityInstaller(
                 extraction.deleteRecursively()
             }
         }
+
+    companion object {
+        /**
+         * Records which release is in the guest, because the binary cannot be asked cheaply.
+         *
+         * `agy --version` boots the whole bundled language server before it prints anything — over a
+         * minute on device — so the app reported [AntigravityManifest.VERSION] for any present
+         * binary instead. That answer goes stale the moment the app ships a newer pin: the card
+         * claimed the new version while the guest still ran the old one, and an update had no
+         * before-and-after to report. The marker is what the installer actually wrote.
+         */
+        private const val VERSION_MARKER = "usr/local/share/and-code/antigravity-version"
+
+        internal fun writeInstalledVersion(
+            rootfs: File,
+            version: String,
+        ) {
+            runCatching {
+                File(rootfs, VERSION_MARKER).apply {
+                    parentFile?.mkdirs()
+                    writeText("$version\n")
+                }
+            }
+        }
+
+        /**
+         * The recorded version, or null when this sandbox predates the marker.
+         *
+         * Callers treat null as "unknown", not as "out of date": a sandbox provisioned by an older
+         * build is running whatever that build pinned, and guessing which release that was would be
+         * inventing history.
+         */
+        fun installedVersion(rootfs: File): String? =
+            runCatching { File(rootfs, VERSION_MARKER).readText().trim().takeIf(String::isNotEmpty) }.getOrNull()
+    }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
@@ -86,12 +86,17 @@ class AntigravityRuntime(
      *
      * `agy --version` is not a cheap probe: it boots the whole bundled language server before it
      * prints anything, and on device it took over a minute and overlapped the `models` call that the
-     * model picker actually needs. The version is not in question either - [AntigravityInstaller]
-     * writes exactly [AntigravityManifest.VERSION] and verifies its SHA-256 first - so reporting the
-     * pinned version for a present, executable binary says the same thing at no cost. Whether the CLI
-     * *works* is answered by [models], which the app needs to run anyway.
+     * model picker actually needs. [AntigravityInstaller] verifies the release's SHA-256 and records
+     * what it wrote, so the marker it leaves answers the same question at no cost.
+     *
+     * A sandbox provisioned before the marker existed falls back to [AntigravityManifest.VERSION] —
+     * the previous assumption, and the only one available for an install whose version was never
+     * written down. Whether the CLI *works* is answered by [models], which the app runs anyway.
      */
-    fun version(): String? = AntigravityManifest.VERSION.takeIf { isInstalled() }
+    fun version(): String? =
+        currentRootfs()
+            ?.takeIf { isInstalled() }
+            ?.let { rootfs -> AntigravityInstaller.installedVersion(rootfs) ?: AntigravityManifest.VERSION }
 
     /** Kept for call sites that invalidate health after an install or update; see [version]. */
     fun invalidateVersion() {

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeController.kt
@@ -25,10 +25,39 @@ sealed interface ClaudeInstallStatus {
     data class Failed(val message: String) : ClaudeInstallStatus
 }
 
+/**
+ * What an update attempt actually did.
+ *
+ * `apk` upgrades in place and says nothing about the version it landed on, so an update that had
+ * nothing to do and an update that installed a new build looked identical from the outside — the
+ * button simply stopped spinning. Comparing the version before and after is the only thing that
+ * tells them apart, and the card reports whichever it was.
+ */
+sealed interface ClaudeUpdateResult {
+    /** The version now installed, whether or not this attempt changed it. */
+    val version: String
+
+    data class Updated(val fromVersion: String, override val version: String) : ClaudeUpdateResult
+
+    data class AlreadyLatest(override val version: String) : ClaudeUpdateResult
+}
+
+/** Classifies an update by what it did to the installed version. */
+internal fun claudeUpdateResult(
+    before: String?,
+    after: String,
+): ClaudeUpdateResult =
+    if (before.isNullOrBlank() || before == after) {
+        ClaudeUpdateResult.AlreadyLatest(after)
+    } else {
+        ClaudeUpdateResult.Updated(before, after)
+    }
+
 data class ClaudeCodeUiState(
     val installed: Boolean = false,
     val version: String? = null,
     val install: ClaudeInstallStatus = ClaudeInstallStatus.Idle,
+    val lastUpdate: ClaudeUpdateResult? = null,
     val auth: ClaudeAuthCoordinator.State = ClaudeAuthCoordinator.State.Idle,
     val signedInAccount: String? = null,
     val permissionMode: ClaudePermissionMode = ClaudePermissionMode.DEFAULT,
@@ -117,9 +146,15 @@ class ClaudeCodeController(
         if (installJob?.isActive == true) return
         installJob =
             scope.launch(Dispatchers.IO) {
+                mutableState.value = mutableState.value.copy(lastUpdate = null)
                 report(ClaudeInstallStatus.Installing(R.string.claude_step_downloading_package))
                 target.update()
-                    .onSuccess { refreshBlocking() }
+                    .onSuccess { result ->
+                        refreshBlocking()
+                        // After the refresh, so the version the card shows and the outcome it
+                        // reports come from the same read of the sandbox.
+                        mutableState.value = mutableState.value.copy(lastUpdate = result)
+                    }
                     .onFailure { error -> report(ClaudeInstallStatus.Failed(error.message ?: messages.updateFailed)) }
             }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
@@ -148,11 +148,19 @@ class ClaudeCodeTarget(
         }
     }
 
-    fun update(): Result<String> =
+    /**
+     * Upgrades the installed package, reporting the version on both sides of the attempt.
+     *
+     * The version is read before the upgrade rather than taken from the UI so the comparison
+     * reflects what is on disk, not what a screen last happened to render.
+     */
+    fun update(): Result<ClaudeUpdateResult> =
         runCatching {
+            val before = runtime.version()
             runtime.update()
-            runtime.version() ?: error("Claude Code did not report a version after the update")
-        }.onSuccess { version -> mutableState.value = RuntimeState.Connected(version) }
+            val after = runtime.version() ?: error("Claude Code did not report a version after the update")
+            claudeUpdateResult(before, after)
+        }.onSuccess { result -> mutableState.value = RuntimeState.Connected(result.version) }
 
     override suspend fun connect(): Result<OpenCodeHealth> =
         runCatching {

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
@@ -259,6 +259,25 @@ class LocalRuntimeInstaller(
 
     fun bundledOpenCodeVersion(): String = manifestReader.read().openCodeVersion
 
+    /**
+     * Reinstalls the pinned Antigravity release into the sandbox that is already active.
+     *
+     * Antigravity ships as a binary this app pins, so an update means "install what this build
+     * pins" — and going through [install] for that would provision a whole new environment
+     * directory to replace one file. [AntigravityInstaller] verifies the release's SHA-256 and swaps
+     * `agy` in place instead, leaving the Debian rootfs and every agent's credentials untouched.
+     *
+     * Not serialised against [install]: that one builds a staging directory and swaps it in, so the
+     * worst a concurrent run can do is discard this binary, which the next update reinstates. The
+     * controller that owns both actions runs one at a time.
+     */
+    suspend fun updateAntigravity(onProgress: (Float) -> Unit = {}): String {
+        val runtime = installedRuntime() ?: error("The Linux environment is not installed")
+        AntigravityInstaller(runtimeDirectory, abi, downloader)
+            .installInto(runtime.antigravityRootfs ?: runtime.rootfs, onProgress)
+        return AntigravityManifest.VERSION
+    }
+
     private fun extractOpenCode(
         archive: File,
         staging: File,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -974,6 +974,7 @@ fun AndCodeApp(
                     antigravityActions =
                         com.yugahashimoto.andcode.ui.navigation.AntigravitySettingsActions(
                             onInstall = app.antigravityController::install,
+                            onUpdate = app.antigravityController::update,
                             onSelectPermissionMode = app.antigravityController::setPermissionMode,
                             onSignIn = app.antigravityController::beginAuth,
                             onSubmitCode = app.antigravityController::submitAuthCode,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -240,6 +240,7 @@ fun NavGraphBuilder.settingsNavGraph(
         AntigravityAgentSettingsScreen(
             antigravity = antigravity(),
             onInstall = antigravityActions.onInstall,
+            onUpdate = antigravityActions.onUpdate,
             onSelectPermissionMode = antigravityActions.onSelectPermissionMode,
             onSignIn = antigravityActions.onSignIn,
             onSubmitCode = antigravityActions.onSubmitCode,
@@ -346,6 +347,7 @@ data class ClaudeSettingsActions(
 /** Antigravity actions the settings graph forwards to its agent screen. */
 data class AntigravitySettingsActions(
     val onInstall: () -> Unit,
+    val onUpdate: () -> Unit,
     val onSelectPermissionMode: (com.yugahashimoto.andcode.runtime.local.AntigravityPermissionMode) -> Unit,
     val onSignIn: () -> Unit,
     val onSubmitCode: (String) -> Unit,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -817,6 +817,10 @@
     <string name="claude_install_button">تثبيت Claude Code</string>
     <string name="claude_retry_install_button">إعادة محاولة التثبيت</string>
     <string name="claude_update_button">تحديث Claude Code</string>
+    <string name="agent_update_result_updated">تم التحديث: %1$s ← %2$s</string>
+    <string name="agent_update_result_latest">محدَّث بالفعل (%1$s)</string>
+    <string name="antigravity_update_button">تحديث Antigravity</string>
+    <string name="antigravity_update_available">يتوفّر Antigravity %1$s</string>
     <string name="claude_step_preparing_runtime">جارٍ تحضير بيئة Linux</string>
     <string name="claude_step_adding_repository">جارٍ إضافة مستودع حزم Claude Code</string>
     <string name="claude_step_downloading_package">جارٍ تنزيل Claude Code (حوالي 80 ميغابايت)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -817,6 +817,10 @@
     <string name="claude_install_button">Instalar Claude Code</string>
     <string name="claude_retry_install_button">Reintentar la instalación</string>
     <string name="claude_update_button">Actualizar Claude Code</string>
+    <string name="agent_update_result_updated">Actualizado: %1$s → %2$s</string>
+    <string name="agent_update_result_latest">Ya está actualizado (%1$s)</string>
+    <string name="antigravity_update_button">Actualizar Antigravity</string>
+    <string name="antigravity_update_available">Antigravity %1$s está disponible</string>
     <string name="claude_step_preparing_runtime">Preparando el entorno Linux</string>
     <string name="claude_step_adding_repository">Añadiendo el repositorio de paquetes de Claude Code</string>
     <string name="claude_step_downloading_package">Descargando Claude Code (unos 80 MB)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -817,6 +817,10 @@
     <string name="claude_install_button">Installer Claude Code</string>
     <string name="claude_retry_install_button">Réessayer l’installation</string>
     <string name="claude_update_button">Mettre à jour Claude Code</string>
+    <string name="agent_update_result_updated">Mis à jour : %1$s → %2$s</string>
+    <string name="agent_update_result_latest">Déjà à jour (%1$s)</string>
+    <string name="antigravity_update_button">Mettre à jour Antigravity</string>
+    <string name="antigravity_update_available">Antigravity %1$s est disponible</string>
     <string name="claude_step_preparing_runtime">Préparation de l’environnement Linux</string>
     <string name="claude_step_adding_repository">Ajout du dépôt de paquets Claude Code</string>
     <string name="claude_step_downloading_package">Téléchargement de Claude Code (environ 80 Mo)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -829,6 +829,10 @@
     <string name="claude_install_button">Claude Codeをインストール</string>
     <string name="claude_retry_install_button">インストールを再試行</string>
     <string name="claude_update_button">Claude Codeを更新</string>
+    <string name="agent_update_result_updated">更新しました: %1$s → %2$s</string>
+    <string name="agent_update_result_latest">最新です (%1$s)</string>
+    <string name="antigravity_update_button">Antigravityを更新</string>
+    <string name="antigravity_update_available">Antigravity %1$sを利用できます</string>
     <string name="claude_step_preparing_runtime">Linux環境を準備しています</string>
     <string name="claude_step_adding_repository">Claude Codeのパッケージリポジトリを追加しています</string>
     <string name="claude_step_downloading_package">Claude Codeをダウンロードしています（約80MB）</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -817,6 +817,10 @@
     <string name="claude_install_button">Instalar o Claude Code</string>
     <string name="claude_retry_install_button">Tentar instalar novamente</string>
     <string name="claude_update_button">Atualizar o Claude Code</string>
+    <string name="agent_update_result_updated">Atualizado: %1$s → %2$s</string>
+    <string name="agent_update_result_latest">Já está atualizado (%1$s)</string>
+    <string name="antigravity_update_button">Atualizar o Antigravity</string>
+    <string name="antigravity_update_available">O Antigravity %1$s está disponível</string>
     <string name="claude_step_preparing_runtime">Preparando o ambiente Linux</string>
     <string name="claude_step_adding_repository">Adicionando o repositório de pacotes do Claude Code</string>
     <string name="claude_step_downloading_package">Baixando o Claude Code (cerca de 80 MB)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -817,6 +817,10 @@
     <string name="claude_install_button">Установить Claude Code</string>
     <string name="claude_retry_install_button">Повторить установку</string>
     <string name="claude_update_button">Обновить Claude Code</string>
+    <string name="agent_update_result_updated">Обновлено: %1$s → %2$s</string>
+    <string name="agent_update_result_latest">Уже актуальная версия (%1$s)</string>
+    <string name="antigravity_update_button">Обновить Antigravity</string>
+    <string name="antigravity_update_available">Доступна версия Antigravity %1$s</string>
     <string name="claude_step_preparing_runtime">Подготовка среды Linux</string>
     <string name="claude_step_adding_repository">Добавление репозитория пакетов Claude Code</string>
     <string name="claude_step_downloading_package">Загрузка Claude Code (около 80 МБ)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -817,6 +817,10 @@
     <string name="claude_install_button">安装 Claude Code</string>
     <string name="claude_retry_install_button">重试安装</string>
     <string name="claude_update_button">更新 Claude Code</string>
+    <string name="agent_update_result_updated">已更新：%1$s → %2$s</string>
+    <string name="agent_update_result_latest">已是最新版本（%1$s）</string>
+    <string name="antigravity_update_button">更新 Antigravity</string>
+    <string name="antigravity_update_available">可安装 Antigravity %1$s</string>
     <string name="claude_step_preparing_runtime">正在准备 Linux 环境</string>
     <string name="claude_step_adding_repository">正在添加 Claude Code 软件源</string>
     <string name="claude_step_downloading_package">正在下载 Claude Code（约 80 MB）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -829,6 +829,10 @@
     <string name="claude_install_button">Install Claude Code</string>
     <string name="claude_retry_install_button">Retry installation</string>
     <string name="claude_update_button">Update Claude Code</string>
+    <string name="agent_update_result_updated">Updated: %1$s → %2$s</string>
+    <string name="agent_update_result_latest">Already up to date (%1$s)</string>
+    <string name="antigravity_update_button">Update Antigravity</string>
+    <string name="antigravity_update_available">Antigravity %1$s is available</string>
     <string name="claude_step_preparing_runtime">Preparing the Linux environment</string>
     <string name="claude_step_adding_repository">Adding the Claude Code package repository</string>
     <string name="claude_step_downloading_package">Downloading Claude Code (about 80 MB)</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityUpdateTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityUpdateTest.kt
@@ -1,0 +1,73 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class AntigravityUpdateTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `the installer records the release it wrote`() {
+        val rootfs = temporaryFolder.newFolder("rootfs")
+
+        AntigravityInstaller.writeInstalledVersion(rootfs, "1.1.6")
+
+        assertEquals("1.1.6", AntigravityInstaller.installedVersion(rootfs))
+    }
+
+    @Test
+    fun `a sandbox without a marker reports no recorded version`() {
+        assertNull(AntigravityInstaller.installedVersion(temporaryFolder.newFolder("bare-rootfs")))
+    }
+
+    @Test
+    fun `an older recorded release offers the version this app carries`() {
+        val state =
+            AntigravityControllerState(
+                installed = true,
+                version = "1.1.6",
+                bundledVersion = "1.1.7",
+            )
+
+        assertTrue(state.updateAvailable)
+    }
+
+    @Test
+    fun `the pinned release offers no update`() {
+        val state =
+            AntigravityControllerState(
+                installed = true,
+                version = "1.1.7",
+                bundledVersion = "1.1.7",
+            )
+
+        assertFalse(state.updateAvailable)
+    }
+
+    @Test
+    fun `an agent that is not installed is never offered an update`() {
+        assertFalse(AntigravityControllerState(installed = false, version = "1.1.6").updateAvailable)
+    }
+
+    @Test
+    fun `an update reports both sides of the version change`() {
+        assertEquals(
+            AntigravityUpdateResult.Updated("1.1.6", "1.1.7"),
+            antigravityUpdateResult(before = "1.1.6", after = "1.1.7"),
+        )
+        assertEquals(
+            AntigravityUpdateResult.AlreadyLatest("1.1.7"),
+            antigravityUpdateResult(before = "1.1.7", after = "1.1.7"),
+        )
+        assertEquals(
+            AntigravityUpdateResult.AlreadyLatest("1.1.7"),
+            antigravityUpdateResult(before = null, after = "1.1.7"),
+        )
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeUpdateResultTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeUpdateResultTest.kt
@@ -1,0 +1,36 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClaudeUpdateResultTest {
+    @Test
+    fun `a changed version reports both sides of the upgrade`() {
+        assertEquals(
+            ClaudeUpdateResult.Updated("2.1.212", "2.1.220"),
+            claudeUpdateResult(before = "2.1.212", after = "2.1.220"),
+        )
+    }
+
+    @Test
+    fun `an unchanged version reports that nothing newer was published`() {
+        assertEquals(
+            ClaudeUpdateResult.AlreadyLatest("2.1.212"),
+            claudeUpdateResult(before = "2.1.212", after = "2.1.212"),
+        )
+    }
+
+    @Test
+    fun `an unknown starting version does not invent an upgrade`() {
+        // The pre-update read can fail on a sandbox that has just been repaired; reporting
+        // "updated from nothing" would be a claim the versions do not support.
+        assertEquals(
+            ClaudeUpdateResult.AlreadyLatest("2.1.212"),
+            claudeUpdateResult(before = null, after = "2.1.212"),
+        )
+        assertEquals(
+            ClaudeUpdateResult.AlreadyLatest("2.1.212"),
+            claudeUpdateResult(before = "  ", after = "2.1.212"),
+        )
+    }
+}

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -2,6 +2,25 @@
 
 The Android app provisions the official Google Antigravity CLI release in the shared Alpine/PRoot environment. Release 1.1.7 is pinned in `AntigravityManifest` and every archive is downloaded through `VerifiedRuntimeDownloader` and SHA-256 checked before activation.
 
+## Versions and updates
+
+`agy --version` boots the whole bundled language server before it prints anything — over a minute on
+device — so the app does not ask the binary which release it is. `AntigravityInstaller` writes
+`usr/local/share/and-code/antigravity-version` after the SHA-256-verified binary is swapped in, and
+`AntigravityRuntime.version` reads that marker. Before the marker existed the app simply reported
+`AntigravityManifest.VERSION` for any present binary, which went stale as soon as a new release was
+pinned: the card claimed a version the guest was not running. A sandbox provisioned by one of those
+builds has no marker and still falls back to the pinned version, since nothing recorded what it
+installed.
+
+Antigravity comes from a version pinned in the app rather than a package repository, so the update
+check needs no network: the card compares the marker against `AntigravityManifest.VERSION` and offers
+`AntigravityController.update` when they differ. That update goes through
+`LocalRuntimeInstaller.updateAntigravity`, which re-verifies the release and swaps the single binary
+in place — a full reinstall would rebuild the whole environment directory to replace one file. The
+outcome is reported as `Updated(from, to)` or `AlreadyLatest(version)` so an update that changed
+nothing is distinguishable from one that did.
+
 The Termux fork is reference material only. Its native-Termux wrapper and patched binaries are not bundled or used. The runtime uses Alpine `gcompat`, `util-linux`, and CA certificates; an ABI/loader failure is reported as unsupported instead of silently installing an unofficial binary.
 
 OAuth is a remote PTY flow. The browser URL and one-time code are passed to the PTY, while credentials remain in `/root/.gemini` inside the Linux rootfs and are never copied into Android preferences. `AGY_CLI_DISABLE_AUTO_UPDATE=1` is set so updates remain verified and app-controlled.

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -66,6 +66,18 @@ consequences for these scripts:
 The failure diagnostics list the flagged packages, since apk names a package when it breaks it but
 never when it later refuses to work because of the flag.
 
+### The card reports which version an update landed on
+
+`apk` upgrades in place and reports nothing about the version, so an update that had nothing to do
+and one that installed a new build were indistinguishable — the button stopped spinning either way.
+`ClaudeCodeTarget.update` therefore reads `claude --version` on both sides of the upgrade and returns
+a `ClaudeUpdateResult`: `Updated(from, to)` when the version moved, `AlreadyLatest(version)` when it
+did not. The card shows the installed version next to the update button and the outcome underneath.
+
+"Already up to date" is a claim the update script has verified, not an assumption: the script only
+succeeds once `apk version -q -l '<' claude-code` reports nothing pending, so a version that did not
+move means the repository has nothing newer.
+
 ## Execution
 
 Prompts run through Claude Code's streaming-JSON protocol rather than its terminal UI:


### PR DESCRIPTION
## Problem

Neither the Claude Code nor the Antigravity card showed which version was installed, and their update buttons reported nothing when they finished. An update that installed a new build and one that had nothing to do looked identical — the button stopped spinning either way — so a working update is indistinguishable from a failed one.

Antigravity had two further problems behind that:

- **The reported version was a guess.** `AntigravityRuntime.version` returned `AntigravityManifest.VERSION` for any present binary. The moment the app pins a newer release, the card claims a version the guest is not running.
- **There was no update path at all.** Antigravity's binary is only ever installed by a full runtime install, so a newly pinned release never reached an existing sandbox.

## Changes

**Both agents**

- The card states the installed version next to the update button.
- The update reports its outcome: `Updated: <from> → <to>` or `Already up to date (<version>)`, from reading the agent on both sides of the attempt rather than from what a screen last rendered.

**Claude Code**

- `ClaudeCodeTarget.update` returns a `ClaudeUpdateResult` instead of a bare version string; `ClaudeCodeController` keeps it in `ClaudeCodeUiState.lastUpdate`.
- "Already up to date" is a claim the update script has verified — it only succeeds once `apk version -q -l '<' claude-code` reports nothing pending — so a version that did not move means the repository has nothing newer.

**Antigravity**

- `AntigravityInstaller` records the release it wrote to `usr/local/share/and-code/antigravity-version`, and `AntigravityRuntime.version` reads that marker. Asking the binary is not an option: `agy --version` boots the whole bundled language server and takes over a minute on device. A sandbox provisioned before the marker existed still falls back to the pinned version, since nothing recorded what it installed.
- `LocalRuntimeInstaller.updateAntigravity` reinstalls the pinned release by re-verifying it and swapping that one binary in place, rather than rebuilding the whole environment directory to replace one file. Credentials and the Debian rootfs are untouched.
- `AntigravityController.update` drives it, and the card offers it only when the recorded version differs from `AntigravityManifest.VERSION`. Since the newest available release is the one the app carries, this check needs no network.

## Testing

- `./gradlew spotlessCheck detekt :app:testDebugUnitTest :app:lintDebug` — 591 tests, 0 failures.
- New tests cover the version-marker round trip, a sandbox with no marker, when an update is offered, and the classification of an update from the versions on either side.
- Translation keys added to all eight `values*/strings.xml` (verified against the i18n check's own comparison).

---
_Generated by [Claude Code](https://claude.ai/code/session_017c3T2a8nzWuPtpz6AufmaZ)_