### PR TITLE
fix: show the assistant agent's own models, not the chat agent's

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/AssistantTargetResolver.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/AssistantTargetResolver.kt
@@ -15,6 +15,17 @@ internal fun assistantTargets(targets: List<RuntimeTarget>): List<RuntimeTarget>
 /** Models the selected agent can use, excluding providers that are not authenticated. */
 internal fun assistantProviderOptions(catalog: ProviderCatalog): List<OpenCodeProvider> = catalog.all.filter { it.id in catalog.connected }
 
+/**
+ * The assistant's agent is usually not the runtime the chat has open, so its server is often still
+ * stopped when the voice settings appear. Connecting first is what the chat catalogue already does;
+ * without it the fetch failed and the picker offered the chat agent's models for an assistant that
+ * cannot run them. An unreachable agent returns nothing, never another agent's catalogue.
+ */
+internal suspend fun loadAssistantProviders(target: RuntimeTarget): List<OpenCodeProvider> {
+    if (runCatching { target.connect() }.getOrNull()?.isSuccess != true) return emptyList()
+    return runCatching { assistantProviderOptions(target.listProviders()) }.getOrDefault(emptyList())
+}
+
 /** Prefer folders belonging to the assistant agent, with the chat catalogue as a safe fallback. */
 internal fun assistantWorkspaceOptions(
     targetWorkspaces: List<WorkspaceRef>,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
@@ -81,7 +81,6 @@ fun VoiceSettingsScreen(
     availableWakeWordModels: List<String> = emptyList(),
     assistantRuntimeId: String? = null,
     runtimeTargets: List<RuntimeTarget> = emptyList(),
-    providers: List<OpenCodeProvider> = emptyList(),
     workspaces: List<WorkspaceRef> = emptyList(),
     assistantProviderId: String? = null,
     assistantModelId: String? = null,
@@ -246,7 +245,6 @@ fun VoiceSettingsScreen(
                     SettingsGroup(title = stringResource(R.string.assistant_target_section)) {
                         AssistantTargetSection(
                             runtimeTargets = runtimeTargets,
-                            providers = providers,
                             workspaces = workspaces,
                             assistantRuntimeId = assistantRuntimeId,
                             assistantProviderId = assistantProviderId,
@@ -345,7 +343,6 @@ private fun SecretTextField(
 @Composable
 private fun AssistantTargetSection(
     runtimeTargets: List<RuntimeTarget>,
-    providers: List<OpenCodeProvider>,
     workspaces: List<WorkspaceRef>,
     assistantRuntimeId: String?,
     assistantProviderId: String?,
@@ -373,15 +370,12 @@ private fun AssistantTargetSection(
         targetProviders = emptyList()
         if (target != null) {
             targetWorkspaces = runCatching { target.listWorkspaces() }.getOrDefault(emptyList())
-            targetProviders =
-                runCatching { assistantProviderOptions(target.listProviders()) }
-                    .getOrDefault(emptyList())
+            targetProviders = loadAssistantProviders(target)
         }
     }
     val workspaceOptions = assistantWorkspaceOptions(targetWorkspaces, workspaces)
-    val modelProviders = targetProviders.ifEmpty { providers }
     val selectedModelName =
-        modelProviders.firstOrNull { it.id == assistantProviderId }?.models?.get(assistantModelId)?.name
+        targetProviders.firstOrNull { it.id == assistantProviderId }?.models?.get(assistantModelId)?.name
 
     SelectionRow(
         icon = runtimeAgentIcon(selectedTarget?.agent),
@@ -413,7 +407,7 @@ private fun AssistantTargetSection(
             runtimeTargets = selectableTargets,
             selectedRuntimeId = assistantRuntimeId,
             onSelectRuntime = onRuntimeChange,
-            providers = modelProviders,
+            providers = targetProviders,
             selectedProviderId = assistantProviderId,
             selectedModelId = assistantModelId,
             showLocalSuffix = false,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -130,7 +130,6 @@ fun NavGraphBuilder.settingsNavGraph(
             availableWakeWordModels = settingsState.availableWakeWordModels,
             assistantRuntimeId = settingsState.assistantRuntimeId,
             runtimeTargets = runtimeTargets(),
-            providers = settingsState.providers,
             workspaces = workspaces(),
             assistantProviderId = settingsState.assistantProviderId,
             assistantModelId = settingsState.assistantModelId,

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/settings/AssistantTargetResolverTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/settings/AssistantTargetResolverTest.kt
@@ -20,10 +20,23 @@ import com.yugahashimoto.andcode.runtime.WorkspaceRef
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class AssistantTargetResolverTest {
+    private val openCodeCatalog =
+        ProviderCatalog(
+            all =
+                listOf(
+                    OpenCodeProvider(
+                        id = "opencode",
+                        models = mapOf("grok-code" to OpenCodeModel("grok-code", "opencode", "Grok Code")),
+                    ),
+                ),
+            connected = listOf("opencode"),
+        )
+
     @Test
     fun `assistant choices contain named agents and never a generic remote or local option`() {
         val targets =
@@ -62,6 +75,28 @@ class AssistantTargetResolverTest {
     }
 
     @Test
+    fun `assistant models are fetched after connecting the agent's own runtime`() =
+        runTest {
+            val target = FakeTarget("open-code", agent = LocalAgent.OPEN_CODE, catalog = openCodeCatalog)
+
+            assertEquals(listOf("opencode"), loadAssistantProviders(target).map { it.id })
+        }
+
+    @Test
+    fun `assistant models stay empty when the agent's runtime cannot be reached`() =
+        runTest {
+            val target =
+                FakeTarget(
+                    "open-code",
+                    agent = LocalAgent.OPEN_CODE,
+                    catalog = openCodeCatalog,
+                    connects = false,
+                )
+
+            assertEquals(emptyList<String>(), loadAssistantProviders(target).map { it.id })
+        }
+
+    @Test
     fun `assistant workspace options prefer the selected agent over chat fallback`() {
         val selected = WorkspaceRef("/workspace/selected", "selected", "selected")
         val fallback = WorkspaceRef("/workspace/chat", "chat", "chat")
@@ -72,13 +107,21 @@ class AssistantTargetResolverTest {
     private class FakeTarget(
         override val id: String,
         override val agent: LocalAgent?,
+        private val catalog: ProviderCatalog = ProviderCatalog(),
+        private val connects: Boolean = true,
     ) : RuntimeTarget {
         override val displayName: String = id
         override val type: RuntimeType = RuntimeType.LOCAL
         override val kind: BackendKind = BackendKind.LOCAL
         override val state = MutableStateFlow<RuntimeState>(RuntimeState.Disconnected)
 
-        override suspend fun connect(): Result<OpenCodeHealth> = Result.success(OpenCodeHealth(true, "test"))
+        private var connected = false
+
+        override suspend fun connect(): Result<OpenCodeHealth> {
+            if (!connects) return Result.failure(IllegalStateException("runtime is not running"))
+            connected = true
+            return Result.success(OpenCodeHealth(true, "test"))
+        }
 
         override fun disconnect() = Unit
 
@@ -93,7 +136,11 @@ class AssistantTargetResolverTest {
 
         override suspend fun listMessages(sessionId: String): List<OpenCodeMessage> = emptyList()
 
-        override suspend fun listProviders(): ProviderCatalog = ProviderCatalog()
+        /** A local runtime only answers once its server is up, which is what [connect] establishes. */
+        override suspend fun listProviders(): ProviderCatalog {
+            check(connected) { "runtime is not connected" }
+            return catalog
+        }
 
         override suspend fun listAgents(): List<OpenCodeAgent> = emptyList()
 


### PR DESCRIPTION
## What was wrong

Choosing **OpenCode** as the assistant Agent in 音声設定 offered **Claude Code's** models, and OpenCode's own models were nowhere to be found.

The assistant target section fetched its catalogue with `listProviders()` **without connecting first**. Confirmed on a real device with temporary instrumentation:

```
target=local-android agent=OPEN_CODE state=Disconnected ok=false
err=java.net.ConnectException: Failed to connect to /127.0.0.1:4097
```

For a local agent whose server is not running that call fails, the failure was swallowed by `runCatching{}.getOrDefault(emptyList())`, and then:

```kotlin
val modelProviders = targetProviders.ifEmpty { providers }  // providers = the chat runtime's catalogue
```

silently substituted a **different agent's** models.

The chat path in `RuntimeCatalogRepository` already calls `connect()` (with retries) before listing, and its own comments record fixing this same class of bug there ("OpenCode models appeared under Claude Code"). The voice settings path never got the same treatment.

## The fix

`AssistantTargetResolver.loadAssistantProviders()` connects before listing, and the cross-agent fallback is gone — an unreachable agent now shows nothing rather than models it cannot run. The unused `providers` plumbing into `VoiceSettingsScreen` is removed.

## Verification

Unit tests written first (both red before the fix): the catalogue is fetched after connecting, and an unreachable agent yields empty rather than another agent's list.

Verified on a physical device (Xiaomi, Android 16):

- **Agent = Claude Code** → its own 4 models load (`claude-opus-5` / Fable / Haiku / Sonnet). Previously this row showed `<synthetic>`.
- **Agent = OpenCode**, runtime stopped → "接続済みのプロバイダがありません" / "モデル未選択" instead of Claude Code's models.

`./gradlew :app:testDebugUnitTest spotlessCheck detekt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)