### PR TITLE
ci: add OpenCodeReview PR review bot (OpenCode Zen DeepSeek V4 Flash)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,35 @@
+name: OCR PR Review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  # pull_request_target so secrets are available even for PRs from forks.
+  # Safe because OCR only reads the diff and never executes PR code.
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  code-review:
+    if: ${{ secrets.OPENCODE_ZEN_API_KEY != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Run OpenCodeReview
+        uses: alibaba/open-code-review@v1.8.8
+        with:
+          llm_url: https://opencode.ai/zen/v1/chat/completions
+          llm_auth_token: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+          llm_model: deepseek-v4-flash
+          llm_use_anthropic: 'false'
+          llm_extra_body: '{}'
+          language: 'Japanese'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          sticky_summary: 'true'
+          incremental: 'true'
+          upload_artifacts: 'true'

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -16,18 +16,19 @@ permissions:
 
 jobs:
   code-review:
-    if: ${{ secrets.OPENCODE_ZEN_API_KEY != '' }}
+    if: ${{ secrets.OPENCODE_GO_API_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Run OpenCodeReview
-        uses: alibaba/open-code-review@v1.8.8
+        # alibaba/open-code-review v1.8.8, pinned by SHA (tags are mutable).
+        uses: alibaba/open-code-review@6dc3eb067071c01e7234ac6032a9f7d656a29f84
         with:
-          llm_url: https://opencode.ai/zen/v1/chat/completions
-          llm_auth_token: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+          llm_url: https://opencode.ai/zen/go/v1/chat/completions
+          llm_auth_token: ${{ secrets.OPENCODE_GO_API_KEY }}
           llm_model: deepseek-v4-flash
           llm_use_anthropic: 'false'
-          llm_extra_body: '{}'
+          llm_extra_body: '{"enable_thinking": false}'
           language: 'Japanese'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           sticky_summary: 'true'

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -16,7 +16,6 @@ permissions:
 
 jobs:
   code-review:
-    if: ${{ secrets.OPENCODE_GO_API_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Adds .github/workflows/ocr-review.yml: runs alibaba/open-code-review (v1.8.8) on PRs as a review bot.

- LLM: OpenCode Zen `deepseek-v4-flash` via OpenAI-compatible endpoint (`https://opencode.ai/zen/v1/chat/completions`)
- Posts inline review comments + sticky summary on PRs (incremental, non-destructive)
- Review output language: Japanese
- Requires repo secret `OPENCODE_ZEN_API_KEY` (OpenCode Zen API key); job skips until it is set
- Uses `pull_request_target` so fork PRs can be reviewed; OCR only reads the diff and never executes PR code