### PR TITLE
fix: make context window meter fill left to right

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -101,6 +101,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
@@ -1769,6 +1770,11 @@ private fun CompactContextMeter(
                     .clip(RoundedCornerShape(2.dp)),
             color = barColor,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            // Material3 defaults round the bar's cap, gap it from the track and draw a stop dot at
+            // the far end. At this size that reads as two dots instead of one bar filling L to R.
+            strokeCap = StrokeCap.Butt,
+            gapSize = 0.dp,
+            drawStopIndicator = {},
         )
         Text(
             text = "${formatTokenCount(displayedTokens)}/${formatTokenCount(contextLimit)}",


### PR DESCRIPTION
## 問題

チャット下部のコンテキストウィンドウゲージが、左から右に溜まらず**両端に点が表示される**状態になっていた。


`9k/200k`（4.5%）で、左端に点・右端に点・真ん中は空。

## 原因

`CompactContextMeter` が `LinearProgressIndicator` に progress と色しか渡しておらず、Material3 1.3（compose-bom 2024.12.01）のデフォルトが3つそのまま効いていた:

1. `strokeCap = StrokeCap.Round` — バー幅 34dp に対し 4.5% は約 1.5dp しかなく、丸キャップで潰れて**左端の点**になる
2. `drawStopIndicator` — M3 1.3 で追加されたトラック終端のドット。これが**右端の点**
3. `gapSize = 4.dp` — バーとトラックの隙間

ゲージのロジック自体は正常で、M3 のデフォルト装飾がこのサイズでは破綻していた。

## 修正

`strokeCap = StrokeCap.Butt` / `gapSize = 0.dp` / `drawStopIndicator = {}` を指定。

## テスト

- [x] `:app:compileDebugKotlin` 通過
- [x] 実機（25098PN5AC / Android 16）に debug ビルドをインストールし目視確認
  - 0/200k → トラックのみ、ドットなし
  - 9k/200k → 左端から1本の細いバーが伸びる。右端ドット・隙間ともに消失
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
