### PR TITLE
fix: follow the latest Claude Code channel so updates actually update

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
@@ -26,7 +26,19 @@ object ClaudeCodeInstaller {
      */
     const val DNS_PRELOAD = "/usr/local/share/claude-setdns.js"
 
-    private const val REPOSITORY = "https://downloads.claude.ai/claude-code/apk/stable"
+    /**
+     * The `latest` channel, not `stable`.
+     *
+     * Anthropic publishes both: `stable` deliberately lags — "typically about one week old" per the
+     * install docs, and in practice it sat on 2.1.212 for over two weeks while `latest` moved eight
+     * releases ahead. Pinned to `stable`, the update button had nothing to fetch no matter how often
+     * it was pressed, and the card truthfully — but uselessly — reported the agent as up to date.
+     */
+    private const val REPOSITORY = "https://downloads.claude.ai/claude-code/apk/latest"
+
+    /** Matches any channel of [REPOSITORY], so a sandbox on an older one can be rewritten. */
+    private const val REPOSITORY_MARKER = "downloads.claude.ai/claude-code/apk/"
+    private const val REPOSITORIES = "/etc/apk/repositories"
     private const val SIGNING_KEY_URL = "https://downloads.claude.ai/keys/claude-code.rsa.pub"
     private const val SIGNING_KEY_PATH = "/etc/apk/keys/claude-code.rsa.pub"
     private const val APK = "/sbin/apk"
@@ -54,6 +66,28 @@ object ClaudeCodeInstaller {
      * would otherwise work, so the verification below decides the outcome instead.
      */
     private fun repairBrokenPackages(apk: String) = "$apk fix || echo 'and-code: apk fix could not clear every broken package' >&2"
+
+    /**
+     * Points [repositories] at [REPOSITORY], replacing whichever channel is configured there.
+     *
+     * Every sandbox provisioned before this switched to `latest` carries the `stable` line, and the
+     * update path never rewrote that file — appending only when the exact line was missing — so a
+     * channel change would otherwise have reached fresh installs alone. Deleting by [REPOSITORY_MARKER]
+     * and re-appending covers both directions and stays idempotent when nothing changed.
+     *
+     * `grep -v` rather than `sed -i` because BSD sed reads the argument after `-i` as a backup
+     * suffix, which would make this untestable on a macOS host. `|| true` because grep exits 1 when
+     * it selects nothing, which under `set -e` would abort on a repositories file holding only the
+     * Claude Code line.
+     */
+    internal fun configureRepositoryCommands(repositories: String = REPOSITORIES) =
+        """
+        if [ -f "$repositories" ]; then
+          grep -v '$REPOSITORY_MARKER' "$repositories" > "$repositories.tmp" || true
+          mv -f "$repositories.tmp" "$repositories"
+        fi
+        printf '%s\n' '$REPOSITORY' >> "$repositories"
+        """.trimIndent()
 
     /**
      * Package-manager half of the install, split out so tests can drive it with a stub `apk`.
@@ -112,10 +146,8 @@ object ClaudeCodeInstaller {
             """
             set -e
             /usr/bin/wget -qO $SIGNING_KEY_PATH $SIGNING_KEY_URL
-            if ! grep -qxF '$REPOSITORY' /etc/apk/repositories; then
-              printf '%s\n' '$REPOSITORY' >> /etc/apk/repositories
-            fi
             """,
+            configureRepositoryCommands(),
             installPackageCommands(),
         )
 
@@ -125,7 +157,7 @@ object ClaudeCodeInstaller {
             set -e
             # Refresh the signing key on every update so a rotated or expired key cannot strand an
             # upgrade behind an untrusted repository (every version then resolves as masked in:
-            # stable). If the download fails, keep the existing key so a transient outage does not
+            # latest). If the download fails, keep the existing key so a transient outage does not
             # block an otherwise-valid update; only abort when there is no key to fall back to.
             if /usr/bin/wget -qO $SIGNING_KEY_PATH.new $SIGNING_KEY_URL; then
               mv -f $SIGNING_KEY_PATH.new $SIGNING_KEY_PATH
@@ -134,6 +166,9 @@ object ClaudeCodeInstaller {
               exit 1
             fi
             """,
+            // Repeated on every update, not just at install: a sandbox provisioned before the switch
+            // to the `latest` channel is still on `stable`, and this is the only path that reaches it.
+            configureRepositoryCommands(),
             updatePackageCommands(),
         )
 

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
@@ -108,10 +108,10 @@ class ClaudeCodeInstallerTest {
         val repositories =
             temporaryFolder.newFile("repositories").apply {
                 writeText(
-                    """
-                    https://dl-cdn.alpinelinux.org/alpine/v3.24/main
-                    https://downloads.claude.ai/claude-code/apk/stable
-                    """.trimIndent() + "\n",
+                    listOf(
+                        "https://dl-cdn.alpinelinux.org/alpine/v3.24/main",
+                        "https://downloads.claude.ai/claude-code/apk/stable",
+                    ).joinToString("\n", postfix = "\n"),
                 )
             }
 

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
@@ -92,6 +92,72 @@ class ClaudeCodeInstallerTest {
     }
 
     @Test
+    fun `both scripts point the sandbox at the latest channel before apk reads the index`() {
+        listOf(ClaudeCodeInstaller.INSTALL_SCRIPT, ClaudeCodeInstaller.UPDATE_SCRIPT).forEach { script ->
+            assertTrue(script.contains("https://downloads.claude.ai/claude-code/apk/latest"))
+            // The repository has to be in place before the index is refreshed, or the first update
+            // after a channel change still resolves against the old channel.
+            assertTrue(script.indexOf("apk/latest") < script.indexOf("/sbin/apk update"))
+        }
+    }
+
+    @Test
+    fun `repository configuration moves an existing sandbox off the stable channel`() {
+        // A sandbox provisioned by an earlier build carries the stable line, and nothing else in the
+        // update rewrites it -- so without this the channel change would only reach fresh installs.
+        val repositories =
+            temporaryFolder.newFile("repositories").apply {
+                writeText(
+                    """
+                    https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+                    https://downloads.claude.ai/claude-code/apk/stable
+                    """.trimIndent() + "\n",
+                )
+            }
+
+        configureRepository(repositories)
+
+        assertEquals(
+            listOf(
+                "https://dl-cdn.alpinelinux.org/alpine/v3.24/main",
+                "https://downloads.claude.ai/claude-code/apk/latest",
+            ),
+            repositories.readLines(),
+        )
+    }
+
+    @Test
+    fun `repository configuration adds the channel to a sandbox that has none`() {
+        val repositories =
+            temporaryFolder.newFile("repositories").apply {
+                writeText("https://dl-cdn.alpinelinux.org/alpine/v3.24/main\n")
+            }
+
+        configureRepository(repositories)
+
+        assertEquals(
+            listOf(
+                "https://dl-cdn.alpinelinux.org/alpine/v3.24/main",
+                "https://downloads.claude.ai/claude-code/apk/latest",
+            ),
+            repositories.readLines(),
+        )
+    }
+
+    @Test
+    fun `repository configuration leaves a single channel line when it runs again`() {
+        val repositories =
+            temporaryFolder.newFile("repositories").apply {
+                writeText("https://dl-cdn.alpinelinux.org/alpine/v3.24/main\n")
+            }
+
+        configureRepository(repositories)
+        configureRepository(repositories)
+
+        assertEquals(1, repositories.readLines().count { it.contains("downloads.claude.ai") })
+    }
+
+    @Test
     fun `update reinstalls every broken package rather than naming one`() {
         val run = runPackageCommands(ClaudeCodeInstaller::updatePackageCommands)
 
@@ -167,6 +233,17 @@ class ClaudeCodeInstallerTest {
 
         assertNotEquals(0, run.exitCode)
         assertTrue(run.output.contains("requested packages are not installed"))
+    }
+
+    /** Runs the repository half of a script against a stand-in for `/etc/apk/repositories`. */
+    private fun configureRepository(repositories: File) {
+        val process =
+            ProcessBuilder("sh", "-c", "set -e\n" + ClaudeCodeInstaller.configureRepositoryCommands(repositories.absolutePath))
+                .redirectErrorStream(true)
+                .start()
+        val output = process.inputStream.bufferedReader().readText()
+        assertTrue("stub script timed out", process.waitFor(60, TimeUnit.SECONDS))
+        assertEquals(output, 0, process.exitValue())
     }
 
     private class ScriptRun(val exitCode: Int, val output: String, val apkInvocations: List<String>) {


### PR DESCRIPTION
## What was wrong

Pressing **Claude Codeを更新** never moved the version. On the device it sat on 2.1.212 and reported 最新です (2.1.212) forever.

The update pipeline is fine — the channel it reads is not. [`ClaudeCodeInstaller`](app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt) pinned the apk repository to Anthropic's `stable` channel:

| channel | head version |
|---|---|
| `stable` (what we used) | 2.1.212-r1 |
| `latest` | 2.1.220-r1 |

Verified by fetching both `APKINDEX.tar.gz` files directly; npm's dist-tags agree (`stable: 2.1.212`, `latest: 2.1.220`). 2.1.212 shipped 2026-07-16 — over two weeks and eight releases behind. `apk add --upgrade claude-code` genuinely had nothing to fetch, `ClaudeCodeTarget.update()` measured the same version on both sides, and the card honestly reported `AlreadyLatest`.

The docs describe `stable` as "typically about one week old, skipping releases with major regressions". For an agent this lag is a bug, not a feature.

## The fix

1. `REPOSITORY` now points at `.../apk/latest`.
2. Repository configuration became its own idempotent step, and it runs **on update as well as install**.

(2) is the part that matters. Switching the constant alone would only have reached fresh installs: existing sandboxes carry the `stable` line, `INSTALL_SCRIPT` appended only when the exact line was missing, and `UPDATE_SCRIPT` never touched `/etc/apk/repositories` at all. The new step deletes the Claude Code line whatever channel it names and re-appends `latest`, before `apk update` reads the index.

`grep -v` + `mv` rather than `sed -i`: BSD sed reads the argument after `-i` as a backup suffix, which would make the step untestable on a macOS host.

## Test plan

- [x] 4 new cases in `ClaudeCodeInstallerTest`: both scripts configure the channel before `apk update`; a `stable` sandbox is migrated; a sandbox with no Claude Code line gets one; running twice leaves one line. Written first, confirmed red, then implemented.
- [x] `./gradlew :app:testDebugUnitTest detekt` — 595 tests, 0 failures.
- [ ] **On-device**: install the CI debug APK, press 更新, confirm it moves 2.1.212 → 2.1.220 and the card reports `Updated`. Not done locally — the connected device runs a release build and no signing keystore is available here, so verifying would have meant uninstalling and wiping the Alpine sandbox and the Claude sign-in.