### PR TITLE
fix: settle failed Claude Code activity state

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeRuntime.kt
@@ -225,7 +225,13 @@ class ClaudeCodeRuntime(
         auth.cancel()
     }
 
-    fun listMessages(sessionId: String): List<OpenCodeMessage> = messageStore.list(sessionId)
+    @Synchronized
+    fun listMessages(sessionId: String): List<OpenCodeMessage> {
+        if (sessions[sessionId]?.process?.isAlive != true) {
+            return messageStore.settleRunningTools(sessionId, INTERRUPTED_TOOL_ERROR)
+        }
+        return messageStore.list(sessionId)
+    }
 
     @Synchronized
     fun deleteSessionData(sessionId: String) {
@@ -642,5 +648,6 @@ class ClaudeCodeRuntime(
         const val TITLE_MAX_LENGTH = 60
         const val TITLE_TIMEOUT_SECONDS = 45L
         const val WORKSPACE_COMMAND_TIMEOUT_SECONDS = 60L
+        const val INTERRUPTED_TOOL_ERROR = "Claude Code session ended before the tool result was received"
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeMessageStore.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeMessageStore.kt
@@ -3,6 +3,9 @@ package com.yugahashimoto.andcode.runtime.local
 import com.yugahashimoto.andcode.core.api.OpenCodeMessage
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import java.io.File
 
 /**
@@ -28,6 +31,46 @@ class ClaudeMessageStore(
 
     @Synchronized
     fun list(sessionId: String): List<OpenCodeMessage> = messages[sessionId].orEmpty().toList()
+
+    /**
+     * Converts tool calls left in an in-flight state by a process that disappeared into a
+     * terminal error. This is also applied to history loaded after an app restart, where there is
+     * no stream event left to do the cleanup.
+     */
+    @Synchronized
+    fun settleRunningTools(
+        sessionId: String,
+        error: String,
+    ): List<OpenCodeMessage> {
+        val existing = messages[sessionId].orEmpty()
+        val updated =
+            existing.map { message ->
+                message.copy(
+                    parts =
+                        message.parts.map { part ->
+                            val status = part.state?.get("status")?.jsonPrimitive?.contentOrNull
+                            if (part.type == "tool" && status in setOf("running", "pending")) {
+                                part.copy(
+                                    state =
+                                        part.state.orEmpty() +
+                                            mapOf(
+                                                "status" to JsonPrimitive("error"),
+                                                "error" to JsonPrimitive(error),
+                                            ),
+                                )
+                            } else {
+                                part
+                            }
+                        },
+                )
+            }
+        if (updated != existing) {
+            messages[sessionId] = updated.toMutableList()
+            dirty = true
+            flush()
+        }
+        return updated.toList()
+    }
 
     /** Adds [message], replacing any earlier version of the same message id. */
     @Synchronized

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParser.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParser.kt
@@ -45,6 +45,15 @@ class ClaudeStreamJsonParser(
 
     private var currentMessageId: String? = null
 
+    /** Tool calls that have not received a matching tool_result from Claude Code yet. */
+    private val openTools = linkedMapOf<String, OpenTool>()
+    private val messagesById = linkedMapOf<String, OpenCodeMessage>()
+
+    private data class OpenTool(
+        val messageId: String,
+        val partId: String,
+    )
+
     fun parse(line: String): Parsed {
         val root = runCatching { json.parseToJsonElement(line).jsonObject }.getOrNull() ?: return Parsed()
         return when (root.string("type")) {
@@ -78,27 +87,38 @@ class ClaudeStreamJsonParser(
                 is JsonPrimitive -> listOf(JsonObject(mapOf("type" to JsonPrimitive("text"), "text" to content)))
                 else -> emptyList()
             }
-        val parts = blocks.mapNotNull { block -> parseContentBlock(messageId, block) }
+        val parts =
+            buildList {
+                blocks.forEach { block ->
+                    val part = parseContentBlock(messageId, block) ?: return@forEach
+                    add(part)
+                    val partId = part.id ?: return@forEach
+                    when (block.string("type")) {
+                        "tool_use" -> openTools[partId] = OpenTool(messageId, partId)
+                        "tool_result" -> openTools.remove(block.string("tool_use_id") ?: partId)
+                    }
+                }
+            }
         if (parts.isEmpty()) return Parsed()
         // Tool results arrive on a "user" message; surfacing them as assistant activity keeps the
         // transcript readable instead of interleaving fake user turns.
         val effectiveRole = if (role == "user") "assistant" else role
+        val parsedMessage =
+            OpenCodeMessage(
+                info =
+                    OpenCodeMessageInfo(
+                        id = messageId,
+                        sessionId = sessionId,
+                        role = effectiveRole,
+                        time = now(),
+                        agent = "claude",
+                    ),
+                parts = parts,
+            )
+        messagesById[messageId] = parsedMessage
         return Parsed(
             events = parts.map { OpenCodeEvent.MessagePartUpdated(it) },
-            messages =
-                listOf(
-                    OpenCodeMessage(
-                        info =
-                            OpenCodeMessageInfo(
-                                id = messageId,
-                                sessionId = sessionId,
-                                role = effectiveRole,
-                                time = now(),
-                                agent = "claude",
-                            ),
-                        parts = parts,
-                    ),
-                ),
+            messages = listOf(parsedMessage),
             claudeSessionId = root.string("session_id"),
             resolvedModel = message.string("model"),
             todos = blocks.firstNotNullOfOrNull(::parseTodos),
@@ -122,8 +142,10 @@ class ClaudeStreamJsonParser(
         val subtype = root.string("subtype")
         if (isError || (subtype != null && subtype != "success")) {
             val message = root.string("result") ?: subtype ?: "Claude Code reported an error"
+            val settled = settleOpenTools(message)
             return Parsed(
-                events = listOf(OpenCodeEvent.SessionError(sessionId, message), OpenCodeEvent.SessionIdle(sessionId)),
+                events = settled.events + OpenCodeEvent.SessionError(sessionId, message) + OpenCodeEvent.SessionIdle(sessionId),
+                messages = settled.messages,
                 claudeSessionId = claudeSessionId,
                 turnFinished = true,
                 errorMessage = message,
@@ -135,6 +157,50 @@ class ClaudeStreamJsonParser(
             claudeSessionId = claudeSessionId,
             turnFinished = true,
         )
+    }
+
+    private data class SettledTools(
+        val messages: List<OpenCodeMessage>,
+        val events: List<OpenCodeEvent>,
+    )
+
+    /** Persists a terminal state for tools whose result was lost with the failed API turn. */
+    private fun settleOpenTools(error: String): SettledTools {
+        if (openTools.isEmpty()) return SettledTools(emptyList(), emptyList())
+        val settledPartIds = openTools.keys.toSet()
+        val openByMessage = openTools.values.groupBy(OpenTool::messageId)
+        val messages =
+            openByMessage.mapNotNull { (messageId, tools) ->
+                val original = messagesById[messageId] ?: return@mapNotNull null
+                val openPartIds = tools.mapTo(mutableSetOf(), OpenTool::partId)
+                val updatedParts =
+                    original.parts.map { part ->
+                        if (part.id !in openPartIds || part.type != "tool") {
+                            part
+                        } else {
+                            part.copy(
+                                state =
+                                    part.state.orEmpty() +
+                                        mapOf(
+                                            "status" to JsonPrimitive("error"),
+                                            "error" to JsonPrimitive(error),
+                                        ),
+                            )
+                        }
+                    }
+                val updated = original.copy(parts = updatedParts)
+                messagesById[messageId] = updated
+                updated
+            }
+        val events =
+            messages.flatMap { message ->
+                message.parts.filter { part ->
+                    part.type == "tool" && part.id?.let(settledPartIds::contains) == true
+                }
+                    .map(OpenCodeEvent::MessagePartUpdated)
+            }
+        openTools.clear()
+        return SettledTools(messages, events)
     }
 
     private fun parseContentBlock(

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import com.yugahashimoto.andcode.core.api.OpenCodeHealth
 import com.yugahashimoto.andcode.core.api.OpenCodeMessage
 import com.yugahashimoto.andcode.core.api.OpenCodeMessageInfo
+import com.yugahashimoto.andcode.core.api.OpenCodePart
 import com.yugahashimoto.andcode.core.api.OpenCodeSession
 import com.yugahashimoto.andcode.core.api.PromptRequest
 import com.yugahashimoto.andcode.core.api.ProviderCatalog
@@ -400,6 +401,37 @@ class RuntimeActivityRepositoryTest {
             advanceUntilIdle()
 
             assertTrue(completed.isEmpty())
+        }
+
+    @Test
+    fun `late tool events after a session error do not resurrect activity`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val repository = RuntimeActivityRepository(registry, TestScope(dispatcher))
+            advanceUntilIdle()
+
+            target.eventFlow.emit(OpenCodeEvent.SessionError("ses_1", "API disconnected"))
+            advanceUntilIdle()
+            target.eventFlow.emit(
+                OpenCodeEvent.MessagePartUpdated(
+                    OpenCodePart(
+                        id = "tool-1",
+                        sessionId = "ses_1",
+                        type = "tool",
+                        tool = "Bash",
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(repository.state.value.activeSessionIds.isEmpty())
         }
 
     private class FakeUnreadStore(

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
@@ -174,6 +174,16 @@ class AssistantActivityGroupTest {
     }
 
     @Test
+    fun `activity part keys stay unique when Claude repeats a call id`() {
+        val parts = listOf(tool("call-1", "bash"), tool("call-1", "bash", status = ToolStatus.ERROR))
+
+        assertEquals(
+            listOf("activity-part:0:call-1", "activity-part:1:call-1"),
+            parts.mapIndexed(::activityPartKey),
+        )
+    }
+
+    @Test
     fun `flags a run that contains a failed tool`() {
         val summary = summarizeActivity(listOf(tool("t1", "bash"), tool("t2", "bash", status = ToolStatus.ERROR)))
 

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeMessageStoreTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeMessageStoreTest.kt
@@ -1,0 +1,64 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import com.yugahashimoto.andcode.core.api.OpenCodeMessage
+import com.yugahashimoto.andcode.core.api.OpenCodeMessageInfo
+import com.yugahashimoto.andcode.core.api.OpenCodePart
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class ClaudeMessageStoreTest {
+    @Test
+    fun `settles persisted running tools without changing completed tools`() {
+        val file = File.createTempFile("claude-message-store", ".json").also(File::delete)
+        val json = Json { encodeDefaults = true }
+        val store = ClaudeMessageStore(file, json)
+        val sessionId = "session-1"
+        val message =
+            OpenCodeMessage(
+                info = OpenCodeMessageInfo("message-1", sessionId, "assistant"),
+                parts =
+                    listOf(
+                        OpenCodePart(
+                            id = "running-tool",
+                            sessionId = sessionId,
+                            messageId = "message-1",
+                            type = "tool",
+                            tool = "Bash",
+                            state = mapOf("status" to JsonPrimitive("running")),
+                        ),
+                        OpenCodePart(
+                            id = "completed-tool",
+                            sessionId = sessionId,
+                            messageId = "message-1",
+                            type = "tool",
+                            tool = "Bash",
+                            state = mapOf("status" to JsonPrimitive("completed")),
+                        ),
+                    ),
+            )
+        store.upsert(sessionId, message)
+        store.flush()
+
+        val reloaded = ClaudeMessageStore(file, json)
+        val settled = reloaded.settleRunningTools(sessionId, "Claude Code session ended before the tool result was received")
+
+        assertEquals(
+            JsonPrimitive("error"),
+            settled.single().parts.first { it.id == "running-tool" }.state?.get("status"),
+        )
+        assertEquals(
+            JsonPrimitive("Claude Code session ended before the tool result was received"),
+            settled.single().parts.first { it.id == "running-tool" }.state?.get("error"),
+        )
+        assertEquals(
+            JsonPrimitive("completed"),
+            settled.single().parts.first { it.id == "completed-tool" }.state?.get("status"),
+        )
+        assertEquals(settled, reloaded.list(sessionId))
+
+        file.delete()
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParserTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParserTest.kt
@@ -2,6 +2,7 @@ package com.yugahashimoto.andcode.runtime.local
 
 import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -107,6 +108,27 @@ class ClaudeStreamJsonParserTest {
         assertEquals("boom", parsed.errorMessage)
         assertTrue(parsed.events.first() is OpenCodeEvent.SessionError)
         assertTrue(parsed.events.last() is OpenCodeEvent.SessionIdle)
+    }
+
+    @Test
+    fun `settles open tools when a turn ends with an error`() {
+        val parser = parser()
+        parser.parse(
+            """{"type":"assistant","message":{"id":"m-tool","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"grep"}}]}}""",
+        )
+
+        val failed =
+            parser.parse(
+                """{"type":"result","subtype":"error_during_execution","result":"API disconnected","session_id":"abc"}""",
+            )
+
+        val recovered = failed.messages.single()
+        val tool = recovered.parts.single()
+        assertEquals("m-tool", recovered.info.id)
+        assertEquals("t1", tool.id)
+        assertEquals("error", tool.state?.get("status")?.jsonPrimitive?.content)
+        assertEquals("API disconnected", tool.state?.get("error")?.jsonPrimitive?.content)
+        assertTrue(failed.events.any { event -> event is OpenCodeEvent.MessagePartUpdated })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- settle Claude Code tool parts when a stream turn ends with an API error
- prevent late events from restoring a failed session to running
- normalize persisted running tools after restart
- use unique activity row keys to prevent the detail sheet crash

## Verification
- :app:testDebugUnitTest
- :app:lintDebug
- :app:assembleDebug
- installed and smoke-tested on Xiaomi 25098PN5AC (1ff6a149); stale activity rows show エラー and the detail sheet opens without a crash