### PR TITLE
fix: wake word setting crashes release builds (Vosk/JNA R8 stripping)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,13 @@ android {
             }
         }
     }
+    testOptions {
+        unitTests {
+            // android.util.Log is a stub on the unit test classpath and throws on every call.
+            // Returning defaults instead lets tests exercise code that logs on its error paths.
+            isReturnDefaultValues = true
+        }
+    }
     lint {
         // The androidx.startup Initializers are deliberately not auto-started: the manifest removes
         // their <meta-data> entries with tools:node="remove" so they cannot run inside

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -49,6 +49,21 @@
 -keep class com.yugahashimoto.andcode.data.settings.Draft { *; }
 -keep class com.yugahashimoto.andcode.runtime.local.LocalRuntimeMetadata { *; }
 
+# Vosk wake word spotting, and the JNA bridge it reaches the native library through.
+#
+# Neither artifact ships consumer rules, so without these R8 renames the fields JNA's own native
+# code resolves by name from Native.initIDs() — "Can't obtain peer field ID for class
+# com.sun.jna.Pointer" — which fails com.sun.jna.Native's static initializer and leaves every
+# org.vosk class permanently unloadable in a release build. Members have to be kept, not just the
+# class names. Callbacks and Structure subclasses are read reflectively from native code too, so
+# anything deriving from a JNA type keeps its members as well.
+-keep class com.sun.jna.** { *; }
+-keep class org.vosk.** { *; }
+-keepclassmembers class * extends com.sun.jna.** { *; }
+-keepclassmembers class * implements com.sun.jna.** { *; }
+-dontwarn com.sun.jna.**
+-dontwarn java.awt.**
+
 # Firebase Crashlytics
 -keep class com.google.firebase.crashlytics.** { *; }
 -dontwarn com.google.firebase.crashlytics.**

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/VoskWakeWordDetector.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/VoskWakeWordDetector.kt
@@ -39,9 +39,16 @@ internal class VoskWakeWordDetector(
             recognizer = recogniser
             Log.i(TAG, "Initialized for \"${WakeWordGrammar.normalize(phrase)}\"")
             true
-        } catch (e: UnsatisfiedLinkError) {
-            // No native library for this ABI. Nothing to retry, and the caller switches the wake
-            // word back off rather than looping on a service that can never listen.
+        } catch (e: LinkageError) {
+            // The native library is unusable: missing for this ABI, or failed to bind to the Java
+            // side. Either way it surfaces as an error rather than an exception, and it arrives as
+            // UnsatisfiedLinkError only on the very first attempt — once a class has failed to
+            // initialize it stays marked as failed, and later attempts report NoClassDefFoundError
+            // instead. Catching the shared supertype covers both, plus the
+            // ExceptionInInitializerError that wraps a failure thrown out of a static initializer.
+            //
+            // Nothing here is retryable, and the caller switches the wake word back off rather than
+            // looping on a service that can never listen.
             Log.e(TAG, "Vosk native library is unavailable on this device", e)
             release()
             false

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/wakeword/VoskWakeWordDetectorTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/wakeword/VoskWakeWordDetectorTest.kt
@@ -1,0 +1,31 @@
+package com.yugahashimoto.andcode.feature.wakeword
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+
+class VoskWakeWordDetectorTest {
+    /**
+     * The Vosk native library cannot load on the JVM test runtime, so `org.vosk.LibVosk` fails in
+     * its static initializer. The first attempt reports that as an UnsatisfiedLinkError; every
+     * later one reports NoClassDefFoundError, because the class stays marked as failed. A minified
+     * build reaches the same second state from the first attempt, since the JNA fields the native
+     * code looks up by name are renamed and the failure is already recorded against the class.
+     *
+     * Neither of those is an Exception, so both have to be contained here: the service switches the
+     * wake word back off when initialize() reports failure, but an error escaping this call takes
+     * the whole process down instead.
+     */
+    @Test
+    fun `initialize reports failure instead of throwing when the native library cannot load`() {
+        val detector =
+            VoskWakeWordDetector(
+                modelDirectory = File("/nonexistent/vosk-model-en-us"),
+                phrase = "hey andcode",
+                sensitivity = 0.5f,
+            )
+
+        assertFalse(detector.initialize())
+        assertFalse(detector.initialize())
+    }
+}


### PR DESCRIPTION
## Summary
- Turning on the wake word setting crashed release builds with `NoClassDefFoundError: org.vosk.LibVosk`, caused by `UnsatisfiedLinkError: Can't obtain peer field ID for class com.sun.jna.Pointer`.
- Neither the `vosk-android` AAR nor the `net.java.dev.jna` jar ships consumer ProGuard rules, so R8 renamed the `Pointer.peer` field that JNA's native code resolves by name via `GetFieldID`. That breaks `Native`'s static initializer and makes every `org.vosk.*` class permanently unloadable for the rest of the process.
- Added `-keep` rules for `com.sun.jna.**` and `org.vosk.**` in `app/proguard-rules.pro` (root cause fix). Verified with `dexdump`: the field is renamed to `p` in the currently-installed crashing APK, and stays `peer` after this fix.
- Widened `VoskWakeWordDetector.initialize()`'s catch from `UnsatisfiedLinkError` to `LinkageError`: a failed class initializer reports `UnsatisfiedLinkError` only on the *first* attempt — later attempts (and the equivalent R8-stripped-field failure) report `NoClassDefFoundError`/`ExceptionInInitializerError` instead, which wasn't caught and crashed the process instead of switching the wake word back off (the existing recovery path in `WakeWordService`).

## Test plan
- [x] Added `VoskWakeWordDetectorTest` reproducing the exact device failure shape on the JVM unit test runtime (confirmed RED before the catch-clause fix, GREEN after)
- [x] `./gradlew :app:testDebugUnitTest` — full suite passes
- [x] `./gradlew spotlessCheck detekt` — clean
- [x] `./gradlew :app:assembleRelease` — builds; confirmed via `dexdump` that `com.sun.jna.Pointer.peer` survives minification post-fix (vs. renamed to `p` in the previously shipped, crashing build)
- [ ] Manual on-device verification of the signed release APK (couldn't sign locally — no release keystore in this environment)