### PR TITLE
feat: add Firebase Crashlytics logging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.devtools.ksp")
     id("androidx.baselineprofile")
+    id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 val repoRoot = rootProject.projectDir
@@ -184,6 +186,10 @@ tasks.named("preBuild").configure {
 dependencies {
     // Core Android
     implementation("androidx.core:core-ktx:1.15.0")
+
+    // Firebase
+    implementation(platform("com.google.firebase:firebase-bom:34.17.0"))
+    implementation("com.google.firebase:firebase-crashlytics")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("androidx.savedstate:savedstate-ktx:1.2.1")

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "1077322463853",
+    "project_id": "andcode-51031",
+    "storage_bucket": "andcode-51031.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1077322463853:android:0748cdbd40b1f032569d64",
+        "android_client_info": {
+          "package_name": "com.yugahashimoto.andcode"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDJqOJeefjubyYfDDia4Nd69hQpl5YJPr0"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -48,3 +48,7 @@
 -keep class com.yugahashimoto.andcode.data.connection.ConnectionProfile { *; }
 -keep class com.yugahashimoto.andcode.data.settings.Draft { *; }
 -keep class com.yugahashimoto.andcode.runtime.local.LocalRuntimeMetadata { *; }
+
+# Firebase Crashlytics
+-keep class com.google.firebase.crashlytics.** { *; }
+-dontwarn com.google.firebase.crashlytics.**

--- a/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
@@ -9,6 +9,7 @@ import android.os.Looper
 import androidx.startup.AppInitializer
 import com.yugahashimoto.andcode.core.api.GitHubApiClient
 import com.yugahashimoto.andcode.core.diagnostics.CrashLog
+import com.yugahashimoto.andcode.core.diagnostics.CrashReporter
 import com.yugahashimoto.andcode.core.locale.AppLanguage
 import com.yugahashimoto.andcode.core.notification.RuntimeNotificationHelper
 import com.yugahashimoto.andcode.core.storage.DeviceStorage
@@ -150,6 +151,8 @@ class AndCodeApplication : Application() {
         super.onCreate()
         // First, so a crash in the rest of this method is recorded too.
         CrashLog.install(this)
+        // CrashLog handles the local file; Crashlytics adds remote fatal and non-fatal reporting.
+        CrashReporter.install()
         startKoin {
             androidContext(this@AndCodeApplication)
             modules(appModule, viewModelModule)
@@ -331,7 +334,14 @@ class AndCodeApplication : Application() {
                     notifications.notifySessionComplete(sessionId, title)
                     githubStarCoordinator.onSessionCompleted()
                 },
-                onSessionError = notifications::notifySessionError,
+                onSessionError = { sessionId, message ->
+                    CrashReporter.recordException(
+                        error = IllegalStateException(message ?: "Runtime session failed"),
+                        message = "Runtime session error",
+                        customKeys = mapOf("session_id" to (sessionId ?: "unknown")),
+                    )
+                    notifications.notifySessionError(sessionId, message)
+                },
                 onQuestionAsked = notifications::notifyQuestion,
                 unreadStore = settings,
             )

--- a/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporter.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporter.kt
@@ -1,0 +1,70 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+import android.os.Build
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+/**
+ * Best-effort bridge for non-fatal diagnostics.
+ *
+ * Fatal crashes are collected by Crashlytics automatically. This wrapper keeps ordinary error
+ * reporting from making an already failing app fail again, and centralizes the small amount of
+ * sanitization needed before sending messages and keys off-device.
+ */
+object CrashReporter {
+    private const val MAX_LOG_CHARS = 1_000
+    private const val MAX_KEY_CHARS = 40
+    private const val MAX_VALUE_CHARS = 100
+
+    @Volatile
+    private var crashlytics: FirebaseCrashlytics? = null
+
+    /** Initializes Crashlytics and records only non-sensitive app metadata. */
+    fun install() {
+        val client =
+            runCatching { FirebaseCrashlytics.getInstance() }
+                .getOrNull()
+                ?: return
+        crashlytics = client
+        runCatching {
+            client.setCrashlyticsCollectionEnabled(!com.yugahashimoto.andcode.BuildConfig.DEBUG)
+            client.setCustomKey("app_version", com.yugahashimoto.andcode.BuildConfig.VERSION_NAME)
+            client.setCustomKey(
+                "build_type",
+                if (com.yugahashimoto.andcode.BuildConfig.DEBUG) "debug" else "release",
+            )
+            client.setCustomKey("os_version", Build.VERSION.RELEASE)
+        }
+    }
+
+    fun log(message: String) {
+        crashlytics?.let { client ->
+            runCatching { client.log(CrashReportSanitizer.message(message)) }
+        }
+    }
+
+    fun recordException(
+        error: Throwable,
+        message: String? = null,
+        customKeys: Map<String, String> = emptyMap(),
+    ) {
+        val client = crashlytics ?: return
+        runCatching {
+            message?.let { client.log(CrashReportSanitizer.message(it)) }
+            customKeys.forEach { (key, value) ->
+                client.setCustomKey(
+                    CrashReportSanitizer.key(key),
+                    CrashReportSanitizer.value(value),
+                )
+            }
+            client.recordException(error)
+        }
+    }
+
+    internal object CrashReportSanitizer {
+        fun message(value: String): String = value.replace(Regex("\\s+"), " ").trim().take(MAX_LOG_CHARS)
+
+        fun key(value: String): String = value.replace(Regex("[^A-Za-z0-9_]"), "_").take(MAX_KEY_CHARS).ifBlank { "key" }
+
+        fun value(value: String): String = message(value).take(MAX_VALUE_CHARS)
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporterTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporterTest.kt
@@ -1,0 +1,22 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CrashReporterTest {
+    @Test
+    fun `sanitizer collapses whitespace and caps log size`() {
+        val input = "  first\n\tsecond  " + "x".repeat(1_100)
+
+        val sanitized = CrashReporter.CrashReportSanitizer.message(input)
+
+        assertEquals(("first second " + "x".repeat(1_100)).take(1_000), sanitized)
+    }
+
+    @Test
+    fun `sanitizer makes custom keys safe and caps values`() {
+        assertEquals("runtime_error_code", CrashReporter.CrashReportSanitizer.key("runtime.error-code"))
+        assertEquals("value", CrashReporter.CrashReportSanitizer.value(" value "))
+        assertEquals(100, CrashReporter.CrashReportSanitizer.value("x".repeat(200)).length)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.28" apply false
     id("androidx.baselineprofile") version "1.3.3" apply false
+    id("com.google.gms.google-services") version "4.5.0" apply false
+    id("com.google.firebase.crashlytics") version "3.0.7" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.6"
     id("com.diffplug.spotless") version "6.25.0"
     id("jacoco")


### PR DESCRIPTION
## Summary
- add Firebase Android app configuration and Crashlytics Gradle integration
- preserve local last-crash file and report runtime session errors as non-fatal Crashlytics events
- disable Crashlytics collection for debug builds and enable it for release builds

## Verification
- `./gradlew :app:testDebugUnitTest`
- `./gradlew spotlessKotlinCheck detekt`
- `./gradlew :app:assembleRelease`
- installed and launched the debug APK on a connected Android device

Firebase Console: project `andcode-51031`, Android app `com.yugahashimoto.andcode`.