### PR TITLE
fix: keep model picker open while scrolling

### DIFF
--- a/app/src/androidTest/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheetInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheetInstrumentedTest.kt
@@ -1,0 +1,68 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasScrollToIndexAction
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.yugahashimoto.andcode.core.api.OpenCodeModel
+import com.yugahashimoto.andcode.core.api.OpenCodeProvider
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ModelAndRuntimePickerSheetInstrumentedTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun swipingDownWhileModelListIsScrolledDoesNotDismissPicker() {
+        var dismissed by mutableStateOf(false)
+
+        composeRule.setContent {
+            ModelAndRuntimePickerSheet(
+                runtimeTargets = emptyList(),
+                selectedRuntimeId = null,
+                onSelectRuntime = {},
+                providers = listOf(testProvider),
+                selectedProviderId = testProvider.id,
+                selectedModelId = null,
+                onSelectModel = { _, _ -> },
+                onDismiss = { dismissed = true },
+            )
+        }
+
+        val list = composeRule.onNode(hasScrollToIndexAction())
+        list.assertIsDisplayed()
+        list.performScrollToIndex(25)
+        composeRule.onNode(hasScrollAction()).performTouchInput {
+            swipe(Offset(200f, 240f), Offset(200f, 290f))
+        }
+
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { assertFalse(dismissed) }
+    }
+
+    private companion object {
+        val testProvider =
+            OpenCodeProvider(
+                id = "test-provider",
+                name = "Test provider",
+                models =
+                    (0..60).associate { index ->
+                        val id = "model-$index"
+                        id to OpenCodeModel(id = id, name = "Model $index")
+                    },
+            )
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -86,7 +86,6 @@ import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -201,7 +200,6 @@ fun ChatHomeScreen(
     var input by remember { mutableStateOf("") }
     val listState = rememberLazyListState()
     var showModelPicker by remember { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState()
     val errorKind = classifyChatError(state.error)
     val runtimeNotReady = errorKind == ChatErrorKind.RUNTIME_NOT_READY && state.messages.isEmpty()
     val isAtBottom = remember { mutableStateOf(true) }
@@ -615,7 +613,6 @@ fun ChatHomeScreen(
 
     if (showModelPicker) {
         ModelAndRuntimePickerSheet(
-            sheetState = sheetState,
             runtimeTargets = runtimeTargets,
             selectedRuntimeId = selectedRuntimeId,
             onSelectRuntime = onSelectRuntime,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ExpandMore
@@ -25,8 +26,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -47,6 +49,11 @@ import com.yugahashimoto.andcode.ui.runtimeTargetLabel
 
 private const val MAX_RECENT_MODELS = 3
 
+internal fun isModelPickerDismissAllowed(
+    targetValue: SheetValue,
+    isListAtTop: Boolean,
+): Boolean = targetValue != SheetValue.Hidden || isListAtTop
+
 /**
  * Bottom sheet opened from the chat screen's model chip. Lets the user pick both
  * the execution target (this Android device or a registered remote runtime) and
@@ -55,7 +62,6 @@ private const val MAX_RECENT_MODELS = 3
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ModelAndRuntimePickerSheet(
-    sheetState: SheetState,
     runtimeTargets: List<RuntimeTarget>,
     selectedRuntimeId: String?,
     onSelectRuntime: (String) -> Unit,
@@ -72,11 +78,24 @@ fun ModelAndRuntimePickerSheet(
 ) {
     var query by remember { mutableStateOf("") }
     var runtimesExpanded by remember { mutableStateOf(false) }
+    val listState = rememberLazyListState()
+    val sheetState =
+        rememberModalBottomSheetState(
+            confirmValueChange = { targetValue ->
+                isModelPickerDismissAllowed(
+                    targetValue = targetValue,
+                    isListAtTop =
+                        listState.firstVisibleItemIndex == 0 &&
+                            listState.firstVisibleItemScrollOffset == 0,
+                )
+            },
+        )
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
         LazyColumn(
+            state = listState,
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDatePickerState
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -114,7 +113,6 @@ fun ScheduleEditorScreen(
     var invalidCron by remember { mutableStateOf(false) }
     var saveError by remember { mutableStateOf<String?>(null) }
 
-    val sheetState = rememberModalBottomSheetState()
     val snackbarHostState = remember { SnackbarHostState() }
 
     // Saving used to fail silently whenever a required field was missing; surface the reason instead.
@@ -522,7 +520,6 @@ fun ScheduleEditorScreen(
 
     if (showModelPicker) {
         ModelAndRuntimePickerSheet(
-            sheetState = sheetState,
             runtimeTargets = runtimeTargets,
             selectedRuntimeId = runtimeId,
             onSelectRuntime = { runtimeId = it },

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -594,7 +593,6 @@ private fun AssistantTargetSection(
     onWorkspaceChange: (String) -> Unit,
 ) {
     var showPicker by remember { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState()
     val selectableTargets = assistantTargets(runtimeTargets)
     val selectedTarget = selectableTargets.firstOrNull { it.id == assistantRuntimeId }
 
@@ -644,7 +642,6 @@ private fun AssistantTargetSection(
 
     if (showPicker) {
         ModelAndRuntimePickerSheet(
-            sheetState = sheetState,
             runtimeTargets = selectableTargets,
             selectedRuntimeId = assistantRuntimeId,
             onSelectRuntime = onRuntimeChange,

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ModelPickerDismissPolicyTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ModelPickerDismissPolicyTest.kt
@@ -1,0 +1,23 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import androidx.compose.material3.SheetValue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelPickerDismissPolicyTest {
+    @Test
+    fun `rejects hiding while the model list is scrolled`() {
+        assertFalse(isModelPickerDismissAllowed(SheetValue.Hidden, isListAtTop = false))
+    }
+
+    @Test
+    fun `allows hiding when the model list is at the top`() {
+        assertTrue(isModelPickerDismissAllowed(SheetValue.Hidden, isListAtTop = true))
+    }
+
+    @Test
+    fun `allows non-hidden sheet transitions regardless of list position`() {
+        assertTrue(isModelPickerDismissAllowed(SheetValue.Expanded, isListAtTop = false))
+    }
+}


### PR DESCRIPTION
## Summary
- Keep the model picker sheet open while the model list is scrolled.
- Allow swipe-to-dismiss only when the list is at the top.
- Add unit and instrumented regression coverage.

## Verification
- `./gradlew detekt spotlessCheck :app:lintDebug :app:testDebugUnitTest :app:assembleDebug :app:assembleDebugAndroidTest`
- Physical-device UI execution was attempted, but the ADB device disconnected before instrumentation could start.