### PR TITLE
feat: add Firebase Analytics usage reporting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,7 +188,11 @@ dependencies {
     implementation("androidx.core:core-ktx:1.15.0")
 
     // Firebase
-    implementation(platform("com.google.firebase:firebase-bom:34.17.0"))
+    // 34.17.0 pulls Play Services Measurement compiled with Kotlin 2.2 metadata, while this
+    // project is currently on Kotlin 2.0/KSP 2.0. Keep the Firebase stack on the compatible
+    // 33.6 line until the Android build toolchain is upgraded together.
+    implementation(platform("com.google.firebase:firebase-bom:33.6.0"))
+    implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-crashlytics")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")

--- a/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.startup.AppInitializer
 import com.yugahashimoto.andcode.core.api.GitHubApiClient
+import com.yugahashimoto.andcode.core.diagnostics.AnalyticsReporter
 import com.yugahashimoto.andcode.core.diagnostics.CrashLog
 import com.yugahashimoto.andcode.core.diagnostics.CrashReporter
 import com.yugahashimoto.andcode.core.locale.AppLanguage
@@ -155,6 +156,8 @@ class AndCodeApplication : Application() {
         CrashLog.install(this)
         // CrashLog handles the local file; Crashlytics adds remote fatal and non-fatal reporting.
         CrashReporter.install()
+        // Analytics supplies anonymous app-open/session metrics and selected product events.
+        AnalyticsReporter.install(this)
         startKoin {
             androidContext(this@AndCodeApplication)
             modules(appModule, viewModelModule)
@@ -337,10 +340,12 @@ class AndCodeApplication : Application() {
                 },
                 onPermissionResolved = notifications::cancelPermission,
                 onSessionIdle = { sessionId, title ->
+                    AnalyticsReporter.recordRuntimeSessionCompleted()
                     notifications.notifySessionComplete(sessionId, title)
                     githubStarCoordinator.onSessionCompleted()
                 },
                 onSessionError = { sessionId, message ->
+                    AnalyticsReporter.recordRuntimeSessionError()
                     CrashReporter.recordException(
                         error = IllegalStateException(message ?: "Runtime session failed"),
                         message = "Runtime session error",

--- a/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporter.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporter.kt
@@ -1,0 +1,53 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+import android.content.Context
+import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
+
+internal data class AnalyticsEvent(
+    val name: String,
+    val parameters: Map<String, String> = emptyMap(),
+)
+
+internal object AnalyticsEvents {
+    fun runtimeSessionCompleted(): AnalyticsEvent = AnalyticsEvent("runtime_session_completed")
+
+    fun runtimeSessionError(): AnalyticsEvent = AnalyticsEvent("runtime_session_error")
+}
+
+/** Reports anonymous product-usage events while Firebase Analytics supplies automatic metrics. */
+object AnalyticsReporter {
+    @Volatile
+    private var analytics: FirebaseAnalytics? = null
+
+    /** Enables Analytics for release builds and keeps local debug runs out of production data. */
+    fun install(context: Context) {
+        val client =
+            runCatching { FirebaseAnalytics.getInstance(context.applicationContext) }
+                .getOrNull()
+                ?: return
+        analytics = client
+        runCatching {
+            client.setAnalyticsCollectionEnabled(!com.yugahashimoto.andcode.BuildConfig.DEBUG)
+        }
+    }
+
+    fun recordRuntimeSessionCompleted() {
+        record(AnalyticsEvents.runtimeSessionCompleted())
+    }
+
+    fun recordRuntimeSessionError() {
+        record(AnalyticsEvents.runtimeSessionError())
+    }
+
+    private fun record(event: AnalyticsEvent) {
+        val client = analytics ?: return
+        runCatching {
+            val parameters =
+                Bundle().apply {
+                    event.parameters.forEach { (key, value) -> putString(key, value) }
+                }
+            client.logEvent(event.name, parameters)
+        }
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporterTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporterTest.kt
@@ -1,0 +1,23 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnalyticsReporterTest {
+    @Test
+    fun `runtime session completed event has a stable name and no user data`() {
+        val event = AnalyticsEvents.runtimeSessionCompleted()
+
+        assertEquals("runtime_session_completed", event.name)
+        assertTrue(event.parameters.isEmpty())
+    }
+
+    @Test
+    fun `runtime session error event has a stable name and no user data`() {
+        val event = AnalyticsEvents.runtimeSessionError()
+
+        assertEquals("runtime_session_error", event.name)
+        assertTrue(event.parameters.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- enable Firebase Analytics for the existing AndCode Firebase project
- collect release-only automatic usage metrics and anonymous runtime session events
- keep debug Analytics collection disabled and send no user content or identifiers
- keep Firebase BoM on 33.6.0 until the Kotlin/KSP toolchain can consume newer measurement metadata

## Verification
- ./gradlew :app:testDebugUnitTest --no-daemon
- ./gradlew spotlessKotlinCheck detekt --no-daemon
- ./gradlew :app:assembleRelease --no-daemon

No APK was installed during this change.