### PR TITLE
fix: Antigravityのサインインが初回タップで反応しない問題を修正

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityAuthCoordinator.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityAuthCoordinator.kt
@@ -41,18 +41,47 @@ class AntigravityAuthCoordinator(
     private val mutableState = MutableStateFlow<State>(State.Idle)
     val state: StateFlow<State> = mutableState.asStateFlow()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var process: Process? = null
-    private var transcript = StringBuilder()
 
     /**
-     * Frozen once the code field is live. Everything the TUI paints from that point on can contain
-     * the authorization code the user typed, so it must never reach the UI or a log.
+     * The attempt whose output and death still speak for this coordinator; null when none does.
+     *
+     * Volatile so [markStarting] can read it from the UI thread. Writes and compare-and-clear go
+     * through this class's monitor, which [start] holds for as long as its pre-flight takes - a
+     * minute and a half in the worst case - so nothing on the UI thread may wait for it.
      */
-    @Volatile private var diagnostics: String = ""
+    @Volatile private var current: Attempt? = null
 
-    @Volatile private var codeFieldLive = false
+    /**
+     * One sign-in attempt: the guest process and everything read out of it.
+     *
+     * Attempts overlap by construction. Killing the guest process tree is asynchronous, so an
+     * attempt the user cancelled - or one a second press replaced - keeps draining its buffer, and
+     * still reports its own exit, while the next attempt is already running. Per-attempt state is
+     * what keeps the two apart: the coordinator acts only on the attempt it still holds, so a dead
+     * one can neither publish a stale URL nor stamp its own kill onto its successor.
+     */
+    internal class Attempt(val process: Process) {
+        private val transcript = StringBuilder()
 
-    @Volatile private var menuAnswered = false
+        /**
+         * Frozen once the code field is live. Everything the TUI paints from that point on can
+         * contain the authorization code the user typed, so it must never reach the UI or a log.
+         */
+        @Volatile var diagnostics: String = ""
+
+        @Volatile var codeFieldLive = false
+
+        @Volatile var menuAnswered = false
+
+        fun append(chunk: String) {
+            synchronized(this) {
+                transcript.append(chunk)
+                if (transcript.length > MAX_TRANSCRIPT) transcript.delete(0, transcript.length - MAX_TRANSCRIPT)
+            }
+        }
+
+        fun clean(): String = AntigravityAuthParser.stripAnsi(synchronized(this) { transcript.toString() })
+    }
 
     /**
      * Starts the no-argument agy TUI and returns once it is past its own vulnerable startup window.
@@ -66,13 +95,18 @@ class AntigravityAuthCoordinator(
      */
     @Synchronized
     fun start(): AntigravityAuthStart {
-        // Before anything blocking. Everything below - killing a previous process, repairing the
-        // guest settings, and above all the already-signed-in check, which is a whole `agy models`
-        // run behind a gate that waits up to a minute - happens before the TUI exists, and the state
-        // used to be published only after all of it. Pressing "Sign in" therefore did nothing
-        // visible for tens of seconds.
+        // A press while an attempt is already running is a second press, not a request to start
+        // over: restarting would kill the process that is about to print the URL, and that kill
+        // would then be reported as a failure of the attempt the press had just started.
+        current?.takeIf { it.process.isAlive }?.let { return AntigravityAuthStart(it.process) }
+        // Before anything blocking. Everything below - repairing the guest settings, and above all
+        // the already-signed-in check, which is a whole `agy models` run behind a gate that waits up
+        // to a minute - happens before the TUI exists, and the state used to be published only after
+        // all of it. Worse, the cleanup this used to do here went through `cancel`, which publishes
+        // Idle: pressing "Sign in" put the plain sign-in button straight back on screen and left it
+        // there for as long as the check took, so the press looked like it had done nothing at all.
         mutableState.value = State.Starting
-        cancel()
+        abandonCurrent()
         val runtime = installedRuntimeProvider() ?: error("Linux environment is not installed")
         AntigravityGuestSettings.repair(runtime)
         if (verifyModels()) {
@@ -82,19 +116,50 @@ class AntigravityAuthCoordinator(
         val started =
             AntigravityProcessGate.acquireThenRelease(STARTUP_GRACE_MS) { launchTui(runtime) }
                 ?: error("Antigravity is busy with another operation; try again in a moment")
-        process = started
-        transcript = StringBuilder()
-        diagnostics = ""
-        codeFieldLive = false
-        menuAnswered = false
+        val attempt = adopt(Attempt(started))
         mutableState.value = State.Starting
-        scope.launch { driveLoginChooser(started) }
+        scope.launch { driveLoginChooser(attempt) }
         scope.launch {
-            runCatching { started.inputStream.bufferedReader().forEachChunk(::onOutput) }
-            onProcessExit(runCatching { started.waitFor() }.getOrDefault(-1))
+            runCatching { started.inputStream.bufferedReader().forEachChunk { chunk -> onOutput(attempt, chunk) } }
+            onProcessExit(attempt, runCatching { started.waitFor() }.getOrDefault(-1))
         }
-        scope.launch { watchForDiscoveryTimeout(started) }
+        scope.launch { watchForDiscoveryTimeout(attempt) }
         return AntigravityAuthStart(started)
+    }
+
+    /**
+     * Takes ownership of [attempt], so that from here on it is the one allowed to publish state.
+     *
+     * Internal rather than private because the abandonment rules are the whole point of [Attempt]
+     * and testing them needs an attempt, not a guest process.
+     */
+    @Synchronized
+    internal fun adopt(attempt: Attempt): Attempt {
+        current = attempt
+        return attempt
+    }
+
+    /**
+     * Drops the current attempt and kills its process, publishing nothing.
+     *
+     * The kill is asynchronous, so the abandoned attempt keeps running for a moment and then reports
+     * its own exit. Dropping it *before* that happens is what stops the report: [onProcessExit] only
+     * speaks for the attempt this coordinator still holds.
+     */
+    @Synchronized
+    private fun abandonCurrent() {
+        current?.let { terminateAsync(it.process) }
+        current = null
+    }
+
+    @Synchronized
+    private fun isCurrent(attempt: Attempt): Boolean = current === attempt
+
+    @Synchronized
+    private fun releaseIfCurrent(attempt: Attempt): Boolean {
+        if (current !== attempt) return false
+        current = null
+        return true
     }
 
     /**
@@ -102,11 +167,12 @@ class AntigravityAuthCoordinator(
      * once the bundled language server is up, which is why this waits for the chooser to be painted
      * instead of pressing Enter on a fixed delay.
      */
-    private suspend fun driveLoginChooser(started: Process) {
+    private suspend fun driveLoginChooser(attempt: Attempt) {
+        val started = attempt.process
         val deadline = System.currentTimeMillis() + MENU_TIMEOUT_MS
         while (started.isAlive && System.currentTimeMillis() < deadline) {
-            if (AntigravityAuthParser.isLoginMenuVisible(cleanTranscript())) {
-                menuAnswered = true
+            if (AntigravityAuthParser.isLoginMenuVisible(attempt.clean())) {
+                attempt.menuAnswered = true
                 // Bubble Tea reads Enter as CR because it puts the PTY in raw mode.
                 runCatching {
                     started.outputStream.write('\r'.code)
@@ -118,83 +184,68 @@ class AntigravityAuthCoordinator(
         }
     }
 
-    private suspend fun watchForDiscoveryTimeout(started: Process) {
+    private suspend fun watchForDiscoveryTimeout(attempt: Attempt) {
         delay(AUTH_DISCOVERY_TIMEOUT_MS)
-        if (!started.isAlive || mutableState.value !is State.Starting) return
-        val clean = cleanTranscript()
+        if (!attempt.process.isAlive || !isCurrent(attempt) || mutableState.value !is State.Starting) return
+        val clean = attempt.clean()
         mutableState.value =
             State.Failed(
                 when {
                     AntigravityAuthParser.isLocalBrowserMode(clean) ->
                         "Antigravity selected local browser mode and did not print a sign-in URL"
-                    !menuAnswered -> "Antigravity did not show its sign-in chooser"
+                    !attempt.menuAnswered -> "Antigravity did not show its sign-in chooser"
                     else -> "Antigravity did not print a Google sign-in URL"
                 },
                 visibleDiagnostics(clean),
             )
-        terminate(started)
-    }
-
-    fun submitCode(
-        start: AntigravityAuthStart,
-        code: String,
-    ) {
-        submitCode(code, start.process)
+        terminate(attempt.process)
     }
 
     @Synchronized
     fun submitCode(code: String) {
-        submitCode(code, process ?: return)
-    }
-
-    private fun submitCode(
-        code: String,
-        target: Process,
-    ) {
+        val attempt = current ?: return
         val trimmed = code.trim()
         if (trimmed.isEmpty()) return
         mutableState.value = State.Verifying
         runCatching {
-            target.outputStream.write((trimmed + "\r").toByteArray())
-            target.outputStream.flush()
+            attempt.process.outputStream.write((trimmed + "\r").toByteArray())
+            attempt.process.outputStream.flush()
         }.onFailure {
-            mutableState.value = State.Failed(it.message ?: "Could not submit the Antigravity code", diagnostics)
+            mutableState.value = State.Failed(it.message ?: "Could not submit the Antigravity code", attempt.diagnostics)
             return
         }
-        scope.launch { awaitVerification(target) }
+        scope.launch { awaitVerification(attempt) }
     }
 
     /**
      * The official CLI stays running after a successful exchange, so completion is confirmed out of
      * band with `agy models` rather than by waiting for the process to exit.
      */
-    private suspend fun awaitVerification(target: Process) {
+    private suspend fun awaitVerification(attempt: Attempt) {
         val deadline = System.currentTimeMillis() + VERIFY_TIMEOUT_MS
         while (System.currentTimeMillis() < deadline) {
             if (mutableState.value !is State.Verifying) return
-            val clean = cleanTranscript()
+            val clean = attempt.clean()
             if (AntigravityAuthParser.isFailure(clean)) {
-                mutableState.value = State.Failed("Antigravity rejected the authorization code", diagnostics)
+                mutableState.value = State.Failed("Antigravity rejected the authorization code", attempt.diagnostics)
                 return
             }
             if (AntigravityAuthParser.isSignedIn(clean) || verifyModels()) {
-                terminate(target)
-                synchronized(this) { process = null }
+                releaseIfCurrent(attempt)
+                terminate(attempt.process)
                 mutableState.value = State.SignedIn()
                 return
             }
             delay(VERIFY_POLL_MS)
         }
         if (mutableState.value is State.Verifying) {
-            mutableState.value = State.Failed("Antigravity sign-in did not complete in time", diagnostics)
+            mutableState.value = State.Failed("Antigravity sign-in did not complete in time", attempt.diagnostics)
         }
     }
 
     @Synchronized
     fun cancel() {
-        process?.let(::terminateAsync)
-        process = null
-        codeFieldLive = false
+        abandonCurrent()
         if (mutableState.value !is State.SignedIn) mutableState.value = State.Idle
     }
 
@@ -228,13 +279,29 @@ class AntigravityAuthCoordinator(
     /**
      * Publishes [State.Starting] without taking [start]'s lock, so the button reacts on the tap.
      *
-     * [start] is `@Synchronized` and everything it does before publishing a state is slow - killing
-     * a previous process, and an already-signed-in check that is a whole `agy models` run behind a
-     * gate that waits up to a minute. Its own first line cannot report anything until it holds the
-     * lock, so the press has to be acknowledged from outside it.
+     * [start] is `@Synchronized` and everything it does before publishing a state is slow - an
+     * already-signed-in check that is a whole `agy models` run behind a gate that waits up to a
+     * minute. Its own first line cannot report anything until it holds the lock, so the press has to
+     * be acknowledged from outside it.
      */
     fun markStarting() {
+        // Not over a live attempt: a second press while the sign-in URL is on screen would replace
+        // it with a spinner for a process nothing is going to restart. [start] ignores that press.
+        // Read without the lock - this runs on the UI thread. See [current].
+        if (current?.process?.isAlive == true) return
         mutableState.value = State.Starting
+    }
+
+    /**
+     * Publishes a failure that happened instead of a sign-in rather than during one.
+     *
+     * [AntigravityController.beginAuth] used to record this on its own state, which is combined with
+     * - and therefore immediately overwritten by - this flow. A sign-in that could not even start,
+     * because no Linux environment is installed or the process gate is still busy, left the UI on a
+     * spinner with nothing to say and no way back.
+     */
+    fun markFailed(message: String) {
+        mutableState.value = State.Failed(message, "")
     }
 
     private fun launchTui(runtime: LocalRuntimeInstaller.InstalledRuntime): Process {
@@ -257,27 +324,36 @@ class AntigravityAuthCoordinator(
             .start()
     }
 
-    private fun cleanTranscript(): String = AntigravityAuthParser.stripAnsi(synchronized(this) { transcript.toString() })
-
     private fun visibleDiagnostics(clean: String): String = AntigravityAuthParser.redact(clean).takeLast(VISIBLE_TRANSCRIPT)
 
-    private fun onOutput(chunk: String) {
-        synchronized(this) {
-            transcript.append(chunk)
-            if (transcript.length > MAX_TRANSCRIPT) transcript.delete(0, transcript.length - MAX_TRANSCRIPT)
-        }
-        val clean = cleanTranscript()
-        if (!codeFieldLive) {
-            diagnostics = visibleDiagnostics(clean)
-            codeFieldLive = AntigravityAuthParser.isAwaitingCode(clean)
+    private fun onOutput(
+        attempt: Attempt,
+        chunk: String,
+    ) {
+        attempt.append(chunk)
+        // An abandoned attempt drains whatever is left in its buffer before the kill lands. None of
+        // it can be published: its URL is dead, and its transcript is not the live attempt's.
+        if (!isCurrent(attempt)) return
+        val clean = attempt.clean()
+        if (!attempt.codeFieldLive) {
+            attempt.diagnostics = visibleDiagnostics(clean)
+            attempt.codeFieldLive = AntigravityAuthParser.isAwaitingCode(clean)
         }
         if (mutableState.value is State.Verifying || mutableState.value is State.SignedIn) return
         val url = AntigravityAuthParser.findOAuthUrl(clean)
-        if (url != null) mutableState.value = State.AwaitingBrowser(url, diagnostics)
+        if (url != null) mutableState.value = State.AwaitingBrowser(url, attempt.diagnostics)
     }
 
-    private fun onProcessExit(exitCode: Int) {
-        synchronized(this) { process = null }
+    /** Internal for the same reason as [adopt]: the rule below is what the tests are about. */
+    internal fun onProcessExit(
+        attempt: Attempt,
+        exitCode: Int,
+    ) {
+        // Only the attempt this coordinator still holds may report anything. A cancelled attempt, or
+        // one a second press replaced, is being killed on purpose, and announcing that kill as
+        // "stopped (exit code 137)" described the coordinator's own SIGKILL as a sign-in failure -
+        // on top of whatever state had already taken its place.
+        if (!releaseIfCurrent(attempt)) return
         when (mutableState.value) {
             is State.SignedIn -> return
             // Verification owns the terminal state once a code has been submitted.
@@ -293,7 +369,7 @@ class AntigravityAuthCoordinator(
             if (verifyModels()) {
                 State.SignedIn()
             } else {
-                State.Failed("Antigravity sign-in stopped (exit code $exitCode)", diagnostics)
+                State.Failed("Antigravity sign-in stopped (exit code $exitCode)", attempt.diagnostics)
             }
     }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
@@ -225,23 +225,29 @@ class AntigravityController(
      * code because it is dispatched onto [scope] here.
      */
     fun beginAuth() {
-        // On the click, and through the coordinator: [state] takes its auth from the coordinator's
-        // own flow, so setting it on this controller's state would be overwritten immediately.
+        // Both of these go through the coordinator: [state] takes its auth from the coordinator's
+        // own flow, so setting it on this controller's state is overwritten on the next emission.
+        // The failure below used to do exactly that, which is why a sign-in that could not start at
+        // all - no Linux environment, or the process gate still busy - said nothing.
         target.auth.markStarting()
         scope.launch {
             runCatching { target.auth.start() }
-                .onFailure { error ->
-                    mutableState.value =
-                        mutableState.value.copy(
-                            auth = AntigravityAuthCoordinator.State.Failed(error.message ?: "Unable to start sign-in", ""),
-                        )
-                }
+                .onFailure { error -> target.auth.markFailed(error.message ?: "Unable to start sign-in") }
         }
     }
 
     fun submitAuthCode(code: String) = target.auth.submitCode(code)
 
-    fun cancelAuth() = target.auth.cancel()
+    /**
+     * Off the caller's thread, for the same reason as [beginAuth].
+     *
+     * [AntigravityAuthCoordinator.cancel] takes the same lock [AntigravityAuthCoordinator.start]
+     * holds through its whole pre-flight, so cancelling a sign-in that is still starting up would
+     * otherwise block the UI thread for as long as that takes.
+     */
+    fun cancelAuth() {
+        scope.launch { target.auth.cancel() }
+    }
 
     /** Mirrors [ClaudeCodeController.setPermissionMode]: the open chat changes with the default. */
     fun setPermissionMode(

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityAuthCoordinatorTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityAuthCoordinatorTest.kt
@@ -1,0 +1,90 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.OutputStream
+
+/**
+ * Which sign-in attempt is allowed to speak for the coordinator.
+ *
+ * Killing the guest process tree is asynchronous, so a cancelled or superseded attempt is still
+ * running - and still on its way to reporting its own death - while the state it used to own has
+ * already moved on. On device that death arrived as "Antigravity sign-in stopped (exit code 137)",
+ * 137 being the coordinator's own SIGKILL: pressing Cancel produced an error, and pressing Sign in a
+ * second time failed the attempt that press had just started.
+ */
+class AntigravityAuthCoordinatorTest {
+    private val coordinator =
+        AntigravityAuthCoordinator(
+            runtimeDirectory = File("/nonexistent"),
+            installedRuntimeProvider = { null },
+        )
+
+    @Test
+    fun `cancelling leaves sign-in idle when the kill it sent lands`() {
+        val attempt = coordinator.adopt(AntigravityAuthCoordinator.Attempt(FakeProcess()))
+
+        coordinator.cancel()
+        coordinator.onProcessExit(attempt, SIGKILL_EXIT)
+
+        assertEquals(AntigravityAuthCoordinator.State.Idle, coordinator.state.value)
+    }
+
+    @Test
+    fun `an attempt replaced by a newer one cannot fail the newer one`() {
+        val first = coordinator.adopt(AntigravityAuthCoordinator.Attempt(FakeProcess()))
+        coordinator.adopt(AntigravityAuthCoordinator.Attempt(FakeProcess()))
+
+        coordinator.onProcessExit(first, SIGKILL_EXIT)
+
+        assertEquals(AntigravityAuthCoordinator.State.Idle, coordinator.state.value)
+    }
+
+    /** The guard above must not swallow the failure the user actually needs to see. */
+    @Test
+    fun `the live attempt dying is still reported`() {
+        val attempt = coordinator.adopt(AntigravityAuthCoordinator.Attempt(FakeProcess()))
+
+        coordinator.onProcessExit(attempt, SIGKILL_EXIT)
+
+        assertTrue(coordinator.state.value is AntigravityAuthCoordinator.State.Failed)
+    }
+
+    /** A superseded attempt keeps draining its buffer; none of it belongs to the live transcript. */
+    @Test
+    fun `transcripts do not leak between attempts`() {
+        val abandoned = AntigravityAuthCoordinator.Attempt(FakeProcess())
+        val live = AntigravityAuthCoordinator.Attempt(FakeProcess())
+
+        abandoned.append("output of a sign-in the user cancelled")
+        live.append("Select login method")
+
+        assertEquals("Select login method", live.clean())
+    }
+
+    private class FakeProcess : Process() {
+        override fun getOutputStream(): OutputStream =
+            object : OutputStream() {
+                override fun write(b: Int) = Unit
+            }
+
+        override fun getInputStream() = ByteArrayInputStream(ByteArray(0))
+
+        override fun getErrorStream() = ByteArrayInputStream(ByteArray(0))
+
+        override fun waitFor() = SIGKILL_EXIT
+
+        override fun exitValue() = SIGKILL_EXIT
+
+        override fun destroy() = Unit
+
+        override fun isAlive() = false
+    }
+
+    private companion object {
+        const val SIGKILL_EXIT = 137
+    }
+}


### PR DESCRIPTION
## 症状

- Antigravityの「サインイン」を押しても**画面が何も変わらない**（設定画面・セットアップ画面の両方）
- もう一度押すと `Antigravity sign-in stopped (exit code 137)` が表示される

## 原因

サインインの状態機械が、**すでに破棄したプロセスについて報告していた**ことが原因です。

**① 無反応 — `start()` が自分の「開始中」表示を即座に打ち消していた**

`start()` は `Starting` を publish した直後に `cancel()` を呼んでおり、`cancel()` は状態を `Idle` に戻します。その後に走る前処理（ゲスト設定の修復と、プロセスゲートで最大60秒待ち・自身も最大90秒かかる `agy models` チェック）は、画面が「サインイン」ボタンのまま・スピナーもない状態で進行していました。実機計測では**タップの2.7秒後には `Idle` に戻っていました**。

**② `exit code 137` — アプリ自身のSIGKILLを失敗として報告していた**

`cancel()` と2度目の押下が送る kill は非同期なので、死にゆくプロセスが**すでに別の状態に置き換わった画面へ**自分の終了を報告していました。137 はアプリ自身のSIGKILLです。結果として、中止を押すとエラーが表示され、2度目の押下は自分が今始めた試行を失敗させていました。

## 修正

- 試行ごとの状態（プロセス・トランスクリプト・診断・進捗フラグ）を `Attempt` に集約し、**現在保持している試行だけ**が状態を publish できるように。破棄された試行は古いURLも自分のkillも報告できません
- `start()` の後始末を `cancel()` から分離し、前処理の間ずっと `Starting` を表示
- 実行中の押下は再起動せず無視
- 起動すらできなかった場合を表示（`beginAuth` はコーディネータのflowに上書きされる側へ書いていたため、「Linux環境が未インストール」が一度も表示されていなかった）
- `cancelAuth` をUIスレッドから外す（`start()` が保持するロックを取るため）

## テスト計画

- [x] ユニットテスト4件追加（`AntigravityAuthCoordinatorTest`）— 中止・世代交代・生きている試行の失敗報告・トランスクリプト分離
- [x] `spotlessCheck` / `detekt` / 全ユニットテスト green
- [x] エミュレータ実機検証（Antigravity 1.1.7 新規インストール、セットアップ画面のサインインステップ）

| 操作 | 修正前（実機） | 修正後 |
|---|---|---|
| サインイン押下 | 2.7秒後に `Idle`（無反応） | `Starting` → `AwaitingBrowser` |
| 中止押下 | `exit code 137` エラー | `Idle` |
| 3連打 | プロセス乱立 → 137 | agyプロセス1個のみ、正常遷移 |

- [ ] リリース署名ビルドでの実機確認（署名鍵が必要なため未実施）

## 補足（本PR対象外）

実機に約6時間前の `agy` プロセスが残留していました（アプリ再起動をまたいでゲスト側プロセスが生き残る別のリーク）。`agy` の同時起動はデッドロックの既知条件のため、体感の遅さに寄与している可能性があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)