### PR TITLE
ci: switch review bot to OpenCode Zen free tier (keyless)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -5,7 +5,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  # pull_request_target so secrets are available even for PRs from forks.
+  # pull_request_target so the job can post comments even on fork PRs
+  # (GITHUB_TOKEN is read-only for pull_request events from forks).
   # Safe because OCR only reads the diff and never executes PR code.
   pull_request_target:
     types: [opened, synchronize]
@@ -23,9 +24,12 @@ jobs:
         # alibaba/open-code-review v1.8.8, pinned by SHA (tags are mutable).
         uses: alibaba/open-code-review@6dc3eb067071c01e7234ac6032a9f7d656a29f84
         with:
-          llm_url: https://opencode.ai/zen/go/v1/chat/completions
-          llm_auth_token: ${{ secrets.OPENCODE_GO_API_KEY }}
-          llm_model: deepseek-v4-flash
+          # OpenCode Zen free tier: keyless anonymous access via the special
+          # "public" token (same mechanism opencode itself uses when no key
+          # is configured). $0 per token; rate-limited per IP.
+          llm_url: https://opencode.ai/zen/v1/chat/completions
+          llm_auth_token: public
+          llm_model: deepseek-v4-flash-free
           llm_use_anthropic: 'false'
           llm_extra_body: '{"enable_thinking": false}'
           language: 'Japanese'


### PR DESCRIPTION
Switches the OCR review bot from the paid Go endpoint to OpenCode Zen's free tier:

- `deepseek-v4-flash-free` via `https://opencode.ai/zen/v1/chat/completions` with the anonymous `public` token (no secret needed)
- Same keyless mechanism opencode itself uses when no API key is configured (verified in opencode source: `packages/core/src/plugin/provider/opencode.ts`)
- Cost: $0 per token; anonymous access is rate-limited per IP

Verified:
- Anonymous endpoint + tool calling: OK
- Full local `ocr review` run with this config: completed (1m43s, 2 tool calls)

Known upstream caveats (anomalyco/opencode#40479, #39204): the free route can intermittently hang; artifacts are uploaded on failure for debugging.

The now-unused `OPENCODE_GO_API_KEY` secret will be deleted.