### PR TITLE
fix(chat): badge the pull requests a chat opened, not the ones it read

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/PullRequestLinks.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/PullRequestLinks.kt
@@ -12,7 +12,7 @@ data class ChatPullRequest(
 )
 
 /**
- * The pull requests this conversation links to, newest first.
+ * The pull requests this conversation opened, newest first.
  *
  * Assistant text carries the link an agent reports after opening a pull request, tool output
  * carries the one `gh pr create` prints, and user text carries one that was pasted in - all three
@@ -22,16 +22,30 @@ data class ChatPullRequest(
 fun pullRequestRefsIn(messages: List<ChatMessage>): List<PullRequestRef> {
     val refs = LinkedHashSet<PullRequestRef>()
     messages.forEach { message ->
-        message.parts.forEach { part ->
-            when (part) {
-                is ChatPart.Text -> refs += parsePullRequestRefs(part.text)
-                is ChatPart.Tool -> {
-                    part.output?.let { refs += parsePullRequestRefs(it) }
-                    part.error?.let { refs += parsePullRequestRefs(it) }
-                }
-                else -> Unit
-            }
-        }
+        message.parts.forEach { part -> part.openedPullRequest()?.let(refs::add) }
     }
     return refs.toList().takeLast(MAX_TRACKED_PULL_REQUESTS).reversed()
+}
+
+/**
+ * The one pull request [this] part reports, or null when it reports none - or several.
+ *
+ * A part that links several at once is listing them, not opening one: release notes credit every
+ * pull request in the version, `gh pr list` prints the queue, a changelog names the whole history.
+ * Counting those filled the badge with pull requests the conversation never touched. A part that
+ * opens one names one - `gh pr create` prints a single link, and an agent announces its work as it
+ * lands - so a lone link is the signal, and anything longer is a list to be read, not a badge.
+ */
+private fun ChatPart.openedPullRequest(): PullRequestRef? {
+    val refs =
+        when (this) {
+            is ChatPart.Text -> parsePullRequestRefs(text)
+            // A retried command can report the same pull request twice, once as output and once as
+            // the error of the attempt before it, and that is still a single pull request.
+            is ChatPart.Tool ->
+                (parsePullRequestRefs(output.orEmpty()) + parsePullRequestRefs(error.orEmpty()))
+                    .distinct()
+            else -> return null
+        }
+    return refs.singleOrNull()
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/PullRequestLinksTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/PullRequestLinksTest.kt
@@ -78,6 +78,38 @@ class PullRequestLinksTest {
     }
 
     @Test
+    fun `ignores the pull requests a release notes listing links`() {
+        val messages =
+            listOf(
+                toolMessage(output = "https://github.com/o/r/pull/182"),
+                assistantMessage(
+                    "## What's Changed\n" +
+                        "* fix(ci) by @u in https://github.com/o/r/pull/178\n" +
+                        "* Refresh README by @u in https://github.com/o/r/pull/177\n" +
+                        "* feat(workspace) by @u in https://github.com/o/r/pull/180\n" +
+                        "* feat: agent versions by @u in https://github.com/o/r/pull/181\n" +
+                        "* chore: prepare release by @u in https://github.com/o/r/pull/182\n",
+                ),
+            )
+
+        assertEquals(listOf(PullRequestRef("o", "r", 182)), pullRequestRefsIn(messages))
+    }
+
+    @Test
+    fun `ignores a listing of open pull requests`() {
+        val messages =
+            listOf(
+                toolMessage(
+                    output =
+                        "https://github.com/o/r/pull/12\thttps://github.com/o/r/pull/11\t" +
+                            "https://github.com/o/r/pull/10",
+                ),
+            )
+
+        assertTrue(pullRequestRefsIn(messages).isEmpty())
+    }
+
+    @Test
     fun `keeps only the newest few pull requests, newest first`() {
         val messages = (1..8).map { assistantMessage("https://github.com/o/r/pull/$it") }
 


### PR DESCRIPTION
## 問題

実機のチャット「新バージョンリリース」で、PR チップが **#181 / #180 / #177 / #178 / #182** と5件表示されていた。このチャットが実際に開いた PR は **#182 だけ**。


## 原因

残り4件は **v1.1.21 のリリースノート本文**から拾われていた。`gh release view v1.1.21` で確認したノートがこれ:

```
* fix(ci): ... in https://github.com/yuga-hashimoto/and-code/pull/178
* Refresh README ... in https://github.com/yuga-hashimoto/and-code/pull/177
* feat(workspace): ... in https://github.com/yuga-hashimoto/and-code/pull/180
* feat: show agent versions ... in https://github.com/yuga-hashimoto/and-code/pull/181
* chore: prepare release v1.1.21 ... in https://github.com/yuga-hashimoto/and-code/pull/182
```

`pullRequestRefsIn` はトランスクリプト中の github.com の PR URL を無条件に全部集めていたため、**changelog を読むことと PR を開くことが区別できていなかった**。リリースノートに限らず `gh pr list` や生成された changelog を表示しただけでも、会話が触れてもいない PR がバッジになる。

チップの並び（#182 が最後）も、#182 を先に作成 → 後からノートで4件追加、という挿入順と一致していた。

## 修正

**1つのパートが複数の PR をリンクしている場合、それは一覧であって PR を開いた記録ではない**として無視する。PR を開くパートは1件しか名指ししない — `gh pr create` は1本しか出力せず、エージェントも作業が着地するたびに1件ずつ報告する。単独リンクだけを採用する。

## 検討して見送った案

PR の作成時刻とチャット開始時刻を比較する方が精密だが、`ChatMessage.timestamp` は永続化されず解析時の `System.currentTimeMillis()` なので、再読み込みしたトランスクリプトでは全メッセージが「今」になり、バッジが丸ごと消える。

## トレードオフ

1メッセージに PR リンクを2本まとめて貼った場合、どちらもバッジに出なくなる（作成時に個別に報告されていれば拾われる）。

## Test plan

- [x] リリースノート一覧の再現テストを追加（失敗を確認してから実装）
- [x] `gh pr list` 形式の一覧の再現テストを追加
- [x] `./gradlew testDebugUnitTest` 全件グリーン（既存13件の PR リンクテストを含む）
- [x] `./gradlew spotlessCheck detekt` グリーン
- [ ] 実機での目視確認 — アプリが debuggable でないため会話データを直接読めず、確認には debug ビルドの入れ替え（＝保存済みセッションの消去）が必要なので未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)
