### PR TITLE
fix: make chat drawer follow edge swipe

### DIFF
--- a/app/src/androidTest/java/com/yugahashimoto/andcode/ui/DrawerGestureInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/yugahashimoto/andcode/ui/DrawerGestureInstrumentedTest.kt
@@ -1,0 +1,74 @@
+package com.yugahashimoto.andcode.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DrawerGestureInstrumentedTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun swipeFromTheCenterDoesNotOpenTheDrawer() {
+        setDrawerContent()
+
+        composeRule.onNodeWithTag("screen-content").performTouchInput {
+            swipe(Offset(300f, 400f), Offset(700f, 400f))
+        }
+
+        composeRule.onNodeWithTag("drawer-content").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun swipeFromTheLeftEdgeOpensTheDrawer() {
+        setDrawerContent()
+
+        composeRule.onNodeWithTag("screen-content").performTouchInput {
+            swipe(Offset(8f, 400f), Offset(500f, 400f))
+        }
+
+        composeRule.onNodeWithTag("drawer-content").assertIsDisplayed()
+    }
+
+    private fun setDrawerContent() {
+        composeRule.setContent {
+            val drawerState = rememberDrawerState(DrawerValue.Closed)
+            ModalNavigationDrawer(
+                modifier = Modifier.onlyAllowDrawerEdgeSwipe(),
+                drawerState = drawerState,
+                drawerContent = {
+                    ModalDrawerSheet {
+                        Text("Drawer", modifier = Modifier.testTag("drawer-content"))
+                    }
+                },
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .testTag("screen-content"),
+                )
+            }
+        }
+        composeRule.waitForIdle()
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -309,25 +309,8 @@ fun ChatHomeScreen(
             Modifier
                 .fillMaxSize()
                 .pointerInput(showSidePanel) {
-                    val edgeWidthPx = 48.dp.toPx()
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
-                        if (!showSidePanel && down.position.x <= edgeWidthPx) {
-                            var overSlop = 0f
-                            awaitHorizontalTouchSlopOrCancellation(down.id) { change, over ->
-                                overSlop = over
-                                if (over > 0f) change.consume()
-                            } ?: return@awaitEachGesture
-                            if (overSlop <= 0f) return@awaitEachGesture
-                            onOpenDrawer()
-                            while (true) {
-                                val event = awaitPointerEvent()
-                                val change = event.changes.firstOrNull { it.id == down.id } ?: break
-                                if (!change.pressed) break
-                                change.consume()
-                            }
-                            return@awaitEachGesture
-                        }
                         val onRightEdge = down.position.x > size.width - 80f || showSidePanel
                         if (!onRightEdge) return@awaitEachGesture
                         awaitHorizontalTouchSlopOrCancellation(down.id) { change, _ ->

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -660,13 +660,21 @@ fun AndCodeApp(
         if (drawerState.isOpen) keyboardController?.hide()
     }
 
+    val drawerGesturesEnabled = currentRoute in DRAWER_ROOT_ROUTES
+
     AndCodeTheme(
         appTheme = AppTheme.fromKey(preferences.theme),
         uiFontSize = preferences.uiFontSize,
     ) {
         ModalNavigationDrawer(
+            modifier =
+                if (drawerGesturesEnabled) {
+                    Modifier.onlyAllowDrawerEdgeSwipe(drawerIsOpen = drawerState.isOpen)
+                } else {
+                    Modifier
+                },
             drawerState = drawerState,
-            gesturesEnabled = currentRoute in DRAWER_ROOT_ROUTES,
+            gesturesEnabled = drawerGesturesEnabled,
             drawerContent = {
                 ModalDrawerSheet {
                     AppDrawerContent(

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/DrawerGestures.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/DrawerGestures.kt
@@ -1,0 +1,39 @@
+package com.yugahashimoto.andcode.ui
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+private val DrawerEdgeWidth = 48.dp
+
+internal fun isDrawerGestureAllowed(
+    startX: Float,
+    edgeWidthPx: Float,
+    drawerIsOpen: Boolean,
+): Boolean = drawerIsOpen || startX in 0f..edgeWidthPx
+
+/**
+ * Keeps the drawer's built-in drag behavior while limiting its gesture start area to the leading
+ * edge. The drawer remains responsible for tracking the finger and settling to an anchor.
+ */
+internal fun Modifier.onlyAllowDrawerEdgeSwipe(
+    edgeWidth: Dp = DrawerEdgeWidth,
+    drawerIsOpen: Boolean = false,
+): Modifier =
+    pointerInput(edgeWidth, drawerIsOpen) {
+        val edgeWidthPx = edgeWidth.toPx()
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false)
+            if (isDrawerGestureAllowed(down.position.x, edgeWidthPx, drawerIsOpen)) {
+                return@awaitEachGesture
+            }
+
+            awaitHorizontalTouchSlopOrCancellation(down.id) { change, overSlop ->
+                if (overSlop > 0f) change.consume()
+            }
+        }
+    }

--- a/app/src/test/java/com/yugahashimoto/andcode/ui/DrawerGesturesTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/ui/DrawerGesturesTest.kt
@@ -1,0 +1,24 @@
+package com.yugahashimoto.andcode.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DrawerGesturesTest {
+    @Test
+    fun `allows a drawer gesture that starts inside the edge hit target`() {
+        assertTrue(isDrawerGestureAllowed(startX = 0f, edgeWidthPx = 48f, drawerIsOpen = false))
+        assertTrue(isDrawerGestureAllowed(startX = 48f, edgeWidthPx = 48f, drawerIsOpen = false))
+    }
+
+    @Test
+    fun `rejects a drawer gesture that starts away from the edge`() {
+        assertFalse(isDrawerGestureAllowed(startX = 48.1f, edgeWidthPx = 48f, drawerIsOpen = false))
+        assertFalse(isDrawerGestureAllowed(startX = 240f, edgeWidthPx = 48f, drawerIsOpen = false))
+    }
+
+    @Test
+    fun `allows a closing gesture from any position while the drawer is open`() {
+        assertTrue(isDrawerGestureAllowed(startX = 240f, edgeWidthPx = 48f, drawerIsOpen = true))
+    }
+}


### PR DESCRIPTION
## Summary
- remove the chat screen's immediate drawer-open gesture handler
- keep Material 3 drawer dragging so the sheet follows the finger
- limit opening gestures to the left edge while preserving close swipes when open
- add unit and Compose UI coverage for the gesture boundary

## Verification
- `./gradlew :app:testDebugUnitTest :app:assembleDebug :app:assembleDebugAndroidTest :app:lintDebug`
- Physical-device test intentionally omitted per request
- Local `spotlessCheck` is blocked by the existing `ClaudeCodeInstaller.kt` formatter non-convergence
