### PR TITLE
fix: stop the wake word failing silently on words the model cannot hear

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsViewModel.kt
@@ -18,12 +18,14 @@ import com.yugahashimoto.andcode.feature.wakeword.VoskModelCatalog
 import com.yugahashimoto.andcode.feature.wakeword.VoskModelLanguage
 import com.yugahashimoto.andcode.feature.wakeword.VoskModelState
 import com.yugahashimoto.andcode.feature.wakeword.VoskModelStore
+import com.yugahashimoto.andcode.feature.wakeword.VoskVocabulary
 import com.yugahashimoto.andcode.feature.wakeword.WakeWordGrammar
 import com.yugahashimoto.andcode.runtime.BackendKind
 import com.yugahashimoto.andcode.runtime.LocalAgent
 import com.yugahashimoto.andcode.runtime.RuntimeRegistry
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
 import com.yugahashimoto.andcode.runtime.local.LocalProviderCredentialStore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,6 +35,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.Locale
 
 data class SettingsUiState(
@@ -270,6 +273,22 @@ class SettingsViewModel(
     fun setWakeWordPhrase(phrase: String) = preferences.setWakeWordPhrase(phrase)
 
     fun setWakeWordSensitivity(sensitivity: Float) = preferences.setWakeWordSensitivity(sensitivity)
+
+    /**
+     * Which words of [phrase] the model for [language] cannot recognise.
+     *
+     * Empty also covers "cannot tell": with no model on disk, or a dictionary that will not read,
+     * there is nothing to hold against the phrase, and blocking on a failed check would be a worse
+     * outcome than the silent mis-detection it exists to prevent.
+     */
+    suspend fun unknownWakeWordWords(
+        language: VoskModelLanguage,
+        phrase: String,
+    ): List<String> =
+        withContext(Dispatchers.IO) {
+            val directory = voskModels.directoryFor(language) ?: return@withContext emptyList()
+            VoskVocabulary.unknownWords(directory, phrase).orEmpty()
+        }
 
     fun setWakeWordModelLanguage(language: VoskModelLanguage) = preferences.setWakeWordModelLanguage(language.id)
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.VoiceChat
+import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -74,6 +75,7 @@ import com.yugahashimoto.andcode.runtime.RuntimeTarget
 import com.yugahashimoto.andcode.runtime.WorkspaceRef
 import com.yugahashimoto.andcode.ui.runtimeAgentIcon
 import com.yugahashimoto.andcode.ui.theme.AndCodeTheme
+import kotlinx.coroutines.delay
 import java.util.Locale
 
 /** Voice settings with explicit wake-word capability status. */
@@ -120,8 +122,8 @@ fun VoiceSettingsScreen(
     onTtsBargeInChange: (Boolean) -> Unit = {},
     onContinuousChange: (Boolean) -> Unit,
     onWakeWordChange: (Boolean) -> Unit,
-    onWakeWordPhraseChange: (String) -> Unit = {},
-    onWakeWordSensitivityChange: (Float) -> Unit = {},
+    onWakeWordApply: (String, Float) -> Unit = { _, _ -> },
+    unknownWakeWordWords: suspend (VoskModelLanguage, String) -> List<String> = { _, _ -> emptyList() },
     onWakeWordModelLanguageChange: (VoskModelLanguage) -> Unit = {},
     onWakeWordModelDownload: () -> Unit = {},
     onWakeWordModelCancel: () -> Unit = {},
@@ -131,6 +133,26 @@ fun VoiceSettingsScreen(
     onAssistantWorkspaceChange: (String) -> Unit = {},
     onBack: () -> Unit,
 ) {
+    // The wake word being edited, held here rather than beside the fields: those live in a
+    // LazyColumn item, and scrolling the section off screen would throw a half-typed phrase away.
+    var draftPhrase by remember(wakeWordPhrase) { mutableStateOf(wakeWordPhrase) }
+    var draftSensitivity by remember(wakeWordSensitivity) { mutableStateOf(wakeWordSensitivity) }
+    var unknownWords by remember { mutableStateOf(emptyList<String>()) }
+    var unknownAppliedWords by remember { mutableStateOf(emptyList<String>()) }
+    val modelState = wakeWordModelStates[wakeWordModelLanguage] ?: VoskModelState.Missing
+    LaunchedEffect(draftPhrase, wakeWordModelLanguage, modelState) {
+        // Settled input only: the dictionary is megabytes, and half-typed words are all unknown.
+        delay(PHRASE_CHECK_DELAY_MS)
+        unknownWords = unknownWakeWordWords(wakeWordModelLanguage, draftPhrase)
+    }
+    // The applied phrase is checked apart from the draft because it is the one the service would
+    // be handed. Editing an unusable phrase does not make it usable until the edit is applied, and
+    // switching detection on before then would only start a service that stops itself again.
+    LaunchedEffect(wakeWordPhrase, wakeWordModelLanguage, modelState) {
+        unknownAppliedWords = unknownWakeWordWords(wakeWordModelLanguage, wakeWordPhrase)
+    }
+    val appliedIsUsable = unknownAppliedWords.isEmpty()
+
     Column(modifier = Modifier.fillMaxSize()) {
         CenterAlignedTopAppBar(
             title = {
@@ -231,18 +253,29 @@ fun VoiceSettingsScreen(
                     VoiceToggleRow(
                         icon = Icons.Default.VoiceChat,
                         title = stringResource(R.string.settings_wake_word_row),
-                        description = stringResource(R.string.wake_word_description),
+                        description =
+                            if (appliedIsUsable) {
+                                stringResource(R.string.wake_word_description)
+                            } else {
+                                stringResource(R.string.wake_word_blocked_by_phrase)
+                            },
                         checked = wakeWordEnabled,
+                        enabled = appliedIsUsable,
                         onCheckedChange = onWakeWordChange,
                     )
                     VoiceDivider()
                     WakeWordSection(
-                        phrase = wakeWordPhrase,
-                        sensitivity = wakeWordSensitivity,
+                        appliedPhrase = wakeWordPhrase,
+                        appliedSensitivity = wakeWordSensitivity,
+                        draftPhrase = draftPhrase,
+                        draftSensitivity = draftSensitivity,
+                        unknownWords = unknownWords,
+                        listening = wakeWordEnabled,
                         language = wakeWordModelLanguage,
-                        modelState = wakeWordModelStates[wakeWordModelLanguage] ?: VoskModelState.Missing,
-                        onPhraseChange = onWakeWordPhraseChange,
-                        onSensitivityChange = onWakeWordSensitivityChange,
+                        modelState = modelState,
+                        onDraftPhraseChange = { draftPhrase = it },
+                        onDraftSensitivityChange = { draftSensitivity = it },
+                        onApply = { onWakeWordApply(draftPhrase, draftSensitivity) },
                         onLanguageChange = onWakeWordModelLanguageChange,
                         onDownload = onWakeWordModelDownload,
                         onCancelDownload = onWakeWordModelCancel,
@@ -418,6 +451,9 @@ private fun VoiceSlider(
 
 private const val SLIDER_STEPS = 29
 
+/** How long typing has to settle before the phrase is looked up in the model's dictionary. */
+private const val PHRASE_CHECK_DELAY_MS = 350L
+
 /**
  * Reads a sample line back with the settings as they stand.
  *
@@ -507,11 +543,13 @@ private fun VoiceTextField(
     label: String,
     value: String,
     onValueChange: (String) -> Unit,
+    isError: Boolean = false,
 ) {
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         label = { Text(label) },
+        isError = isError,
         modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 4.dp),
         singleLine = true,
     )
@@ -757,45 +795,77 @@ private fun WorkspaceDropdown(
  * does the recognising.
  *
  * The phrase is free text rather than a fixed list because the recogniser is constrained to a
- * grammar at start-up, so any phrase works - the previous build could only offer the one phrase
- * someone had trained a network for. The model is downloaded on demand and is the one part of
- * this that can be absent, so its state is shown here rather than failing silently later.
+ * grammar at start-up, so any phrase the model has words for works - the previous build could only
+ * offer the one phrase someone had trained a network for. Which is also why what is typed is not
+ * what is listening: the recogniser is built once from the phrase, so the edit and the applied
+ * value are shown as two separate things rather than pretending a keystroke reaches detection.
  */
 @Composable
 private fun WakeWordSection(
-    phrase: String,
-    sensitivity: Float,
+    appliedPhrase: String,
+    appliedSensitivity: Float,
+    draftPhrase: String,
+    draftSensitivity: Float,
+    unknownWords: List<String>,
+    listening: Boolean,
     language: VoskModelLanguage,
     modelState: VoskModelState,
-    onPhraseChange: (String) -> Unit,
-    onSensitivityChange: (Float) -> Unit,
+    onDraftPhraseChange: (String) -> Unit,
+    onDraftSensitivityChange: (Float) -> Unit,
+    onApply: () -> Unit,
     onLanguageChange: (VoskModelLanguage) -> Unit,
     onDownload: () -> Unit,
     onCancelDownload: () -> Unit,
     onRemove: () -> Unit,
 ) {
+    val edited =
+        WakeWordGrammar.normalize(draftPhrase) != WakeWordGrammar.normalize(appliedPhrase) ||
+            draftSensitivity != appliedSensitivity
     VoiceTextField(
         label = stringResource(R.string.wake_word_phrase_label),
-        value = phrase,
-        onValueChange = onPhraseChange,
+        value = draftPhrase,
+        onValueChange = onDraftPhraseChange,
+        isError = unknownWords.isNotEmpty(),
     )
-    Text(
-        text = stringResource(R.string.wake_word_phrase_hint, WakeWordGrammar.DEFAULT_PHRASE),
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(horizontal = 8.dp),
-    )
+    if (unknownWords.isEmpty()) {
+        Text(
+            text = stringResource(R.string.wake_word_phrase_hint, WakeWordGrammar.DEFAULT_PHRASE),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
+    } else {
+        // Named, not just rejected: "andcode" is one keystroke from "and code", and the failure it
+        // causes is otherwise completely silent.
+        Text(
+            text =
+                stringResource(
+                    R.string.wake_word_phrase_unknown_words,
+                    unknownWords.joinToString(", "),
+                ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
+    }
     VoiceSlider(
         label = stringResource(R.string.wake_word_sensitivity_label),
-        value = sensitivity,
+        value = draftSensitivity,
         range = 0f..1f,
-        onValueChange = onSensitivityChange,
+        onValueChange = onDraftSensitivityChange,
     )
     Text(
         text = stringResource(R.string.wake_word_sensitivity_hint),
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.padding(horizontal = 8.dp),
+    )
+    WakeWordApplyRow(
+        appliedPhrase = appliedPhrase,
+        listening = listening,
+        edited = edited,
+        canApply = edited && unknownWords.isEmpty(),
+        onApply = onApply,
     )
     VoiceDivider()
     ChoiceDropdown(
@@ -815,6 +885,48 @@ private fun WakeWordSection(
         onCancelDownload = onCancelDownload,
         onRemove = onRemove,
     )
+}
+
+/**
+ * What detection is listening for right now, and the button that changes it.
+ *
+ * Applying is a deliberate press rather than something that follows typing: the recogniser is
+ * rebuilt from scratch each time, which means reloading a 40 MB model, and a phrase is not worth
+ * building one for until it is finished being typed.
+ */
+@Composable
+private fun WakeWordApplyRow(
+    appliedPhrase: String,
+    listening: Boolean,
+    edited: Boolean,
+    canApply: Boolean,
+    onApply: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text =
+                when {
+                    edited -> stringResource(R.string.wake_word_pending_changes)
+                    listening -> stringResource(R.string.wake_word_listening_for, WakeWordGrammar.normalize(appliedPhrase))
+                    else -> stringResource(R.string.wake_word_applied_phrase, WakeWordGrammar.normalize(appliedPhrase))
+                },
+            style = MaterialTheme.typography.bodySmall,
+            color =
+                if (edited) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            modifier = Modifier.weight(1f).padding(start = 4.dp),
+        )
+        Button(onClick = onApply, enabled = canApply) {
+            Text(stringResource(R.string.wake_word_apply))
+        }
+    }
 }
 
 /** The download state of the selected speech model, and the one action it currently offers. */

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/VoskVocabulary.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/VoskVocabulary.kt
@@ -1,0 +1,135 @@
+package com.yugahashimoto.andcode.feature.wakeword
+
+import java.io.DataInputStream
+import java.io.File
+import java.io.InputStream
+
+/**
+ * The words a downloaded speech model is able to recognise at all.
+ *
+ * A recogniser constrained to a grammar can only ever return words from the model's dictionary, and
+ * Vosk drops any grammar entry that is not in it - with a warning that goes to native stderr, which
+ * Android throws away. A phrase built out of dropped words leaves a recogniser that never fires,
+ * which from the outside is indistinguishable from a microphone that is not working: the service
+ * runs, the microphone indicator is lit, and nothing ever happens. So the phrase is checked against
+ * the dictionary before it is handed over, both in settings and again in the service.
+ *
+ * Where the dictionary lives depends on the model. The Japanese small model ships
+ * `graph/words.txt`; the English one ships no word list at all and keeps its word symbols only
+ * inside the OpenFst header of `graph/Gr.fst`. Both are read here so neither language skips the
+ * check.
+ */
+object VoskVocabulary {
+    /**
+     * The words of [phrase] the model at [modelDirectory] does not know, or null when the
+     * dictionary could not be read.
+     *
+     * Null is not "no unknown words": refusing to listen because the check itself failed would be a
+     * worse failure than the one it exists to catch, so callers treat it as "cannot tell".
+     */
+    fun unknownWords(
+        modelDirectory: File,
+        phrase: String,
+    ): List<String>? {
+        val wanted = WakeWordGrammar.words(phrase)
+        if (wanted.isEmpty()) return emptyList()
+        val known = knownAmong(modelDirectory, wanted.toSet()) ?: return null
+        return wanted.filterNot { it in known }.distinct()
+    }
+
+    /** Which of [wanted] the model knows. Only the asked-for words are held, never the dictionary. */
+    private fun knownAmong(
+        modelDirectory: File,
+        wanted: Set<String>,
+    ): Set<String>? {
+        val wordList = File(modelDirectory, WORD_LIST_PATH)
+        if (wordList.isFile) {
+            return runCatching { readWordList(wordList, wanted) }.getOrNull()
+        }
+        val grammar = File(modelDirectory, GRAMMAR_PATH)
+        if (grammar.isFile) {
+            return runCatching {
+                grammar.inputStream().buffered().use { readSymbolTable(it, wanted) }
+            }.getOrNull()
+        }
+        return null
+    }
+
+    private fun readWordList(
+        file: File,
+        wanted: Set<String>,
+    ): Set<String> {
+        val found = mutableSetOf<String>()
+        file.bufferedReader().useLines { lines ->
+            for (line in lines) {
+                // Each line is "<word> <id>", and the id is nobody's business here.
+                val word = line.substringBefore(' ')
+                if (word in wanted) found += word
+                if (found.size == wanted.size) break
+            }
+        }
+        return found
+    }
+
+    /**
+     * Walks the word symbols out of an OpenFst archive.
+     *
+     * The header is fixed-shape: magic, two length-prefixed type names, version, flags, then five
+     * fixed-width fields nothing here needs, and only then the symbol tables the flags announced.
+     * Everything is little-endian, which is the opposite of what [DataInputStream] reads.
+     */
+    private fun readSymbolTable(
+        input: InputStream,
+        wanted: Set<String>,
+    ): Set<String> {
+        val data = DataInputStream(input)
+        require(data.readLittleEndianInt() == FST_MAGIC) { "Not an OpenFst archive" }
+        data.readLengthPrefixed()
+        data.readLengthPrefixed()
+        data.readLittleEndianInt()
+        val flags = data.readLittleEndianInt()
+        require(flags and FLAG_HAS_INPUT_SYMBOLS != 0) { "The archive carries no word symbols" }
+        data.readFully(ByteArray(HEADER_TAIL_BYTES))
+
+        require(data.readLittleEndianInt() == SYMBOL_TABLE_MAGIC) { "Not an OpenFst symbol table" }
+        data.readLengthPrefixed()
+        data.readLittleEndianLong()
+        val size = data.readLittleEndianLong()
+        require(size in 0..MAX_SYMBOLS) { "Implausible symbol count $size" }
+
+        val found = mutableSetOf<String>()
+        for (index in 0 until size) {
+            if (found.size == wanted.size) break
+            val symbol = data.readLengthPrefixed()
+            data.readLittleEndianLong()
+            if (symbol in wanted) found += symbol
+        }
+        return found
+    }
+
+    private fun DataInputStream.readLittleEndianInt(): Int = Integer.reverseBytes(readInt())
+
+    private fun DataInputStream.readLittleEndianLong(): Long = java.lang.Long.reverseBytes(readLong())
+
+    private fun DataInputStream.readLengthPrefixed(): String {
+        val length = readLittleEndianInt()
+        require(length in 0..MAX_SYMBOL_BYTES) { "Implausible symbol length $length" }
+        val bytes = ByteArray(length)
+        readFully(bytes)
+        return String(bytes, Charsets.UTF_8)
+    }
+
+    private const val WORD_LIST_PATH = "graph/words.txt"
+    private const val GRAMMAR_PATH = "graph/Gr.fst"
+    private const val FST_MAGIC = 0x7EB2FDD6.toInt()
+    private const val SYMBOL_TABLE_MAGIC = 0x7EB2FB74
+    private const val FLAG_HAS_INPUT_SYMBOLS = 0x1
+
+    /** Properties, start state, state count and arc count: read past, never read. */
+    private const val HEADER_TAIL_BYTES = 32
+
+    // Bounds on what a truncated or mismatched file may claim, so a bad read fails rather than
+    // trying to allocate whatever the bytes happened to spell.
+    private const val MAX_SYMBOL_BYTES = 4096
+    private const val MAX_SYMBOLS = 10_000_000L
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordGrammar.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordGrammar.kt
@@ -24,6 +24,12 @@ object WakeWordGrammar {
      */
     fun normalize(phrase: String): String = phrase.trim().lowercase().replace(WHITESPACE, " ").ifBlank { DEFAULT_PHRASE }
 
+    /**
+     * The individual words the recogniser will be asked for, which is what the model's dictionary
+     * is checked against - a phrase is only recognisable if every word of it is.
+     */
+    fun words(phrase: String): List<String> = normalize(phrase).split(' ').filter(String::isNotBlank)
+
     fun grammarFor(phrase: String): String {
         val normalized = normalize(phrase)
         val entries = if (normalized == UNKNOWN) listOf(UNKNOWN) else listOf(normalized, UNKNOWN)

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordService.kt
@@ -40,7 +40,14 @@ class WakeWordService : Service() {
     @Volatile private var audioRecord: AudioRecord? = null
     private var wakeLock: PowerManager.WakeLock? = null
 
+    // What the running recogniser was actually built from, which is not the same as what settings
+    // hold: all three are read once when it is built, so a change to any of them only reaches
+    // detection by building a new one.
     @Volatile private var currentLanguage = VoskModelLanguage.ENGLISH
+
+    @Volatile private var currentPhrase: String? = null
+
+    @Volatile private var currentSensitivity: Float? = null
 
     @Volatile private var assistantRequestId: String? = null
     private var assistantTimeoutJob: Job? = null
@@ -115,6 +122,10 @@ class WakeWordService : Service() {
         return START_STICKY
     }
 
+    private fun phrase(): String = settings()?.wakeWordPhrase.orEmpty()
+
+    private fun sensitivity(): Float = settings()?.wakeWordSensitivity ?: DEFAULT_SENSITIVITY
+
     override fun onDestroy() {
         stopListening()
         assistantTimeoutJob?.cancel()
@@ -186,14 +197,29 @@ class WakeWordService : Service() {
         resetSession: Boolean = true,
     ) {
         if (micHoldToken != null) {
-            // The holder gets detection back when it releases the microphone.
+            // The holder gets detection back when it releases the microphone, and the recogniser it
+            // comes back with is built then - so a phrase applied during a hold still lands.
             currentLanguage = language
             return
         }
-        if (listenJob?.isActive == true && currentLanguage == language) return
+        val phrase = phrase()
+        val sensitivity = sensitivity()
+        // Comparing the language alone used to make an in-place restart a no-op, so editing the
+        // phrase left the old recogniser listening while the notification already advertised the
+        // new one - the only way to actually apply a phrase was to switch the wake word off and on.
+        if (
+            listenJob?.isActive == true &&
+            currentLanguage == language &&
+            currentPhrase == phrase &&
+            currentSensitivity == sensitivity
+        ) {
+            return
+        }
 
         val previousJob = listenJob
         currentLanguage = language
+        currentPhrase = phrase
+        currentSensitivity = sensitivity
         stopAudioRecord()
         previousJob?.cancel()
         if (resetSession) {
@@ -219,11 +245,22 @@ class WakeWordService : Service() {
                     stopSelf()
                     return@launch
                 }
+                // Vosk drops grammar entries the model has no dictionary entry for, leaving a
+                // recogniser that can never fire. Listening with one burns the battery and holds
+                // the microphone indicator on while looking, from the outside, exactly like a bug
+                // in the microphone - so it is refused rather than run.
+                val unknown = VoskVocabulary.unknownWords(modelDirectory, phrase)
+                if (!unknown.isNullOrEmpty()) {
+                    Log.e(TAG, "The ${language.id} model does not know $unknown - refusing to listen")
+                    persistEnabled(false)
+                    stopSelf()
+                    return@launch
+                }
                 val det =
                     VoskWakeWordDetector(
                         modelDirectory = modelDirectory,
-                        phrase = settings()?.wakeWordPhrase.orEmpty(),
-                        sensitivity = settings()?.wakeWordSensitivity ?: DEFAULT_SENSITIVITY,
+                        phrase = phrase,
+                        sensitivity = sensitivity,
                     )
                 if (!det.initialize()) {
                     Log.e(TAG, "Detector initialization failed")

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -128,7 +128,9 @@ fun NavGraphBuilder.settingsNavGraph(
         val previewSample = stringResource(R.string.tts_preview_sample)
         DisposableEffect(preview) { onDispose(preview::release) }
         // The phrase, sensitivity and model are all read when the recogniser is built, so a change
-        // only takes effect once the service has been restarted with it.
+        // only takes effect once the service has been restarted with it. Which is why applying is
+        // an explicit press rather than something that follows typing: restarting per keystroke
+        // reloaded a 40 MB model for every character of a phrase that was not finished yet.
         val restartWakeWord = {
             if (settingsState.wakeWordEnabled) {
                 val restarted =
@@ -223,14 +225,12 @@ fun NavGraphBuilder.settingsNavGraph(
                     com.yugahashimoto.andcode.feature.wakeword.WakeWordService.stop(context)
                 }
             },
-            onWakeWordPhraseChange = { phrase ->
+            onWakeWordApply = { phrase, sensitivity ->
                 settingsViewModel.setWakeWordPhrase(phrase)
-                restartWakeWord()
-            },
-            onWakeWordSensitivityChange = { sensitivity ->
                 settingsViewModel.setWakeWordSensitivity(sensitivity)
                 restartWakeWord()
             },
+            unknownWakeWordWords = settingsViewModel::unknownWakeWordWords,
             onWakeWordModelLanguageChange = { language ->
                 settingsViewModel.setWakeWordModelLanguage(language)
                 restartWakeWord()

--- a/app/src/main/res/values-ar/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-ar/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">قل كلمة التنبيه لإيقاف الإجابة المقروءة.</string>
     <string name="wake_word_phrase_label">كلمة التنبيه</string>
     <string name="wake_word_phrase_hint">أي عبارة قصيرة تصلح. اتركه فارغًا لاستخدام \"%1$s\".</string>
+    <string name="wake_word_phrase_unknown_words">لا يحتوي نموذج الكلام على مدخل لـ %1$s، لذا لن يُسمع أبدًا. جرّب تقسيمه إلى كلمات عادية.</string>
+    <string name="wake_word_apply">تطبيق</string>
+    <string name="wake_word_pending_changes">لم يُطبَّق بعد.</string>
+    <string name="wake_word_listening_for">الاستماع إلى \"%1$s\".</string>
+    <string name="wake_word_applied_phrase">كلمة التنبيه المطبَّقة: \"%1$s\".</string>
+    <string name="wake_word_blocked_by_phrase">غير متاح حتى تصبح كلمة التنبيه معروفة لنموذج الكلام.</string>
     <string name="wake_word_sensitivity_label">الحساسية</string>
     <string name="wake_word_sensitivity_hint">القيمة الأعلى تجعل التفعيل أصعب وتقلّل الإطلاق العرضي.</string>
     <string name="wake_word_model_language_label">نموذج الكلام</string>

--- a/app/src/main/res/values-es/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-es/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">Di la palabra de activación para cortar una respuesta en voz alta.</string>
     <string name="wake_word_phrase_label">Palabra de activación</string>
     <string name="wake_word_phrase_hint">Sirve cualquier frase corta. Déjalo vacío para usar \"%1$s\".</string>
+    <string name="wake_word_phrase_unknown_words">El modelo de voz no tiene ninguna entrada para %1$s, así que nunca podrá oírse. Prueba a dividirlo en palabras corrientes.</string>
+    <string name="wake_word_apply">Aplicar</string>
+    <string name="wake_word_pending_changes">Todavía sin aplicar.</string>
+    <string name="wake_word_listening_for">Escuchando \"%1$s\".</string>
+    <string name="wake_word_applied_phrase">Palabra de activación aplicada: \"%1$s\".</string>
+    <string name="wake_word_blocked_by_phrase">No disponible hasta que la palabra de activación sea una que el modelo de voz conozca.</string>
     <string name="wake_word_sensitivity_label">Sensibilidad</string>
     <string name="wake_word_sensitivity_hint">Un valor más alto cuesta más de activar y reduce los falsos positivos.</string>
     <string name="wake_word_model_language_label">Modelo de voz</string>

--- a/app/src/main/res/values-fr/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-fr/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">Dites le mot de réveil pour couper une réponse lue à voix haute.</string>
     <string name="wake_word_phrase_label">Mot de réveil</string>
     <string name="wake_word_phrase_hint">Toute phrase courte convient. Laissez vide pour utiliser \"%1$s\".</string>
+    <string name="wake_word_phrase_unknown_words">Le modèle vocal n\'a aucune entrée pour %1$s : il ne pourra jamais l\'entendre. Essayez de le découper en mots ordinaires.</string>
+    <string name="wake_word_apply">Appliquer</string>
+    <string name="wake_word_pending_changes">Pas encore appliqué.</string>
+    <string name="wake_word_listening_for">À l\'écoute de \"%1$s\".</string>
+    <string name="wake_word_applied_phrase">Mot de réveil appliqué : \"%1$s\".</string>
+    <string name="wake_word_blocked_by_phrase">Indisponible tant que le mot de réveil n\'est pas connu du modèle vocal.</string>
     <string name="wake_word_sensitivity_label">Sensibilité</string>
     <string name="wake_word_sensitivity_hint">Plus la valeur est haute, plus le déclenchement est difficile et les faux positifs rares.</string>
     <string name="wake_word_model_language_label">Modèle vocal</string>

--- a/app/src/main/res/values-ja/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-ja/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">読み上げ中にウェイクワードで停止できるようにします。</string>
     <string name="wake_word_phrase_label">ウェイクワード</string>
     <string name="wake_word_phrase_hint">短いフレーズなら何でも使えます。空欄の場合は「%1$s」になります。</string>
+    <string name="wake_word_phrase_unknown_words">音声モデルに %1$s の登録がないため、この語は永久に認識されません。通常の単語に分けてみてください。</string>
+    <string name="wake_word_apply">適用</string>
+    <string name="wake_word_pending_changes">まだ適用されていません。</string>
+    <string name="wake_word_listening_for">「%1$s」を待機中です。</string>
+    <string name="wake_word_applied_phrase">適用中のウェイクワード:「%1$s」</string>
+    <string name="wake_word_blocked_by_phrase">音声モデルが認識できるウェイクワードにするまで使用できません。</string>
     <string name="wake_word_sensitivity_label">感度</string>
     <string name="wake_word_sensitivity_hint">高くすると反応しにくくなり、誤検出も減ります。</string>
     <string name="wake_word_model_language_label">音声モデル</string>

--- a/app/src/main/res/values-pt-rBR/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-pt-rBR/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">Diga a palavra de ativação para cortar uma resposta falada.</string>
     <string name="wake_word_phrase_label">Palavra de ativação</string>
     <string name="wake_word_phrase_hint">Qualquer frase curta serve. Deixe vazio para usar \"%1$s\".</string>
+    <string name="wake_word_phrase_unknown_words">O modelo de voz não tem entrada para %1$s, então nunca poderá ouvi-lo. Tente dividir em palavras comuns.</string>
+    <string name="wake_word_apply">Aplicar</string>
+    <string name="wake_word_pending_changes">Ainda não aplicado.</string>
+    <string name="wake_word_listening_for">Ouvindo \"%1$s\".</string>
+    <string name="wake_word_applied_phrase">Palavra de ativação aplicada: \"%1$s\".</string>
+    <string name="wake_word_blocked_by_phrase">Indisponível até que a palavra de ativação seja uma que o modelo de voz conheça.</string>
     <string name="wake_word_sensitivity_label">Sensibilidade</string>
     <string name="wake_word_sensitivity_hint">Valores mais altos dificultam o acionamento e reduzem disparos acidentais.</string>
     <string name="wake_word_model_language_label">Modelo de voz</string>

--- a/app/src/main/res/values-ru/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-ru/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">Скажите слово активации, чтобы прервать зачитывание ответа.</string>
     <string name="wake_word_phrase_label">Слово активации</string>
     <string name="wake_word_phrase_hint">Подойдёт любая короткая фраза. Оставьте пустым, чтобы использовать «%1$s».</string>
+    <string name="wake_word_phrase_unknown_words">В речевой модели нет записи для %1$s, поэтому услышать это слово невозможно. Попробуйте разбить его на обычные слова.</string>
+    <string name="wake_word_apply">Применить</string>
+    <string name="wake_word_pending_changes">Ещё не применено.</string>
+    <string name="wake_word_listening_for">Ожидание \"%1$s\".</string>
+    <string name="wake_word_applied_phrase">Применённое ключевое слово: \"%1$s\".</string>
+    <string name="wake_word_blocked_by_phrase">Недоступно, пока ключевое слово не станет известным речевой модели.</string>
     <string name="wake_word_sensitivity_label">Чувствительность</string>
     <string name="wake_word_sensitivity_hint">Чем выше, тем труднее сработать и тем реже ложные срабатывания.</string>
     <string name="wake_word_model_language_label">Речевая модель</string>

--- a/app/src/main/res/values-zh-rCN/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-zh-rCN/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">说出唤醒词即可中断正在朗读的回复。</string>
     <string name="wake_word_phrase_label">唤醒词</string>
     <string name="wake_word_phrase_hint">任何短语都可以。留空则使用“%1$s”。</string>
+    <string name="wake_word_phrase_unknown_words">语音模型中没有 %1$s 这一条目，因此永远无法识别。请尝试拆分成常见词语。</string>
+    <string name="wake_word_apply">应用</string>
+    <string name="wake_word_pending_changes">尚未应用。</string>
+    <string name="wake_word_listening_for">正在等待“%1$s”。</string>
+    <string name="wake_word_applied_phrase">已应用的唤醒词：“%1$s”。</string>
+    <string name="wake_word_blocked_by_phrase">在唤醒词是语音模型认识的词之前不可用。</string>
     <string name="wake_word_sensitivity_label">灵敏度</string>
     <string name="wake_word_sensitivity_hint">数值越高越难触发，误触也越少。</string>
     <string name="wake_word_model_language_label">语音模型</string>

--- a/app/src/main/res/values/ui_cleanup_strings.xml
+++ b/app/src/main/res/values/ui_cleanup_strings.xml
@@ -64,6 +64,12 @@
     <string name="wake_word_barge_in_description">Say the wake word to cut a spoken answer short.</string>
     <string name="wake_word_phrase_label">Wake word</string>
     <string name="wake_word_phrase_hint">Any short phrase works. Leave empty to use \"%1$s\".</string>
+    <string name="wake_word_phrase_unknown_words">The speech model has no entry for %1$s, so it can never be heard. Try splitting it into ordinary words.</string>
+    <string name="wake_word_apply">Apply</string>
+    <string name="wake_word_pending_changes">Not applied yet.</string>
+    <string name="wake_word_listening_for">Listening for \"%1$s\".</string>
+    <string name="wake_word_applied_phrase">Applied wake word: \"%1$s\".</string>
+    <string name="wake_word_blocked_by_phrase">Unavailable until the wake word is one the speech model knows.</string>
     <string name="wake_word_sensitivity_label">Sensitivity</string>
     <string name="wake_word_sensitivity_hint">Higher is harder to trigger and less likely to fire by accident.</string>
     <string name="wake_word_model_language_label">Speech model</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/wakeword/VoskVocabularyTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/wakeword/VoskVocabularyTest.kt
@@ -1,0 +1,135 @@
+package com.yugahashimoto.andcode.feature.wakeword
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+/**
+ * The dictionary check that stands between a typed phrase and a recogniser that can never fire.
+ *
+ * The two readers exist because the two shipped models disagree: the Japanese one carries
+ * `graph/words.txt`, the English one keeps its words only inside the `graph/Gr.fst` header.
+ */
+class VoskVocabularyTest {
+    @get:Rule val folder = TemporaryFolder()
+
+    @Test
+    fun `a phrase made of known words has nothing unknown about it`() {
+        val model = modelWithWordList("hey", "and", "code")
+
+        assertEquals(emptyList<String>(), VoskVocabulary.unknownWords(model, "Hey And Code"))
+    }
+
+    @Test
+    fun `the word the model does not know is named, not just rejected`() {
+        // Naming it is the whole point: "andcode" is one keystroke away from "and code", and the
+        // failure it causes is otherwise silent.
+        val model = modelWithWordList("hey", "and", "code")
+
+        assertEquals(listOf("andcode"), VoskVocabulary.unknownWords(model, "hey andcode"))
+    }
+
+    @Test
+    fun `every unknown word is reported, not only the first`() {
+        val model = modelWithWordList("hey", "and", "code")
+
+        assertEquals(listOf("ok", "andcode"), VoskVocabulary.unknownWords(model, "ok andcode"))
+    }
+
+    @Test
+    fun `a word list carries an id after each word`() {
+        // Vosk writes "<word> <id>" per line, and the id is nobody's business here.
+        val model = folder.newFolder("ja")
+        File(model, "graph").mkdirs()
+        File(model, "graph/words.txt").writeText("<eps> 0\nヘイ 29549\nアンド 190303\nコード 74374\n")
+
+        assertEquals(emptyList<String>(), VoskVocabulary.unknownWords(model, "ヘイ アンド コード"))
+        assertEquals(listOf("アンドコード"), VoskVocabulary.unknownWords(model, "ヘイ アンドコード"))
+    }
+
+    @Test
+    fun `the English model is read out of the grammar archive instead`() {
+        // vosk-model-small-en-us-0.15 ships no words.txt at all - its word symbols live in the
+        // OpenFst header of Gr.fst, which is the only place left to look.
+        val model = folder.newFolder("en")
+        File(model, "graph").mkdirs()
+        File(model, "graph/Gr.fst").writeBytes(grammarArchive("<eps>", "hey", "and", "code"))
+
+        assertEquals(emptyList<String>(), VoskVocabulary.unknownWords(model, "hey and code"))
+        assertEquals(listOf("andcode"), VoskVocabulary.unknownWords(model, "hey andcode"))
+    }
+
+    @Test
+    fun `an unreadable dictionary is not treated as a bad phrase`() {
+        // Refusing to listen because the check itself failed would be worse than the mistake it
+        // is there to catch, so "cannot tell" is its own answer.
+        val empty = folder.newFolder("empty")
+
+        assertNull(VoskVocabulary.unknownWords(empty, "hey and code"))
+    }
+
+    @Test
+    fun `a truncated grammar archive reads as unknown rather than as a pass`() {
+        val model = folder.newFolder("torn")
+        File(model, "graph").mkdirs()
+        File(model, "graph/Gr.fst").writeBytes(grammarArchive("hey").copyOfRange(0, 20))
+
+        assertNull(VoskVocabulary.unknownWords(model, "hey"))
+    }
+
+    @Test
+    fun `a blank phrase is the default phrase, which the model must still know`() {
+        val model = modelWithWordList("hey", "and", "code")
+
+        assertEquals(emptyList<String>(), VoskVocabulary.unknownWords(model, "   "))
+    }
+
+    private fun modelWithWordList(vararg words: String): File {
+        val model = folder.newFolder(words.joinToString("-"))
+        File(model, "graph").mkdirs()
+        File(model, "graph/words.txt").writeText(words.mapIndexed { index, word -> "$word $index" }.joinToString("\n"))
+        return model
+    }
+
+    /**
+     * An OpenFst archive carrying nothing but the symbol table this reads: magic, the two
+     * length-prefixed type names, version and flags, the five fixed-width fields nothing here
+     * needs, and then the table itself.
+     */
+    private fun grammarArchive(vararg symbols: String): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.writeLittleEndianInt(0x7EB2FDD6.toInt())
+        out.writeLengthPrefixed("ngram")
+        out.writeLengthPrefixed("standard")
+        out.writeLittleEndianInt(4)
+        out.writeLittleEndianInt(3)
+        repeat(32) { out.write(0) }
+        out.writeLittleEndianInt(0x7EB2FB74)
+        out.writeLengthPrefixed("words.txt")
+        out.writeLittleEndianLong(symbols.size.toLong())
+        out.writeLittleEndianLong(symbols.size.toLong())
+        symbols.forEachIndexed { index, symbol ->
+            out.writeLengthPrefixed(symbol)
+            out.writeLittleEndianLong(index.toLong())
+        }
+        return out.toByteArray()
+    }
+
+    private fun ByteArrayOutputStream.writeLittleEndianInt(value: Int) {
+        repeat(4) { write((value ushr (it * 8)) and 0xFF) }
+    }
+
+    private fun ByteArrayOutputStream.writeLittleEndianLong(value: Long) {
+        repeat(8) { write(((value ushr (it * 8)) and 0xFF).toInt()) }
+    }
+
+    private fun ByteArrayOutputStream.writeLengthPrefixed(value: String) {
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        writeLittleEndianInt(bytes.size)
+        write(bytes)
+    }
+}


### PR DESCRIPTION
## The bug

The wake word was running, holding the microphone, and could never fire. Captured from the device:

```
08-04 00:19:13.884  VoskWakeWord: Initialized for "andcode"
08-04 00:19:13.896  WakeWordService: Wake word listening started
```

`dumpsys audio` confirmed capture was healthy the whole time — `VOICE_RECOGNITION 16000Hz ... silenced:false`. The recogniser was the problem, not the microphone.

A phrase reaches Vosk as a grammar, and Vosk **drops any entry the model has no dictionary entry for**, warning to native stderr — which Android discards. The grammar collapses to `[unk]` alone and nothing can ever match. `andcode` is exactly such a phrase, and it is one keystroke from `and code`, which is not.

Read out of the shipped models:

| phrase | `vosk-model-small-en-us-0.15` | `vosk-model-small-ja-0.22` |
|---|---|---|
| `hey and code` | ok | **`hey`, `and`, `code` all unknown** |
| `andcode` | **`andcode` unknown** | — |
| `ヘイ アンド コード` | — | ok |
| `ヘイ アンドコード` | — | **`アンドコード` unknown** |

The bottom-left cell is the same trap by another route: the default phrase is English regardless of model, so selecting the Japanese model breaks the wake word at stock settings.

## Two more defects found alongside it

**Applying a phrase never worked while detection ran.** `startListening` compared only the language, so the in-place restart returned without rebuilding anything. `startForegroundWithNotification` ran first and advertised the new phrase over a recogniser still listening for the old one. Device logs show it directly — many keystrokes between 00:17:25 and 00:18:10 produced no `Initialized for` line; the phrase only took effect at 00:18:11, after the wake word was switched off and on.

**Restart fired per keystroke.** Each one reloaded a 40 MB model (~1.2s) for a phrase nobody had finished typing.

## The fix

`VoskVocabulary` reads the model's word list before the phrase reaches the recogniser. Where that list lives differs by model — the Japanese one ships `graph/words.txt`, the English one ships none and keeps its symbols only in the OpenFst header of `graph/Gr.fst` — so both are read, streaming, holding only the words asked about rather than the dictionary.

- Settings names the offending words and blocks enabling detection.
- The service checks again and refuses rather than listening with a grammar it knows is dead.
- An unreadable dictionary counts as *cannot tell* and blocks nothing: failing the check is a worse outcome than the mis-detection it prevents.
- `startListening` now compares the phrase and sensitivity it was built with.
- Phrase and sensitivity are edited as a draft and applied by a press, with what detection is *actually* listening for shown beside the button.

Per the author's call, the Japanese default phrase is left as-is — the dictionary warning is what surfaces it.

## Test plan

- [x] `VoskVocabularyTest` — 8 new cases covering both readers, multiple unknown words, truncated archives, and unreadable models
- [x] Both readers verified against the **real downloaded models**, producing the table above
- [x] `./gradlew testDebugUnitTest spotlessCheck detekt`
- [ ] On-device: a valid phrase actually fires detection — **not yet observed.** The OOV finding fully explains the current no-op, but the successful path is unverified. No release signing key is available locally, so a build cannot be installed over the existing release without wiping app data and the ~90 MB of downloaded models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)