### PR TITLE
fix(chat): let the microphone reach the recogniser during dictation

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/SpeechRecognizerManager.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/SpeechRecognizerManager.kt
@@ -22,7 +22,11 @@ private const val MAX_RESULTS = 3
 // A short pause is common inside a Japanese sentence. Giving the recognizer more time here
 // avoids finalizing a segment before the user has finished the thought; chat then starts the next
 // segment after a genuine recognition result so long dictation remains in one composer value.
-private const val SILENCE_LENGTH_MS = 3000L
+//
+// Int, not Long: these extras are read with Bundle.getInt, and a Long is dropped for the default
+// ("expected Integer but value was a java.lang.Long" in the recognizer's log) - which is how this
+// spent a release having no effect at all.
+private const val SILENCE_LENGTH_MS = 3000
 
 /**
  * 音声認識マネージャー

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/VoiceDictationPolicy.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/VoiceDictationPolicy.kt
@@ -1,0 +1,47 @@
+package com.yugahashimoto.andcode.feature.assistant
+
+import android.speech.SpeechRecognizer
+
+/** What chat dictation should do once a recognition segment has ended in an error. */
+internal enum class VoiceDictationOutcome {
+    /** Open another segment: the recogniser heard nothing, which is not a failure yet. */
+    RESTART,
+
+    /** Stop listening quietly, keeping what has been dictated so far. */
+    FINISH,
+
+    /** Stop listening and put the error in front of the user. */
+    REPORT,
+}
+
+/**
+ * Dictation runs as a chain of recognition segments, and a segment that heard nothing ends in an
+ * error rather than an empty result. Reporting every one of those stopped dictation at the first
+ * pause and showed "could not recognise" for what was really just a silent moment, so silence is
+ * only worth saying out loud once nothing at all has been heard for several segments in a row.
+ */
+internal object VoiceDictationPolicy {
+    /** How many silent segments in a row before silence is reported rather than retried. */
+    const val MAX_SILENT_SEGMENTS = 3
+
+    fun outcomeFor(
+        code: Int?,
+        hasTranscript: Boolean,
+        consecutiveFailures: Int,
+    ): VoiceDictationOutcome =
+        when {
+            !isTransient(code) -> VoiceDictationOutcome.REPORT
+            hasTranscript -> VoiceDictationOutcome.FINISH
+            consecutiveFailures < MAX_SILENT_SEGMENTS -> VoiceDictationOutcome.RESTART
+            else -> VoiceDictationOutcome.REPORT
+        }
+
+    /**
+     * Errors that say "nothing was heard this time" rather than "something is wrong". A missing
+     * code means the recogniser never started, which retrying cannot fix.
+     */
+    private fun isTransient(code: Int?): Boolean =
+        code == SpeechRecognizer.ERROR_NO_MATCH ||
+            code == SpeechRecognizer.ERROR_SPEECH_TIMEOUT ||
+            code == SpeechRecognizer.ERROR_RECOGNIZER_BUSY
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordService.kt
@@ -52,6 +52,13 @@ class WakeWordService : Service() {
 
     @Volatile private var speaking = false
 
+    // Detection is not the only microphone reader in the app: chat dictation runs through
+    // SpeechRecognizer, which records from *another* process. Two live capture clients make the
+    // platform silence one of them, and the one it keeps is this service - so the recogniser hears
+    // nothing but zeroes and reports "no match". Whoever needs the microphone takes this hold and
+    // detection stands down until it is handed back.
+    @Volatile private var micHoldToken: String? = null
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
@@ -178,6 +185,11 @@ class WakeWordService : Service() {
         language: VoskModelLanguage,
         resetSession: Boolean = true,
     ) {
+        if (micHoldToken != null) {
+            // The holder gets detection back when it releases the microphone.
+            currentLanguage = language
+            return
+        }
         if (listenJob?.isActive == true && currentLanguage == language) return
 
         val previousJob = listenJob
@@ -348,6 +360,22 @@ class WakeWordService : Service() {
     }
 
     @Synchronized
+    private fun holdMicrophoneInternal(token: String) {
+        micHoldToken = token
+        stopListening()
+    }
+
+    @Synchronized
+    private fun releaseMicrophoneInternal(token: String) {
+        if (micHoldToken != token) return
+        micHoldToken = null
+        // An assistant session owns the microphone on its own terms, and hands detection back
+        // itself through setSpeaking and resumeAfterSession.
+        if (assistantRequestId != null) return
+        startListening(currentLanguage, resetSession = false)
+    }
+
+    @Synchronized
     private fun setSpeakingInternal(
         requestId: String,
         isSpeaking: Boolean,
@@ -432,6 +460,19 @@ class WakeWordService : Service() {
             speaking: Boolean,
         ) {
             activeInstance?.setSpeakingInternal(requestId, speaking)
+        }
+
+        /**
+         * Stops wake-word capture so another recogniser in this app can actually hear the user.
+         * A no-op when the service is not running, and safe to call more than once.
+         */
+        fun holdMicrophone(token: String) {
+            activeInstance?.holdMicrophoneInternal(token)
+        }
+
+        /** Hands the microphone back and resumes detection, unless a session is holding it. */
+        fun releaseMicrophone(token: String) {
+            activeInstance?.releaseMicrophoneInternal(token)
         }
 
         fun pauseForSession(requestId: String) {

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -70,6 +70,8 @@ import com.yugahashimoto.andcode.feature.activity.ActivityViewModel
 import com.yugahashimoto.andcode.feature.assistant.SpeechRecognizerManager
 import com.yugahashimoto.andcode.feature.assistant.SpeechResult
 import com.yugahashimoto.andcode.feature.assistant.SpeechTranscriptAccumulator
+import com.yugahashimoto.andcode.feature.assistant.VoiceDictationOutcome
+import com.yugahashimoto.andcode.feature.assistant.VoiceDictationPolicy
 import com.yugahashimoto.andcode.feature.chat.ChatHomeScreen
 import com.yugahashimoto.andcode.feature.chat.ChatViewModel
 import com.yugahashimoto.andcode.feature.chat.SubagentInfo
@@ -83,6 +85,7 @@ import com.yugahashimoto.andcode.feature.schedule.ScheduleViewModel
 import com.yugahashimoto.andcode.feature.settings.DiagnosticsSheet
 import com.yugahashimoto.andcode.feature.settings.GitHubRepo
 import com.yugahashimoto.andcode.feature.settings.SettingsViewModel
+import com.yugahashimoto.andcode.feature.wakeword.WakeWordService
 import com.yugahashimoto.andcode.feature.wakeword.WakeWordSettingsPolicy
 import com.yugahashimoto.andcode.feature.workspace.WorkspaceViewModel
 import com.yugahashimoto.andcode.runtime.RuntimeState
@@ -116,6 +119,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.UUID
 
 /** How often the open chat asks GitHub whether its pull requests have moved on. */
 private const val PULL_REQUEST_REFRESH_INTERVAL_MS = 30_000L
@@ -316,9 +320,15 @@ fun AndCodeApp(
         voiceJob =
             voiceScope.launch {
                 val transcript = SpeechTranscriptAccumulator()
+                // Wake-word detection records straight from the microphone, while this dictation
+                // records through SpeechRecognizer in another process. Left running, detection wins
+                // the platform's arbitration and the recogniser is handed silence.
+                val micToken = UUID.randomUUID().toString()
+                WakeWordService.holdMicrophone(micToken)
                 try {
+                    var silentSegments = 0
                     while (true) {
-                        var restart = true
+                        var outcome = VoiceDictationOutcome.RESTART
                         speechManager.startListening(speechLocaleTag(context)).collect { result ->
                             when (result) {
                                 SpeechResult.Ready,
@@ -329,16 +339,25 @@ fun AndCodeApp(
                                     chatViewModel.updateSpeechPartial(transcript.preview(result.text))
                                 }
                                 is SpeechResult.Result -> {
+                                    silentSegments = 0
                                     transcript.append(result.text)
                                     chatViewModel.updateSpeechPartial(transcript.text)
                                 }
                                 is SpeechResult.Error -> {
-                                    restart = false
-                                    chatViewModel.reportSpeechError(result.message)
+                                    silentSegments += 1
+                                    outcome =
+                                        VoiceDictationPolicy.outcomeFor(
+                                            code = result.code,
+                                            hasTranscript = transcript.text.isNotBlank(),
+                                            consecutiveFailures = silentSegments,
+                                        )
+                                    if (outcome == VoiceDictationOutcome.REPORT) {
+                                        chatViewModel.reportSpeechError(result.message)
+                                    }
                                 }
                             }
                         }
-                        if (!restart) break
+                        if (outcome != VoiceDictationOutcome.RESTART) break
                         delay(VOICE_RESTART_DELAY_MS)
                         chatViewModel.startListening()
                         if (transcript.text.isNotBlank()) {
@@ -346,6 +365,7 @@ fun AndCodeApp(
                         }
                     }
                 } finally {
+                    WakeWordService.releaseMicrophone(micToken)
                     chatViewModel.stopListening()
                 }
             }
@@ -363,7 +383,7 @@ fun AndCodeApp(
                 if (WakeWordSettingsPolicy.canEnable(microphonePermission = true, assistantActive = assistantActive)) {
                     settingsViewModel.setWakeWordEnabled(true)
                     val started =
-                        com.yugahashimoto.andcode.feature.wakeword.WakeWordService.start(
+                        WakeWordService.start(
                             context,
                             settingsState.wakeWordModelLanguage,
                         )
@@ -456,13 +476,13 @@ fun AndCodeApp(
     LaunchedEffect(preferences.wakeWordEnabled, settingsState.wakeWordModelLanguage, assistantActive) {
         if (preferences.wakeWordEnabled && hasMicrophonePermission() && assistantActive) {
             val started =
-                com.yugahashimoto.andcode.feature.wakeword.WakeWordService.start(
+                WakeWordService.start(
                     context,
                     language = settingsState.wakeWordModelLanguage,
                 )
             if (!started) settingsViewModel.setWakeWordEnabled(false)
         } else {
-            com.yugahashimoto.andcode.feature.wakeword.WakeWordService.stop(context)
+            WakeWordService.stop(context)
             if (preferences.wakeWordEnabled) settingsViewModel.setWakeWordEnabled(false)
         }
     }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/assistant/VoiceDictationPolicyTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/assistant/VoiceDictationPolicyTest.kt
@@ -1,0 +1,96 @@
+package com.yugahashimoto.andcode.feature.assistant
+
+import android.speech.SpeechRecognizer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VoiceDictationPolicyTest {
+    @Test
+    fun `a first silent segment starts another one instead of failing the dictation`() {
+        assertEquals(
+            VoiceDictationOutcome.RESTART,
+            VoiceDictationPolicy.outcomeFor(
+                code = SpeechRecognizer.ERROR_NO_MATCH,
+                hasTranscript = false,
+                consecutiveFailures = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `silence after something was dictated ends the dictation without an error`() {
+        // The user stopped talking. Their words are in the composer, so a red "could not
+        // recognise" banner would be both wrong and alarming.
+        assertEquals(
+            VoiceDictationOutcome.FINISH,
+            VoiceDictationPolicy.outcomeFor(
+                code = SpeechRecognizer.ERROR_NO_MATCH,
+                hasTranscript = true,
+                consecutiveFailures = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `silence that never ends is eventually reported`() {
+        assertEquals(
+            VoiceDictationOutcome.REPORT,
+            VoiceDictationPolicy.outcomeFor(
+                code = SpeechRecognizer.ERROR_NO_MATCH,
+                hasTranscript = false,
+                consecutiveFailures = VoiceDictationPolicy.MAX_SILENT_SEGMENTS,
+            ),
+        )
+    }
+
+    @Test
+    fun `a speech timeout is treated as silence`() {
+        assertEquals(
+            VoiceDictationOutcome.RESTART,
+            VoiceDictationPolicy.outcomeFor(
+                code = SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
+                hasTranscript = false,
+                consecutiveFailures = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `a busy recogniser is retried, as the message the user sees promises`() {
+        assertEquals(
+            VoiceDictationOutcome.RESTART,
+            VoiceDictationPolicy.outcomeFor(
+                code = SpeechRecognizer.ERROR_RECOGNIZER_BUSY,
+                hasTranscript = false,
+                consecutiveFailures = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `errors the user has to act on are reported straight away`() {
+        listOf(
+            SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS,
+            SpeechRecognizer.ERROR_NETWORK,
+            SpeechRecognizer.ERROR_AUDIO,
+            SpeechRecognizer.ERROR_CLIENT,
+            SpeechRecognizer.ERROR_SERVER,
+        ).forEach { code ->
+            assertEquals(
+                "code $code",
+                VoiceDictationOutcome.REPORT,
+                VoiceDictationPolicy.outcomeFor(code = code, hasTranscript = false, consecutiveFailures = 1),
+            )
+        }
+    }
+
+    @Test
+    fun `an error with no code at all is reported`() {
+        // Failing to start the recogniser carries no SpeechRecognizer code; retrying it in a loop
+        // would spin silently forever.
+        assertEquals(
+            VoiceDictationOutcome.REPORT,
+            VoiceDictationPolicy.outcomeFor(code = null, hasTranscript = false, consecutiveFailures = 1),
+        )
+    }
+}


### PR DESCRIPTION
Chat's microphone button answered every attempt with 「認識できませんでした」.

## Cause

`WakeWordService` keeps an `AudioRecord` open for as long as wake-word detection runs. Chat dictation goes through `SpeechRecognizer`, which records from **another process** (`com.google.android.tts`). With two live capture clients the platform silences one, and it keeps our own foreground service — so the recogniser received nothing but zeroes, concluded no one had spoken, and returned `ERROR_NO_MATCH`.

Captured on a Xiaomi running Android 16 while reproducing the bug:

```
D/AudioFlinger: setRecordSilenced(general), portId:3357, silenced 1
W/RecognitionClient: #onRecognitionFinished no speech - erroring
W/RecognitionServiceImpl: Speech recognition error type NO_SPEECH_DETECTED

RecordActivityMonitor:
  uid:10595 pack:com.yugahashimoto.andcode -- silenced:false   <- wake-word capture
  uid:10586 pack:com.google.android.tts    -- silenced:true    <- the chat recogniser
```

Every recognition track from the speech service in that device's history was silenced, including the user's own attempts before any instrumentation.

The assistant voice session has always released the microphone first, via `WakeWordService.pauseForSession`. Chat never did.

## Changes

- `WakeWordService.holdMicrophone` / `releaseMicrophone`: chat takes a hold for the length of the dictation and returns it in the `finally`. Its own token rather than a borrowed session id, so a dictation cannot clear the state an assistant session is keeping.
- `SILENCE_LENGTH_MS` is an `Int`. These extras are read with `Bundle.getInt`, so the `Long` was discarded for the default (`expected Integer but value was a java.lang.Long`) — the Japanese pause tuning from #187 has never actually reached the recogniser.
- `VoiceDictationPolicy`: a segment that hears nothing ends in an error, not an empty result, and chat treated any error as the end of the dictation — one quiet moment stopped it and put a red banner over text already dictated. Silence now restarts, ends quietly with the transcript intact once something has been said, and is only reported after several empty segments; a busy recogniser is retried, which is what its message already promised.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :app:assembleDebug detekt spotlessCheck`
- [x] New `VoiceDictationPolicyTest` (RED before the policy existed, green after)
- [x] Verified on the Xiaomi / Android 16 device with wake word enabled:
  - tap mic → `I/WakeWordService: Wake word listening stopped`, recogniser opens with `silenced:false` and is the only active recorder
  - silent segments restart instead of failing at the first one
  - dictation ends → `I/WakeWordService: Wake word listening started`, detection holds the mic again

## Not in this PR

`QuickInputActivity` (the home-screen widget) drives `SpeechRecognizer` directly and has the same conflict with wake-word capture. Left for a follow-up.