### PR TITLE
chore: add sponsorship links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: yuga-hashimoto
+ko_fi: R5R51S97C4
+custom:
+  - https://paypal.me/yuga620


### PR DESCRIPTION
## Summary
- Add GitHub Sponsors, Ko-fi, and PayPal links via `.github/FUNDING.yml`.

## Verification
- `git diff --check`
- Configuration values checked against the reference repository.