### PR TITLE
feat: add in-app guest browser for localhost pages

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
@@ -32,8 +32,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import com.yugahashimoto.andcode.R
 
 /** In-app browser for pages served inside the guest runtime (e.g. http://127.0.0.1:PORT/). */

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
@@ -83,10 +83,11 @@ fun GuestBrowserScreen(
                 modifier = Modifier.weight(1f),
                 factory = { context ->
                     WebView(context).apply {
-                        layoutParams = ViewGroup.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                        )
+                        layoutParams =
+                            ViewGroup.LayoutParams(
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                            )
                         configure(
                             onProgress = { progress = it },
                             onNavigationStateChange = { url, back, forward ->
@@ -197,7 +198,10 @@ private fun WebView.configure(
         }
     webViewClient =
         object : WebViewClient() {
-            override fun onPageFinished(view: WebView?, url: String?) {
+            override fun onPageFinished(
+                view: WebView?,
+                url: String?,
+            ) {
                 onProgress(100)
                 onNavigationStateChange(
                     url.orEmpty(),

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
@@ -186,19 +186,24 @@ private fun WebView.configure(
     // Guest pages (dev servers, dashboards, tool UIs) are interactive web apps that need JS.
     settings.javaScriptEnabled = true
     settings.domStorageEnabled = true
-    webChromeClient = object : WebChromeClient() {
-        override fun onProgressChanged(view: WebView?, newProgress: Int) {
-            onProgress(newProgress)
+    webChromeClient =
+        object : WebChromeClient() {
+            override fun onProgressChanged(
+                view: WebView?,
+                newProgress: Int,
+            ) {
+                onProgress(newProgress)
+            }
         }
-    }
-    webViewClient = object : WebViewClient() {
-        override fun onPageFinished(view: WebView?, url: String?) {
-            onProgress(100)
-            onNavigationStateChange(
-                url.orEmpty(),
-                view?.canGoBack() == true,
-                view?.canGoForward() == true,
-            )
+    webViewClient =
+        object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                onProgress(100)
+                onNavigationStateChange(
+                    url.orEmpty(),
+                    view?.canGoBack() == true,
+                    view?.canGoForward() == true,
+                )
+            }
         }
-    }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/browser/GuestBrowserScreen.kt
@@ -1,0 +1,204 @@
+package com.yugahashimoto.andcode.feature.browser
+
+import android.annotation.SuppressLint
+import android.view.ViewGroup
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.unit.dp
+import com.yugahashimoto.andcode.R
+
+/** In-app browser for pages served inside the guest runtime (e.g. http://127.0.0.1:PORT/). */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GuestBrowserScreen(
+    initialUrl: String,
+    onBack: () -> Unit,
+) {
+    var urlInput by remember { mutableStateOf(initialUrl) }
+    var progress by remember { mutableIntStateOf(0) }
+    var canGoBack by remember { mutableStateOf(false) }
+    var canGoForward by remember { mutableStateOf(false) }
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    BackHandler {
+        val view = webView
+        if (view != null && view.canGoBack()) {
+            view.goBack()
+        } else {
+            onBack()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            GuestBrowserTopBar(
+                canGoBack = canGoBack,
+                canGoForward = canGoForward,
+                onBack = onBack,
+                onHistoryBack = { webView?.goBack() },
+                onForward = { webView?.goForward() },
+                onReload = { webView?.reload() },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            GuestBrowserUrlBar(
+                urlInput = urlInput,
+                onUrlChange = { urlInput = it },
+                onGo = { webView?.loadUrl(normalizeUrl(urlInput)) },
+            )
+            if (progress in 1..99) {
+                LinearProgressIndicator(progress = { progress / 100f })
+            }
+            AndroidView(
+                modifier = Modifier.weight(1f),
+                factory = { context ->
+                    WebView(context).apply {
+                        layoutParams = ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        )
+                        configure(
+                            onProgress = { progress = it },
+                            onNavigationStateChange = { url, back, forward ->
+                                urlInput = url
+                                canGoBack = back
+                                canGoForward = forward
+                            },
+                        )
+                        webView = this
+                        if (initialUrl.isNotBlank()) {
+                            loadUrl(normalizeUrl(initialUrl))
+                        }
+                    }
+                },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GuestBrowserTopBar(
+    canGoBack: Boolean,
+    canGoForward: Boolean,
+    onBack: () -> Unit,
+    onHistoryBack: () -> Unit,
+    onForward: () -> Unit,
+    onReload: () -> Unit,
+) {
+    TopAppBar(
+        title = { Text(stringResource(R.string.guest_browser_title)) },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(R.string.nav_back),
+                )
+            }
+        },
+        actions = {
+            IconButton(enabled = canGoBack, onClick = onHistoryBack) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(R.string.guest_browser_back),
+                )
+            }
+            IconButton(enabled = canGoForward, onClick = onForward) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowForward,
+                    contentDescription = stringResource(R.string.guest_browser_forward),
+                )
+            }
+            IconButton(onClick = onReload) {
+                Icon(
+                    Icons.Default.Refresh,
+                    contentDescription = stringResource(R.string.guest_browser_reload),
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun GuestBrowserUrlBar(
+    urlInput: String,
+    onUrlChange: (String) -> Unit,
+    onGo: () -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        OutlinedTextField(
+            value = urlInput,
+            onValueChange = onUrlChange,
+            modifier = Modifier.weight(1f),
+            singleLine = true,
+            placeholder = { Text(stringResource(R.string.guest_browser_url_hint)) },
+        )
+        Button(onClick = onGo, modifier = Modifier.padding(start = 8.dp)) {
+            Text(stringResource(R.string.guest_browser_go))
+        }
+    }
+}
+
+private fun normalizeUrl(raw: String): String {
+    val trimmed = raw.trim()
+    return if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+        trimmed
+    } else {
+        "http://$trimmed"
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun WebView.configure(
+    onProgress: (Int) -> Unit,
+    onNavigationStateChange: (url: String, canGoBack: Boolean, canGoForward: Boolean) -> Unit,
+) {
+    // Guest pages (dev servers, dashboards, tool UIs) are interactive web apps that need JS.
+    settings.javaScriptEnabled = true
+    settings.domStorageEnabled = true
+    webChromeClient = object : WebChromeClient() {
+        override fun onProgressChanged(view: WebView?, newProgress: Int) {
+            onProgress(newProgress)
+        }
+    }
+    webViewClient = object : WebViewClient() {
+        override fun onPageFinished(view: WebView?, url: String?) {
+            onProgress(100)
+            onNavigationStateChange(
+                url.orEmpty(),
+                view?.canGoBack() == true,
+                view?.canGoForward() == true,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material.icons.filled.Router
@@ -74,6 +75,7 @@ fun SettingsScreenV2(
     onOpenAgentSettings: () -> Unit = {},
     onOpenGitHubSettings: () -> Unit = {},
     onOpenLocalRuntime: () -> Unit,
+    onOpenGuestBrowser: () -> Unit = {},
     onOpenRemoteConnection: () -> Unit,
     onOpenWorkspaces: () -> Unit,
     onOpenDiagnostics: () -> Unit,
@@ -265,6 +267,12 @@ fun SettingsScreenV2(
                     icon = Icons.Default.Terminal,
                     title = stringResource(R.string.settings_local_runtime_row),
                     onClick = onOpenLocalRuntime,
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Default.OpenInBrowser,
+                    title = stringResource(R.string.guest_browser_row),
+                    onClick = onOpenGuestBrowser,
                 )
                 SettingsDivider()
                 SettingsRow(

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/Routes.kt
@@ -43,6 +43,7 @@ const val SCHEDULE_EDIT_ARG_ID = "scheduleId"
 const val SCHEDULE_EDIT_ROUTE_PATTERN = "$ROUTE_SCHEDULE_EDIT?$SCHEDULE_EDIT_ARG_ID={$SCHEDULE_EDIT_ARG_ID}"
 const val ROUTE_CODE_VIEWER = "code-viewer"
 const val ROUTE_TERMINAL = "terminal"
+const val ROUTE_GUEST_BROWSER = "guest-browser"
 
 const val CODE_VIEWER_ROUTE_PATTERN = "$ROUTE_CODE_VIEWER/{runtimeId}/{workspacePath}/{filePath}"
 

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -74,6 +74,7 @@ fun NavGraphBuilder.settingsNavGraph(
             onOpenAgentSettings = { navController.navigate(ROUTE_SETTINGS_AGENTS) },
             onOpenGitHubSettings = { navController.navigate(ROUTE_SETTINGS_GITHUB) },
             onOpenLocalRuntime = { navController.navigate(LOCAL_RUNTIME_MANAGEMENT_ROUTE) },
+            onOpenGuestBrowser = { navController.navigate(ROUTE_GUEST_BROWSER) },
             onOpenRemoteConnection = { navController.navigate(ROUTE_REMOTE_CONNECTION) },
             onOpenWorkspaces = { navController.navigate(ROUTE_WORKSPACES) },
             onOpenDiagnostics = onShowDiagnostics,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.yugahashimoto.andcode.AndCodeApplication
+import com.yugahashimoto.andcode.feature.browser.GuestBrowserScreen
 import com.yugahashimoto.andcode.feature.workspace.CodeViewerScreen
 import com.yugahashimoto.andcode.feature.workspace.CodeViewerViewModel
 import com.yugahashimoto.andcode.feature.workspace.LocalRuntimeManagementScreen
@@ -181,6 +182,13 @@ fun NavGraphBuilder.workspaceNavGraph(
             onCommand = terminalViewModel::executeCommand,
             onInputChange = terminalViewModel::updateInput,
             onClear = terminalViewModel::clear,
+        )
+    }
+
+    composable(ROUTE_GUEST_BROWSER) {
+        GuestBrowserScreen(
+            initialUrl = app.localRuntimeManager.installedPort()?.let { "http://127.0.0.1:$it/" }.orEmpty(),
+            onBack = { navController.popBackStack() },
         )
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1032,4 +1032,11 @@
     <string name="activity_event_question">سؤال</string>
     <string name="activity_event_unknown">حدث غير مدعوم</string>
     <string name="connection_info_incomplete">معلومات الاتصال غير مكتملة</string>
+    <string name="guest_browser_title">المتصفح الضيف</string>
+    <string name="guest_browser_row">المتصفح الضيف</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:port</string>
+    <string name="guest_browser_go">فتح</string>
+    <string name="guest_browser_back">رجوع</string>
+    <string name="guest_browser_forward">تقدم</string>
+    <string name="guest_browser_reload">إعادة تحميل</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1032,4 +1032,11 @@
     <string name="activity_event_question">Pregunta</string>
     <string name="activity_event_unknown">Evento no compatible</string>
     <string name="connection_info_incomplete">La información de conexión está incompleta</string>
+    <string name="guest_browser_title">Navegador invitado</string>
+    <string name="guest_browser_row">Navegador invitado</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:puerto</string>
+    <string name="guest_browser_go">Abrir</string>
+    <string name="guest_browser_back">Atrás</string>
+    <string name="guest_browser_forward">Avanzar</string>
+    <string name="guest_browser_reload">Recargar</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1032,4 +1032,11 @@
     <string name="activity_event_question">Question</string>
     <string name="activity_event_unknown">Événement non pris en charge</string>
     <string name="connection_info_incomplete">Les informations de connexion sont incomplètes</string>
+    <string name="guest_browser_title">Navigateur invité</string>
+    <string name="guest_browser_row">Navigateur invité</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:port</string>
+    <string name="guest_browser_go">Ouvrir</string>
+    <string name="guest_browser_back">Retour</string>
+    <string name="guest_browser_forward">Avancer</string>
+    <string name="guest_browser_reload">Recharger</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1052,4 +1052,11 @@
     <string name="pr_collapse">閉じる</string>
     <string name="cd_pull_request_expand">他 %1$d 件のプルリクエストを表示</string>
     <string name="cd_pull_request_collapse">プルリクエストの表示を減らす</string>
+    <string name="guest_browser_title">ゲストブラウザ</string>
+    <string name="guest_browser_row">ゲストブラウザ</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:ポート</string>
+    <string name="guest_browser_go">開く</string>
+    <string name="guest_browser_back">戻る</string>
+    <string name="guest_browser_forward">進む</string>
+    <string name="guest_browser_reload">再読み込み</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1032,4 +1032,11 @@
     <string name="activity_event_question">Pergunta</string>
     <string name="activity_event_unknown">Evento não compatível</string>
     <string name="connection_info_incomplete">As informações de conexão estão incompletas</string>
+    <string name="guest_browser_title">Navegador convidado</string>
+    <string name="guest_browser_row">Navegador convidado</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:porta</string>
+    <string name="guest_browser_go">Abrir</string>
+    <string name="guest_browser_back">Voltar</string>
+    <string name="guest_browser_forward">Avançar</string>
+    <string name="guest_browser_reload">Recarregar</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1032,4 +1032,11 @@
     <string name="activity_event_question">Вопрос</string>
     <string name="activity_event_unknown">Неподдерживаемое событие</string>
     <string name="connection_info_incomplete">Недостаточно данных подключения</string>
+    <string name="guest_browser_title">Гостевой браузер</string>
+    <string name="guest_browser_row">Гостевой браузер</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:порт</string>
+    <string name="guest_browser_go">Открыть</string>
+    <string name="guest_browser_back">Назад</string>
+    <string name="guest_browser_forward">Вперёд</string>
+    <string name="guest_browser_reload">Обновить</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1032,4 +1032,11 @@
     <string name="activity_event_question">问题</string>
     <string name="activity_event_unknown">不支持的事件</string>
     <string name="connection_info_incomplete">连接信息不完整</string>
+    <string name="guest_browser_title">访客浏览器</string>
+    <string name="guest_browser_row">访客浏览器</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:端口</string>
+    <string name="guest_browser_go">打开</string>
+    <string name="guest_browser_back">后退</string>
+    <string name="guest_browser_forward">前进</string>
+    <string name="guest_browser_reload">重新加载</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1052,4 +1052,11 @@
     <string name="pr_collapse">Fewer</string>
     <string name="cd_pull_request_expand">Show %1$d more pull requests</string>
     <string name="cd_pull_request_collapse">Show fewer pull requests</string>
+    <string name="guest_browser_title">Guest Browser</string>
+    <string name="guest_browser_row">Guest Browser</string>
+    <string name="guest_browser_url_hint">http://127.0.0.1:port</string>
+    <string name="guest_browser_go">Open</string>
+    <string name="guest_browser_back">Back</string>
+    <string name="guest_browser_forward">Forward</string>
+    <string name="guest_browser_reload">Reload</string>
 </resources>


### PR DESCRIPTION
Adds a WebView-based Guest Browser screen (Settings > Guest Browser) for opening pages served inside the guest runtime (e.g. http://127.0.0.1:PORT/).

- URL bar with scheme auto-complete, back/forward/reload, progress indicator
- Back button unwinds WebView history before popping the screen
- Defaults to the local runtime port when installed
- Strings added for all supported locales