### PR TITLE
fix(chat): only render intentional markdown and http links

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -247,12 +247,11 @@ private fun InlineText(
     style: TextStyle,
     linkColor: Color,
     codeBackground: Color,
-    onFilePathClick: (String) -> Unit,
 ) {
     val context = LocalContext.current
     val annotated =
         remember(inlines, linkColor, codeBackground) {
-            annotateFilePaths(renderInline(inlines, codeBackground, linkColor), linkColor)
+            renderInline(inlines, codeBackground, linkColor)
         }
     var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
     SelectionContainer {
@@ -269,8 +268,7 @@ private fun InlineText(
                                     runCatching {
                                         context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(ann.item)))
                                     }
-                                } ?: annotated.getStringAnnotations("filepath", position, position)
-                                .firstOrNull()?.let { onFilePathClick(it.item) }
+                                }
                         }
                     }
                 },
@@ -328,7 +326,6 @@ private fun LinkedText(
 @Composable
 private fun MarkdownText(
     text: String,
-    onFilePathClick: (String) -> Unit = {},
     onImageClick: (ChatImageSource) -> Unit = {},
 ) {
     val blocks = remember(text) { MarkdownLite.parse(text) }
@@ -352,7 +349,6 @@ private fun MarkdownText(
                             }.copy(fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface),
                         linkColor = linkColor,
                         codeBackground = codeInlineBackground,
-                        onFilePathClick = onFilePathClick,
                     )
                 is MarkdownBlock.Paragraph -> {
                     val currentInlines = mutableListOf<MarkdownInline>()
@@ -365,7 +361,6 @@ private fun MarkdownText(
                                 style = bodyStyle,
                                 linkColor = linkColor,
                                 codeBackground = codeInlineBackground,
-                                onFilePathClick = onFilePathClick,
                             )
                             currentInlines.clear()
                         }
@@ -402,7 +397,7 @@ private fun MarkdownText(
                         block.items.forEach { item ->
                             Row {
                                 Text("•  ", color = MaterialTheme.colorScheme.onSurface)
-                                InlineText(item, bodyStyle, linkColor, codeInlineBackground, onFilePathClick)
+                                InlineText(item, bodyStyle, linkColor, codeInlineBackground)
                             }
                         }
                     }
@@ -411,7 +406,7 @@ private fun MarkdownText(
                         block.items.forEachIndexed { index, item ->
                             Row {
                                 Text("${index + 1}.  ", color = MaterialTheme.colorScheme.onSurface)
-                                InlineText(item, bodyStyle, linkColor, codeInlineBackground, onFilePathClick)
+                                InlineText(item, bodyStyle, linkColor, codeInlineBackground)
                             }
                         }
                     }
@@ -436,7 +431,6 @@ private fun MarkdownText(
                                 style = bodyStyle.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
                                 linkColor = linkColor,
                                 codeBackground = codeInlineBackground,
-                                onFilePathClick = onFilePathClick,
                             )
                         }
                     }
@@ -635,34 +629,6 @@ private fun ChatImageThumbnail(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-            }
-        }
-    }
-}
-
-private val FILE_PATH_REGEX = Regex("[\\w./-]+\\.\\w+")
-
-private fun annotateFilePaths(
-    source: AnnotatedString,
-    linkColor: Color,
-): AnnotatedString {
-    val excludeRanges =
-        source.getStringAnnotations("link", 0, source.text.length) +
-            source.getStringAnnotations("code", 0, source.text.length)
-    return buildAnnotatedString {
-        append(source)
-        FILE_PATH_REGEX.findAll(source.text).forEach { match ->
-            val overlapsProtected =
-                excludeRanges.any { ann ->
-                    match.range.first < ann.end && match.range.last + 1 > ann.start
-                }
-            if (!overlapsProtected) {
-                addStyle(
-                    SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
-                    match.range.first,
-                    match.range.last + 1,
-                )
-                addStringAnnotation("filepath", match.value, match.range.first, match.range.last + 1)
             }
         }
     }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/MarkdownLiteTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/MarkdownLiteTest.kt
@@ -205,6 +205,17 @@ class MarkdownLiteTest {
     }
 
     @Test
+    fun `dotted numbers stay plain text`() {
+        val paragraph =
+            MarkdownLite.parse("versionName 1.2.2, 19.5 MB, v1.2.2")
+                .single() as MarkdownBlock.Paragraph
+        assertEquals(
+            listOf(MarkdownInline.Plain("versionName 1.2.2, 19.5 MB, v1.2.2")),
+            paragraph.inlines,
+        )
+    }
+
+    @Test
     fun `markdown image is parsed`() {
         val paragraph =
             MarkdownLite.parse("Look at ![rabbit](/path/to/rabbit.png) image")


### PR DESCRIPTION
## 問題
アシスタントメッセージ内のドットを含むトークン(バージョン番号 `1.2.2`、小数 `19.5` など)がファイルパス自動リンク処理(`FILE_PATH_REGEX` / `annotateFilePaths`)によりリンク化され、下線+リンク色で表示されていた。

## 修正
- ファイルパス自動リンク処理を完全に削除(タップしても何も起こらないため)。
- リンクはマークダウンパーサが生成するもの(マークダウンリンクと裸の `http(s)://` URL)のみとする。
- 未使用の `onFilePathClick` 配線も削除。
- ドット付き数値がプレーンテキストのままであることを保証する回帰テストを追加。

## 検証
- 新規テスト含む MarkdownLiteTest 16テストすべてパス(ローカルで単独実行)
- `detekt` / `spotlessCheck` パス(ローカル)
- 残りはCI(test-and-build / lint)に委ねる(本デバイスはaarch64/muslでaapt2が実行不可のため)