### PR TITLE
fix: restore local runtime after app replacement

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -145,6 +145,15 @@
         </receiver>
 
         <receiver
+            android:name=".startup.RuntimeAutoStartReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
             android:name=".feature.widget.QuickInputWidgetProvider"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartInitializer.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartInitializer.kt
@@ -21,22 +21,7 @@ class RuntimeAutoStartInitializer : Initializer<RuntimeAutoStartInitializer.Resu
         val app = context.applicationContext as AndCodeApplication
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-        val runtimeStatus = app.localRuntimeManager.status()
-        val setupConfigured =
-            hasUsableRuntimeSetup(
-                localRuntimeStatus = runtimeStatus,
-                hasRemoteConnection = app.settings.connections().isNotEmpty(),
-            )
-        if (app.settings.onboardingCompleted != setupConfigured) {
-            app.settings.onboardingCompleted = setupConfigured
-        }
-
-        if (!app.settings.onboardingCompleted) return Result(null)
-        if (runtimeStatus is LocalRuntimeStatus.NotInstalled) return Result(null)
-        val selectedId = app.settings.selectedRuntimeId
-        if (selectedId != null && selectedId != LOCAL_RUNTIME_ID) return Result(null)
-
-        app.localRuntimeController.start()
+        if (!restoreIfConfigured(app)) return Result(null)
 
         var warmupJob: Job? = null
         scope.launch {
@@ -72,9 +57,38 @@ class RuntimeAutoStartInitializer : Initializer<RuntimeAutoStartInitializer.Resu
 
     override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
 
-    private companion object {
-        const val LOCAL_RUNTIME_ID = "local-android"
-        const val CATALOG_WARMUP_ATTEMPTS = 4
-        const val CATALOG_WARMUP_DELAY_MS = 2500L
+    companion object {
+        /**
+         * Reuses the same gate from both app startup and lifecycle broadcasts. Package updates
+         * stop every process belonging to the old APK, so the initializer alone is not a reliable
+         * recovery hook.
+         */
+        internal fun restoreIfConfigured(app: AndCodeApplication): Boolean {
+            val runtimeStatus = app.localRuntimeManager.status()
+            val setupConfigured =
+                hasUsableRuntimeSetup(
+                    localRuntimeStatus = runtimeStatus,
+                    hasRemoteConnection = app.settings.connections().isNotEmpty(),
+                )
+            if (app.settings.onboardingCompleted != setupConfigured) {
+                app.settings.onboardingCompleted = setupConfigured
+            }
+
+            if (
+                !shouldAutoStartLocalRuntime(
+                    onboardingCompleted = app.settings.onboardingCompleted,
+                    localRuntimeStatus = runtimeStatus,
+                    selectedRuntimeId = app.settings.selectedRuntimeId,
+                )
+            ) {
+                return false
+            }
+
+            app.localRuntimeController.start()
+            return true
+        }
+
+        private const val CATALOG_WARMUP_ATTEMPTS = 4
+        private const val CATALOG_WARMUP_DELAY_MS = 2500L
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartPolicy.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartPolicy.kt
@@ -1,0 +1,18 @@
+package com.yugahashimoto.andcode.startup
+
+import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
+
+internal const val LOCAL_RUNTIME_ID = "local-android"
+
+/**
+ * Keeps the automatic recovery path scoped to a configured local runtime. An explicit remote
+ * selection must never be replaced just because the app was updated or the device rebooted.
+ */
+internal fun shouldAutoStartLocalRuntime(
+    onboardingCompleted: Boolean,
+    localRuntimeStatus: LocalRuntimeStatus,
+    selectedRuntimeId: String?,
+): Boolean =
+    onboardingCompleted &&
+        localRuntimeStatus !is LocalRuntimeStatus.NotInstalled &&
+        (selectedRuntimeId == null || selectedRuntimeId == LOCAL_RUNTIME_ID)

--- a/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartReceiver.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartReceiver.kt
@@ -1,0 +1,21 @@
+package com.yugahashimoto.andcode.startup
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.yugahashimoto.andcode.AndCodeApplication
+
+/** Restores the local runtime after Android terminates it during a reboot or APK replacement. */
+class RuntimeAutoStartReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (!isRuntimeAutoStartBroadcast(intent.action)) return
+        val app = context.applicationContext as? AndCodeApplication ?: return
+        RuntimeAutoStartInitializer.restoreIfConfigured(app)
+    }
+}
+
+internal fun isRuntimeAutoStartBroadcast(action: String?): Boolean =
+    action == Intent.ACTION_BOOT_COMPLETED || action == Intent.ACTION_MY_PACKAGE_REPLACED

--- a/app/src/test/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartPolicyTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartPolicyTest.kt
@@ -1,0 +1,63 @@
+package com.yugahashimoto.andcode.startup
+
+import android.content.Intent
+import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RuntimeAutoStartPolicyTest {
+    @Test
+    fun `restores an installed local runtime after a process losing event`() {
+        assertTrue(
+            shouldAutoStartLocalRuntime(
+                onboardingCompleted = true,
+                localRuntimeStatus = LocalRuntimeStatus.Stopped("1.18.11", 4097),
+                selectedRuntimeId = null,
+            ),
+        )
+        assertTrue(
+            shouldAutoStartLocalRuntime(
+                onboardingCompleted = true,
+                localRuntimeStatus = LocalRuntimeStatus.Stopped("1.18.11", 4097),
+                selectedRuntimeId = "local-android",
+            ),
+        )
+    }
+
+    @Test
+    fun `does not start when onboarding is incomplete or runtime is not installed`() {
+        assertFalse(
+            shouldAutoStartLocalRuntime(
+                onboardingCompleted = false,
+                localRuntimeStatus = LocalRuntimeStatus.Stopped("1.18.11", 4097),
+                selectedRuntimeId = null,
+            ),
+        )
+        assertFalse(
+            shouldAutoStartLocalRuntime(
+                onboardingCompleted = true,
+                localRuntimeStatus = LocalRuntimeStatus.NotInstalled,
+                selectedRuntimeId = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not take over an explicitly selected remote runtime`() {
+        assertFalse(
+            shouldAutoStartLocalRuntime(
+                onboardingCompleted = true,
+                localRuntimeStatus = LocalRuntimeStatus.Stopped("1.18.11", 4097),
+                selectedRuntimeId = "remote-runtime",
+            ),
+        )
+    }
+
+    @Test
+    fun `recognizes reboot and package replacement as runtime recovery triggers`() {
+        assertTrue(isRuntimeAutoStartBroadcast(Intent.ACTION_BOOT_COMPLETED))
+        assertTrue(isRuntimeAutoStartBroadcast(Intent.ACTION_MY_PACKAGE_REPLACED))
+        assertFalse(isRuntimeAutoStartBroadcast("com.yugahashimoto.andcode.RUN_SCHEDULE"))
+    }
+}


### PR DESCRIPTION
## 概要

APK更新や端末再起動でAndCodeのプロセスとForeground Serviceが停止した後、初回起動処理の取りこぼしでOpenCodeが復旧しない問題を修正します。

## 修正内容

- 自動起動判定を共通化
- `MY_PACKAGE_REPLACED` / `BOOT_COMPLETED` 受信時にローカルランタイムの起動要求を再発行
- 未インストール状態や明示的なリモートランタイム選択は対象外
- 復旧ポリシーとブロードキャスト判定のユニットテストを追加

## 検証

- `./gradlew testDebugUnitTest`
- `./gradlew assembleDebug`
- `./gradlew lintDebug`
- 実機ADB検証は、検証開始時点で端末が切断されたため未実施