### PR TITLE
fix(chat): make voice input continuous and understandable

### DIFF
--- a/app/src/androidTest/java/com/yugahashimoto/andcode/feature/chat/ChatVoiceInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/yugahashimoto/andcode/feature/chat/ChatVoiceInstrumentedTest.kt
@@ -59,6 +59,7 @@ class ChatVoiceInstrumentedTest {
         composeRule.onNodeWithText(context.getString(R.string.voice_state_listening)).assertIsDisplayed()
         composeRule.onNodeWithTag("chat-message-input").assertTextContains("こんにちは")
         composeRule.onNodeWithTag("chat-voice-waveform").assertDoesNotExist()
+        composeRule.onNodeWithText(context.getString(R.string.voice_listening_placeholder)).assertDoesNotExist()
 
         screenState.value = ChatUiState(isSpeechProcessing = true)
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/SpeechRecognizerManager.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/SpeechRecognizerManager.kt
@@ -18,7 +18,11 @@ import kotlin.coroutines.EmptyCoroutineContext
 private const val TAG = "SpeechRecognizerManager"
 private const val CLEANUP_DELAY_MS = 300L
 private const val MAX_RESULTS = 3
-private const val SILENCE_LENGTH_MS = 1500L
+
+// A short pause is common inside a Japanese sentence. Giving the recognizer more time here
+// avoids finalizing a segment before the user has finished the thought; chat then starts the next
+// segment after a genuine recognition result so long dictation remains in one composer value.
+private const val SILENCE_LENGTH_MS = 3000L
 
 /**
  * 音声認識マネージャー

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/SpeechTranscriptAccumulator.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/SpeechTranscriptAccumulator.kt
@@ -1,0 +1,43 @@
+package com.yugahashimoto.andcode.feature.assistant
+
+/** Keeps recognition segments together while Android rotates its speech session. */
+internal class SpeechTranscriptAccumulator {
+    private var value = ""
+
+    val text: String
+        get() = value
+
+    fun append(segment: String) {
+        value = combine(value, segment)
+    }
+
+    fun preview(segment: String): String = combine(value, segment)
+
+    private fun combine(
+        prefix: String,
+        segment: String,
+    ): String {
+        val next = segment.trim()
+        if (next.isEmpty()) return prefix
+        if (prefix.isEmpty()) return next
+
+        val separator =
+            if (prefix.last().isWhitespace() || next.first().isWhitespace() ||
+                prefix.last().isCjk() || next.first().isCjk() ||
+                prefix.last() in NO_SPACE_BEFORE_PUNCTUATION || next.first() in OPENING_PUNCTUATION
+            ) {
+                ""
+            } else {
+                " "
+            }
+        return prefix + separator + next
+    }
+
+    private fun Char.isCjk(): Boolean = this in '\u3040'..'\u30ff' || this in '\u3400'..'\u4dbf' || this in '\u4e00'..'\u9fff'
+
+    private companion object {
+        val NO_SPACE_BEFORE_PUNCTUATION =
+            setOf('、', '。', '，', '．', ',', '.', '!', '?', '！', '？', ':', ';', '：', '；')
+        val OPENING_PUNCTUATION = setOf('(', '[', '{', '（', '「', '『', '【')
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -598,16 +598,6 @@ fun ChatHomeScreen(
             }
         }
 
-        LiveTranscriptOverlay(
-            isRecording = state.isListening,
-            transcript = "",
-            amplitude = 0.5f,
-            onAccept = {},
-            onCancel = {},
-            onAcceptAndSend = {},
-            modifier = Modifier.align(Alignment.BottomCenter),
-        )
-
         AnimatedVisibility(
             visible = showSidePanel,
             enter = slideInHorizontally(initialOffsetX = { it }),
@@ -1027,6 +1017,7 @@ private fun ChatComposer(
     onCameraLaunch: () -> Unit,
     onGalleryLaunch: () -> Unit,
 ) {
+    val voiceActive = isListening || isSpeechProcessing
     var showAttachMenu by remember { mutableStateOf(false) }
 
     Column(
@@ -1248,13 +1239,13 @@ private fun ChatComposer(
                         VolumeMeter(amplitude = 0.5f, idle = true)
                     }
                     val micContainerColor =
-                        if (isListening) {
+                        if (voiceActive) {
                             MaterialTheme.colorScheme.primaryContainer
                         } else {
                             MaterialTheme.colorScheme.surfaceVariant
                         }
                     val micContentColor =
-                        if (isListening) {
+                        if (voiceActive) {
                             MaterialTheme.colorScheme.primary
                         } else {
                             MaterialTheme.colorScheme.onSurfaceVariant
@@ -1270,8 +1261,9 @@ private fun ChatComposer(
                     ) {
                         IconButton(onClick = onMic, modifier = Modifier.fillMaxSize()) {
                             Icon(
-                                Icons.Default.Mic,
-                                contentDescription = stringResource(R.string.voice),
+                                if (voiceActive) Icons.Default.Stop else Icons.Default.Mic,
+                                contentDescription =
+                                    stringResource(if (voiceActive) R.string.stop_run else R.string.voice),
                                 modifier = Modifier.size(21.dp),
                                 tint = micContentColor,
                             )

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -69,6 +69,7 @@ import com.yugahashimoto.andcode.core.diagnostics.CrashLog
 import com.yugahashimoto.andcode.feature.activity.ActivityViewModel
 import com.yugahashimoto.andcode.feature.assistant.SpeechRecognizerManager
 import com.yugahashimoto.andcode.feature.assistant.SpeechResult
+import com.yugahashimoto.andcode.feature.assistant.SpeechTranscriptAccumulator
 import com.yugahashimoto.andcode.feature.chat.ChatHomeScreen
 import com.yugahashimoto.andcode.feature.chat.ChatViewModel
 import com.yugahashimoto.andcode.feature.chat.SubagentInfo
@@ -117,6 +118,7 @@ import kotlinx.coroutines.withContext
 
 /** How often the open chat asks GitHub whether its pull requests have moved on. */
 private const val PULL_REQUEST_REFRESH_INTERVAL_MS = 30_000L
+private const val VOICE_RESTART_DELAY_MS = 200L
 
 private fun speechLocaleTag(context: android.content.Context): String {
     val locale =
@@ -310,19 +312,34 @@ fun AndCodeApp(
         chatViewModel.startListening()
         voiceJob =
             voiceScope.launch {
+                val transcript = SpeechTranscriptAccumulator()
                 try {
-                    speechManager.startListening(speechLocaleTag(context)).collect { result ->
-                        when (result) {
-                            SpeechResult.Ready,
-                            SpeechResult.Listening,
-                            -> Unit
-                            SpeechResult.Processing -> chatViewModel.showSpeechProcessing()
-                            is SpeechResult.PartialResult -> chatViewModel.updateSpeechPartial(result.text)
-                            is SpeechResult.Result -> {
-                                chatViewModel.updateSpeechPartial(result.text)
-                                chatViewModel.stopListening()
+                    while (true) {
+                        var restart = true
+                        speechManager.startListening(speechLocaleTag(context)).collect { result ->
+                            when (result) {
+                                SpeechResult.Ready,
+                                SpeechResult.Listening,
+                                -> Unit
+                                SpeechResult.Processing -> chatViewModel.showSpeechProcessing()
+                                is SpeechResult.PartialResult -> {
+                                    chatViewModel.updateSpeechPartial(transcript.preview(result.text))
+                                }
+                                is SpeechResult.Result -> {
+                                    transcript.append(result.text)
+                                    chatViewModel.updateSpeechPartial(transcript.text)
+                                }
+                                is SpeechResult.Error -> {
+                                    restart = false
+                                    chatViewModel.reportSpeechError(result.message)
+                                }
                             }
-                            is SpeechResult.Error -> chatViewModel.reportSpeechError(result.message)
+                        }
+                        if (!restart) break
+                        delay(VOICE_RESTART_DELAY_MS)
+                        chatViewModel.startListening()
+                        if (transcript.text.isNotBlank()) {
+                            chatViewModel.updateSpeechPartial(transcript.text)
                         }
                     }
                 } finally {

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/assistant/SpeechTranscriptAccumulatorTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/assistant/SpeechTranscriptAccumulatorTest.kt
@@ -1,0 +1,26 @@
+package com.yugahashimoto.andcode.feature.assistant
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpeechTranscriptAccumulatorTest {
+    @Test
+    fun `concatenates Japanese recognition segments without adding spaces`() {
+        val accumulator = SpeechTranscriptAccumulator()
+
+        accumulator.append("前半")
+        accumulator.append("後半")
+
+        assertEquals("前半後半", accumulator.text)
+    }
+
+    @Test
+    fun `keeps a word boundary between Latin recognition segments`() {
+        val accumulator = SpeechTranscriptAccumulator()
+
+        accumulator.append("hello")
+        accumulator.append("world")
+
+        assertEquals("hello world", accumulator.text)
+    }
+}


### PR DESCRIPTION
## Summary
- remove the dead transcript overlay that showed an empty panel and no-op buttons
- keep long voice dictation in the composer across recognizer result cycles
- make the active microphone control visibly stoppable and add transcript regression coverage

## Verification
- `./gradlew test :app:lintDebug spotlessCheck detekt`
- 602 unit tests passed locally
- AndroidTest compilation and Debug APK build passed
- local connected test could not install on the attached device: `INSTALL_FAILED_USER_RESTRICTED`

The PR is intentionally draft until CI completes; it will be marked ready and merged after the checks pass.