### PR TITLE
fix(antigravity): start chats in the permission mode settings chose

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -128,6 +128,7 @@ import com.yugahashimoto.andcode.feature.workspace.GitHubAutoAttachChips
 import com.yugahashimoto.andcode.feature.workspace.GitHubReference
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
+import com.yugahashimoto.andcode.runtime.local.AntigravityPermissionMode
 import com.yugahashimoto.andcode.runtime.local.ClaudePermissionMode
 import com.yugahashimoto.andcode.ui.components.StatusChip
 import com.yugahashimoto.andcode.ui.components.VolumeMeter
@@ -160,6 +161,9 @@ fun ChatHomeScreen(
     /** Non-null only for runtimes that decide tool permissions per session, i.e. Claude Code. */
     claudePermissionMode: ClaudePermissionMode? = null,
     onSelectClaudePermissionMode: (ClaudePermissionMode) -> Unit = {},
+    /** The same, for Antigravity: non-null only while that runtime is the selected one. */
+    antigravityPermissionMode: AntigravityPermissionMode? = null,
+    onSelectAntigravityPermissionMode: (AntigravityPermissionMode) -> Unit = {},
     /**
      * Called once the model and runtime sheet closes.
      *
@@ -547,6 +551,8 @@ fun ChatHomeScreen(
                     supportsPermissions = supportsPermissions,
                     claudePermissionMode = claudePermissionMode,
                     onSelectClaudePermissionMode = onSelectClaudePermissionMode,
+                    antigravityPermissionMode = antigravityPermissionMode,
+                    onSelectAntigravityPermissionMode = onSelectAntigravityPermissionMode,
                     onToggleAutoAccept = onToggleAutoAccept,
                     sendBehavior = sendBehavior,
                     enterToSend = enterToSend,
@@ -1003,6 +1009,8 @@ private fun ChatComposer(
     onToggleAutoAccept: (Boolean) -> Unit,
     claudePermissionMode: ClaudePermissionMode?,
     onSelectClaudePermissionMode: (ClaudePermissionMode) -> Unit,
+    antigravityPermissionMode: AntigravityPermissionMode?,
+    onSelectAntigravityPermissionMode: (AntigravityPermissionMode) -> Unit,
     sendBehavior: String,
     enterToSend: Boolean,
     contextTokensUsed: Long,
@@ -1316,8 +1324,18 @@ private fun ChatComposer(
                 // chip selects the permission mode. Auto-accept is an OpenCode concept and has no
                 // meaning here, so it is left out rather than shown as a dead toggle.
                 PermissionModeChip(
-                    selected = claudePermissionMode,
-                    onSelect = onSelectClaudePermissionMode,
+                    selectedLabel = claudePermissionMode.labelRes,
+                    options = ClaudePermissionMode.entries.map { PermissionModeOption(it.cliValue, it.labelRes) },
+                    onSelect = { id -> onSelectClaudePermissionMode(ClaudePermissionMode.fromCliValue(id)) },
+                )
+            } else if (antigravityPermissionMode != null) {
+                // Antigravity decides the same way. Its modes were once offered through the agent
+                // chip below, where the globally remembered agent id overrode the mode settings
+                // chose; the choice now comes from - and goes back to - that same setting.
+                PermissionModeChip(
+                    selectedLabel = antigravityPermissionMode.labelRes,
+                    options = AntigravityPermissionMode.entries.map { PermissionModeOption(it.cliValue, it.labelRes) },
+                    onSelect = { id -> onSelectAntigravityPermissionMode(AntigravityPermissionMode.fromCliValue(id)) },
                 )
             } else {
                 ModeChip(
@@ -1543,8 +1561,9 @@ private fun ModeChip(
 
 @Composable
 private fun PermissionModeChip(
-    selected: ClaudePermissionMode,
-    onSelect: (ClaudePermissionMode) -> Unit,
+    selectedLabel: Int,
+    options: List<PermissionModeOption>,
+    onSelect: (String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box {
@@ -1569,7 +1588,7 @@ private fun PermissionModeChip(
                     modifier = Modifier.size(14.dp),
                 )
                 Text(
-                    stringResource(selected.labelRes),
+                    stringResource(selectedLabel),
                     style = MaterialTheme.typography.labelMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -1582,19 +1601,22 @@ private fun PermissionModeChip(
             }
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            ClaudePermissionMode.entries.forEach { mode ->
+            options.forEach { option ->
                 DropdownMenuItem(
-                    text = { Text(stringResource(mode.labelRes)) },
+                    text = { Text(stringResource(option.labelRes)) },
                     onClick = {
-                        onSelect(mode)
+                        onSelect(option.id)
                         expanded = false
                     },
-                    modifier = Modifier.testTag("chat-permission-mode-${mode.cliValue}"),
+                    modifier = Modifier.testTag("chat-permission-mode-${option.id}"),
                 )
             }
         }
     }
 }
+
+/** One entry of the permission-mode chip, so the chip serves Claude Code and Antigravity alike. */
+private data class PermissionModeOption(val id: String, val labelRes: Int)
 
 @Composable
 private fun AutoAcceptChip(

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
@@ -243,5 +243,9 @@ class AntigravityController(
 
     fun cancelAuth() = target.auth.cancel()
 
-    fun setPermissionMode(mode: AntigravityPermissionMode) = target.setPermissionMode(mode)
+    /** Mirrors [ClaudeCodeController.setPermissionMode]: the open chat changes with the default. */
+    fun setPermissionMode(
+        mode: AntigravityPermissionMode,
+        sessionId: String? = null,
+    ) = target.setPermissionMode(mode, sessionId)
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityPermissionMode.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityPermissionMode.kt
@@ -11,26 +11,17 @@ import com.yugahashimoto.andcode.R
  */
 enum class AntigravityPermissionMode(
     val cliArgs: List<String>,
-    /**
-     * How the mode is named in the chat composer's mode chip.
-     *
-     * The chip is the same control that offers OpenCode's `build`/`plan`, so Antigravity's modes
-     * belong there rather than only in settings. These use the CLI's own vocabulary.
-     */
-    val agentId: String,
     val labelRes: Int,
     val descriptionRes: Int,
 ) {
-    PLAN(listOf("--mode", "plan"), "plan", R.string.claude_permission_plan, R.string.antigravity_permission_plan_desc),
+    PLAN(listOf("--mode", "plan"), R.string.claude_permission_plan, R.string.antigravity_permission_plan_desc),
     ACCEPT_EDITS(
         listOf("--mode", "accept-edits"),
-        "accept-edits",
         R.string.claude_permission_accept_edits,
         R.string.antigravity_permission_accept_edits_desc,
     ),
     FULL_ACCESS(
         listOf("--dangerously-skip-permissions"),
-        "full-access",
         R.string.claude_permission_full_access,
         R.string.antigravity_permission_full_access_desc,
     ),
@@ -43,8 +34,5 @@ enum class AntigravityPermissionMode(
         val DEFAULT = ACCEPT_EDITS
 
         fun fromCliValue(value: String?): AntigravityPermissionMode = entries.firstOrNull { it.cliValue == value } ?: DEFAULT
-
-        /** Resolves the mode the composer's chip selected, or null when [agentId] is not one of ours. */
-        fun fromAgentId(agentId: String?): AntigravityPermissionMode? = entries.firstOrNull { it.agentId == agentId }
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
@@ -371,8 +371,10 @@ class AntigravityRuntime(
         sessionId: String,
         workspace: String,
         title: String? = null,
+        permissionMode: AntigravityPermissionMode = AntigravityPermissionMode.DEFAULT,
     ) {
-        records[sessionId] = AntigravitySessionRecord(sessionId, null, workspace, title = title)
+        records[sessionId] =
+            AntigravitySessionRecord(sessionId, null, workspace, title = title, permissionMode = permissionMode.cliValue)
         persist()
     }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
@@ -87,7 +87,9 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
         directory: String?,
     ): OpenCodeSession {
         val id = UUID.randomUUID().toString()
-        runtime.create(id, directory ?: "/workspace", title)
+        // Same as ClaudeCodeTarget: the mode settings shows is what a new chat runs in. Leaving the
+        // record's own default here is what made a full-access setting start chats in accept-edits.
+        runtime.create(id, directory ?: "/workspace", title, mutableDefaultPermissionMode.value)
         return OpenCodeSession(
             id,
             directory = directory ?: "/workspace",
@@ -128,13 +130,15 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
         withContext(kotlinx.coroutines.Dispatchers.IO) { AntigravityModels.catalog(runtime.models()) }
 
     /**
-     * The permission modes, offered through the composer's mode chip.
+     * The CLI has one agent; its permission mode is not one.
      *
-     * That chip is where OpenCode's `build`/`plan` live, so a single agent named "antigravity" there
-     * told the user nothing and left no way to switch modes without opening settings.
+     * The modes were offered here so the composer's mode chip could switch them, but that chip
+     * reads the agent id the app remembers globally, across runtimes - a "plan" picked once under
+     * OpenCode named Antigravity's plan mode and silently outranked the mode settings chose. The
+     * composer now shows the same dedicated permission-mode chip Claude Code does, fed by
+     * [defaultPermissionMode], and a stale agent id no longer matches anything here.
      */
-    override suspend fun listAgents(): List<OpenCodeAgent> =
-        AntigravityPermissionMode.entries.map { OpenCodeAgent(it.agentId, "Antigravity", "primary", true) }
+    override suspend fun listAgents(): List<OpenCodeAgent> = listOf(OpenCodeAgent("antigravity", "Antigravity", "primary", true))
 
     override suspend fun sendMessage(
         sessionId: String,
@@ -149,12 +153,9 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
         val model = request.modelId ?: record.model
         val variant = request.variant ?: record.variant
         if (model != record.model || variant != record.variant) runtime.setSessionModel(sessionId, model, variant)
-        // The chip's choice wins for this message and is remembered; falling back to the session's
-        // stored mode, then to the default the settings screen shows.
-        val permissionMode =
-            AntigravityPermissionMode.fromAgentId(request.agent)
-                ?.also { runtime.setSessionMode(sessionId, it) }
-                ?: AntigravityPermissionMode.fromCliValue(record.permissionMode)
+        // The session's own mode: set when the chat was created from the default settings shows, and
+        // changed from either the composer's chip or the settings screen.
+        val permissionMode = AntigravityPermissionMode.fromCliValue(record.permissionMode)
         runtime.send(
             sessionId,
             record.workspace,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -784,7 +784,9 @@ fun AndCodeApp(
                         onSubmitAntigravitySignInCode = app.antigravityController::submitAuthCode,
                         onCancelAntigravitySignIn = app.antigravityController::cancelAuth,
                         onSignOutAntigravity = app.antigravityController::logout,
-                        onSelectAntigravityPermissionMode = app.antigravityController::setPermissionMode,
+                        onSelectAntigravityPermissionMode = { mode ->
+                            app.antigravityController.setPermissionMode(mode, chatState.sessionId)
+                        },
                         onOpenUrl = { url ->
                             runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))) }
                         },
@@ -853,6 +855,15 @@ fun AndCodeApp(
                         supportsPermissions = selectedRuntime?.capabilities?.permissions != false,
                         onSelectClaudePermissionMode = { mode ->
                             workspaceViewModel.setClaudePermissionMode(mode, chatState.sessionId)
+                        },
+                        // The mode settings shows, so the chip is not left naming whatever agent id
+                        // another runtime last remembered - see AntigravityTarget.listAgents.
+                        antigravityPermissionMode =
+                            antigravityState
+                                .takeIf { selectedRuntime?.agent == com.yugahashimoto.andcode.runtime.LocalAgent.ANTIGRAVITY }
+                                ?.permissionMode,
+                        onSelectAntigravityPermissionMode = { mode ->
+                            app.antigravityController.setPermissionMode(mode, chatState.sessionId)
                         },
                         onModelPickerClosed = { handoffReady = true },
                         onSelectRuntime = { id ->
@@ -975,7 +986,9 @@ fun AndCodeApp(
                         com.yugahashimoto.andcode.ui.navigation.AntigravitySettingsActions(
                             onInstall = app.antigravityController::install,
                             onUpdate = app.antigravityController::update,
-                            onSelectPermissionMode = app.antigravityController::setPermissionMode,
+                            onSelectPermissionMode = { mode ->
+                                app.antigravityController.setPermissionMode(mode, chatState.sessionId)
+                            },
                             onSignIn = app.antigravityController::beginAuth,
                             onSubmitCode = app.antigravityController::submitAuthCode,
                             onCancelSignIn = app.antigravityController::cancelAuth,

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityPermissionModeTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityPermissionModeTest.kt
@@ -1,0 +1,54 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The permission mode chosen in settings is the one a new Antigravity chat runs in.
+ *
+ * It was not: sessions were created with the enum's own default, and the composer offered the modes
+ * as agents, so the globally remembered agent id - "plan", picked once under OpenCode - selected
+ * Antigravity's plan mode over whatever settings said. [ClaudeCodeTarget] never had either problem,
+ * and these tests hold Antigravity to the same behaviour.
+ */
+class AntigravityPermissionModeTest {
+    @get:Rule val folder = TemporaryFolder()
+
+    private fun target(): AntigravityTarget = AntigravityTarget(AntigravityRuntime(folder.root, { null }))
+
+    private fun AntigravityTarget.storedMode(sessionId: String): String =
+        runtime.listSessions(null).single { it.appSessionId == sessionId }.permissionMode
+
+    @Test
+    fun `a new session starts in the mode settings chose`() =
+        runBlocking {
+            val target = target()
+            target.setPermissionMode(AntigravityPermissionMode.FULL_ACCESS)
+            val session = target.createSession(null, "/workspace")
+            assertEquals(AntigravityPermissionMode.FULL_ACCESS.cliValue, target.storedMode(session.id))
+        }
+
+    @Test
+    fun `the chosen mode outlives the process that chose it`() {
+        runBlocking { target().setPermissionMode(AntigravityPermissionMode.FULL_ACCESS) }
+        runBlocking {
+            val target = target()
+            assertEquals(AntigravityPermissionMode.FULL_ACCESS, target.defaultPermissionMode.value)
+            val session = target.createSession(null, "/workspace")
+            assertEquals(AntigravityPermissionMode.FULL_ACCESS.cliValue, target.storedMode(session.id))
+        }
+    }
+
+    /**
+     * The agent id is remembered globally, across runtimes. While the modes were offered as agents,
+     * a "plan" left over from OpenCode was a valid Antigravity agent and quietly won.
+     */
+    @Test
+    fun `the modes are not offered as agents another runtime could name`() =
+        runBlocking {
+            assertEquals(listOf("antigravity"), target().listAgents().map { it.name })
+        }
+}


### PR DESCRIPTION
## 問題

エージェント設定画面で権限モードを選んでも、チャット画面のデフォルトにならない。Antigravity を「フルアクセス」にしていてもチャットでは `plan` として動いてしまう。

## 原因

Antigravity 側だけ、Claude Code と作りが違っていた。

1. **新規セッションが設定値を読んでいない** — `AntigravityRuntime.create()` が enum のハードコードされた既定値 (`accept-edits`) をレコードに書いていた。`ClaudeCodeTarget` は以前から `defaultPermissionMode` を種にしてセッションを作っている。
2. **モードを「エージェント」として公開していた** — コンポーザーのモードチップから切り替えられるように `listAgents()` が plan / accept-edits / full-access を返していた。ところがこのチップが読む agent id はランタイム横断で 1 つだけ記憶される。OpenCode で一度 `plan` を選んでいると、それが Antigravity の `plan` として有効に解決され、チップの表示も送信時のモードも設定値を上書きしていた。

## 修正

- Antigravity は単一エージェント (`antigravity`) を返すようにし、他ランタイム由来の agent id が何にも一致しないようにした。
- コンポーザーには Claude Code と同じ専用の権限モードチップを表示し、設定値 (`defaultPermissionMode`) を表示元・書き戻し先にした。チップは両ランタイムで共有。
- 新規セッションは設定で選ばれているモードで作成する。
- 設定画面からの変更が、開いているセッションにも適用されるようにした（Claude Code は既にそうなっていた）。

## テスト

新規 `AntigravityPermissionModeTest`（修正前は 3 件とも失敗、修正後 green）:
- 新しいセッションが設定で選んだモードで始まる
- 選んだモードがプロセスをまたいで残り、再起動後の新規セッションにも効く
- モードがエージェントとして公開されていない

`./gradlew detekt spotlessCheck :app:testDebugUnitTest :app:lintDebug :app:assembleDebug` すべて成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)