### PR TITLE
fix: limit chat mode chip to build/plan agents

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -1499,10 +1499,15 @@ private fun ModeChip(
     onSelect: (String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    // OpenCode servers can report arbitrary custom agents alongside its two built-ins; this chip
+    // only offers build/plan to keep the picker to the two modes users actually switch between.
+    // Fall back to the full list if a server configuration omits both, rather than showing an
+    // unusable empty dropdown.
+    val selectableAgents = agents.filter { it.name == "build" || it.name == "plan" }.ifEmpty { agents }
     // The selection is remembered across runtimes, so an id this runtime does not offer would
     // otherwise label the chip with another agent's name. An empty list is not a licence to trust
     // it either: that is exactly the state a stopped runtime is in.
-    val label = selectedAgentId?.takeIf { id -> agents.any { it.name == id } } ?: "build"
+    val label = selectedAgentId?.takeIf { id -> selectableAgents.any { it.name == id } } ?: "build"
     Box {
         Surface(
             modifier =
@@ -1537,7 +1542,7 @@ private fun ModeChip(
             }
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            agents.forEach { agent ->
+            selectableAgents.forEach { agent ->
                 DropdownMenuItem(
                     text = { Text(agent.name) },
                     onClick = {


### PR DESCRIPTION
## Summary
- The chat mode chip (`ModeChip`) listed every agent an OpenCode server reports, including custom agents beyond the two built-ins (`build`/`plan`), making the picker noisier than needed.
- Filter the dropdown to only `build` and `plan`, falling back to the full agent list if a server configuration doesn't expose either (so the dropdown never ends up empty).
- Claude Code / Antigravity are unaffected — they use a separate `PermissionModeChip`, not `ModeChip`.

## Test plan
- [ ] Connect to an OpenCode server with custom agents configured and confirm the mode chip dropdown only shows build/plan
- [ ] Confirm selecting build/plan still works as before
- [ ] Confirm a server with neither build nor plan agent falls back to showing its full agent list (no empty dropdown)