### PR TITLE
fix: prevent completed chats from showing as running

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
@@ -37,6 +37,8 @@ interface UnreadSessionStore {
 data class RuntimeActivityState(
     val activeSessionIds: Set<String> = emptySet(),
     val completedSessionIds: Set<String> = emptySet(),
+    /** Sessions whose current run has ended; late stream events must not resurrect them. */
+    val settledSessionIds: Set<String> = emptySet(),
     val permissions: List<PermissionRequest> = emptyList(),
     val logs: List<RuntimeEventLog> = emptyList(),
     val streamError: String? = null,
@@ -165,6 +167,7 @@ class RuntimeActivityRepository(
             current.copy(
                 activeSessionIds = current.activeSessionIds + sessionId,
                 completedSessionIds = current.completedSessionIds - sessionId,
+                settledSessionIds = current.settledSessionIds - sessionId,
             )
         }
         persistUnread()
@@ -185,6 +188,7 @@ class RuntimeActivityRepository(
                     } else {
                         current.completedSessionIds - sessionId
                     },
+                settledSessionIds = current.settledSessionIds + sessionId,
             )
         }
         persistUnread()
@@ -203,7 +207,7 @@ class RuntimeActivityRepository(
             is OpenCodeEvent.MessagePartUpdated -> {
                 val sessionId = event.part.sessionId ?: return
                 mutableState.update { current ->
-                    if (sessionId in current.completedSessionIds) {
+                    if (sessionId in current.settledSessionIds || sessionId in current.completedSessionIds) {
                         current
                     } else {
                         current.copy(activeSessionIds = current.activeSessionIds + sessionId)
@@ -216,7 +220,7 @@ class RuntimeActivityRepository(
             }
             is OpenCodeEvent.MessagePartDelta -> {
                 mutableState.update { current ->
-                    if (event.sessionId in current.completedSessionIds) {
+                    if (event.sessionId in current.settledSessionIds || event.sessionId in current.completedSessionIds) {
                         current
                     } else {
                         current.copy(activeSessionIds = current.activeSessionIds + event.sessionId)
@@ -242,6 +246,7 @@ class RuntimeActivityRepository(
                     current.copy(
                         activeSessionIds = current.activeSessionIds - event.sessionId,
                         completedSessionIds = current.completedSessionIds + event.sessionId,
+                        settledSessionIds = current.settledSessionIds + event.sessionId,
                     )
                 }
                 appendLog(messages.eventCompleted, null, event.sessionId)
@@ -254,7 +259,7 @@ class RuntimeActivityRepository(
             }
             is OpenCodeEvent.MessageUpdated -> {
                 mutableState.update { current ->
-                    if (event.info.sessionId in current.completedSessionIds) {
+                    if (event.info.sessionId in current.settledSessionIds || event.info.sessionId in current.completedSessionIds) {
                         current
                     } else {
                         current.copy(activeSessionIds = current.activeSessionIds + event.info.sessionId)
@@ -274,10 +279,22 @@ class RuntimeActivityRepository(
                         activeSessionIds =
                             if (event.status == "idle") {
                                 current.activeSessionIds - event.sessionId
-                            } else if (event.sessionId in current.completedSessionIds) {
-                                current.activeSessionIds
                             } else {
                                 current.activeSessionIds + event.sessionId
+                            },
+                        completedSessionIds =
+                            if (event.status == "idle") {
+                                current.completedSessionIds + event.sessionId
+                            } else if (event.sessionId in current.completedSessionIds) {
+                                current.completedSessionIds - event.sessionId
+                            } else {
+                                current.completedSessionIds
+                            },
+                        settledSessionIds =
+                            if (event.status == "idle") {
+                                current.settledSessionIds + event.sessionId
+                            } else {
+                                current.settledSessionIds - event.sessionId
                             },
                     )
                 }
@@ -285,7 +302,10 @@ class RuntimeActivityRepository(
             is OpenCodeEvent.SessionError -> {
                 event.sessionId?.let { sessionId ->
                     mutableState.update { current ->
-                        current.copy(activeSessionIds = current.activeSessionIds - sessionId)
+                        current.copy(
+                            activeSessionIds = current.activeSessionIds - sessionId,
+                            settledSessionIds = current.settledSessionIds + sessionId,
+                        )
                     }
                 }
                 appendLog(messages.eventError, event.message, event.sessionId)

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -37,7 +37,10 @@ sealed interface TimelineEntry {
 }
 
 /** Compose key for a detail-row part; the stream can repeat an OpenCode part id. */
-internal fun activityPartKey(index: Int, part: ChatPart): String = "activity-part:$index:${part.id}"
+internal fun activityPartKey(
+    index: Int,
+    part: ChatPart,
+): String = "activity-part:$index:${part.id}"
 
 /** Broad buckets used to summarise a run of tool calls in one line. */
 enum class ToolCategory { COMMAND, READ, EDIT, SUBAGENT, OTHER }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -36,6 +36,9 @@ sealed interface TimelineEntry {
     ) : TimelineEntry
 }
 
+/** Compose key for a detail-row part; the stream can repeat an OpenCode part id. */
+internal fun activityPartKey(index: Int, part: ChatPart): String = "activity-part:$index:${part.id}"
+
 /** Broad buckets used to summarise a run of tool calls in one line. */
 enum class ToolCategory { COMMAND, READ, EDIT, SUBAGENT, OTHER }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -173,7 +173,7 @@ fun AssistantActivitySheet(
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            items(parts, key = { it.id }) { part ->
+            itemsIndexed(parts, key = ::activityPartKey) { _, part ->
                 when (part) {
                     is ChatPart.Reasoning -> ReasoningCard(part)
                     is ChatPart.Tool -> ToolCard(part)

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.yugahashimoto.andcode.core.api.OpenCodeAgent
 import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import com.yugahashimoto.andcode.core.api.OpenCodeHealth
 import com.yugahashimoto.andcode.core.api.OpenCodeMessage
+import com.yugahashimoto.andcode.core.api.OpenCodeMessageInfo
 import com.yugahashimoto.andcode.core.api.OpenCodeSession
 import com.yugahashimoto.andcode.core.api.PromptRequest
 import com.yugahashimoto.andcode.core.api.ProviderCatalog
@@ -171,6 +172,59 @@ class RuntimeActivityRepositoryTest {
             assertEquals(setOf("ses_1"), repository.state.value.completedSessionIds)
 
             repository.markSessionRead("ses_1")
+            assertTrue(repository.state.value.completedSessionIds.isEmpty())
+        }
+
+    @Test
+    fun `late message events do not resurrect a chat finished locally`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val repository = RuntimeActivityRepository(registry, TestScope(dispatcher))
+            advanceUntilIdle()
+
+            repository.markSessionRunning("ses_1")
+            repository.markSessionFinished("ses_1", unread = false)
+            target.eventFlow.emit(
+                OpenCodeEvent.MessageUpdated(
+                    OpenCodeMessageInfo(
+                        id = "msg_final",
+                        sessionId = "ses_1",
+                        role = "assistant",
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(repository.state.value.activeSessionIds.isEmpty())
+        }
+
+    @Test
+    fun `a new busy status can reactivate a previously settled chat`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val repository = RuntimeActivityRepository(registry, TestScope(dispatcher))
+            advanceUntilIdle()
+
+            repository.markSessionRunning("ses_1")
+            repository.markSessionFinished("ses_1", unread = true)
+            target.eventFlow.emit(OpenCodeEvent.SessionStatusChanged("ses_1", "busy"))
+            advanceUntilIdle()
+
+            assertEquals(setOf("ses_1"), repository.state.value.activeSessionIds)
             assertTrue(repository.state.value.completedSessionIds.isEmpty())
         }
 

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
@@ -293,4 +293,17 @@ class AssistantActivityGroupTest {
         assertEquals("image:i1", image.id)
         assertEquals("see above", (entries[2] as TimelineEntry.Body).part.text)
     }
+
+    @Test
+    fun `activity part keys are unique when streamed parts reuse an id`() {
+        val parts =
+            listOf(
+                tool("toolu_duplicate", "bash"),
+                tool("toolu_duplicate", "read"),
+            )
+
+        val keys = parts.mapIndexed(::activityPartKey)
+
+        assertEquals(parts.size, keys.toSet().size)
+    }
 }


### PR DESCRIPTION
## Summary
- keep locally finished sessions settled so late message events cannot resurrect the running indicator
- allow a new busy status to reactivate a settled session
- avoid duplicate Compose keys in the activity details list

## Validation
- `./gradlew testDebugUnitTest`
- `./gradlew assembleDebug`
- installed and smoke-tested on Android device `1ff6a149`
- verified animation scales are all `1`