### PR TITLE
fix: use app icon for social sharing image

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -10,12 +10,17 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="AndCode — Coding agents, wherever you are" />
   <meta property="og:description" content="A native Android workspace for OpenCode, Claude Code, and Google Antigravity." />
-  <meta property="og:image" content="https://yuga-hashimoto.github.io/and-code/screenshot.png" />
+  <meta property="og:image" content="https://yuga-hashimoto.github.io/and-code/andcode-icon.png" />
+  <meta property="og:image:width" content="1024" />
+  <meta property="og:image:height" content="1024" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:alt" content="AndCode app icon" />
   <meta property="og:url" content="https://yuga-hashimoto.github.io/and-code/" />
-  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="AndCode — Coding agents, wherever you are" />
   <meta name="twitter:description" content="A native Android workspace for OpenCode, Claude Code, and Google Antigravity." />
-  <meta name="twitter:image" content="https://yuga-hashimoto.github.io/and-code/screenshot.png" />
+  <meta name="twitter:image" content="https://yuga-hashimoto.github.io/and-code/andcode-icon.png" />
+  <meta name="twitter:image:alt" content="AndCode app icon" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- Use the 1024×1024 AndCode app icon for Open Graph and Twitter previews.
- Use the square Twitter summary card so X preserves the icon shape.
- Add image dimensions, type, and alt metadata for social crawlers.

## Verification
- `git diff --check`
- `ANDROID_HOME=/Users/yu-ga/Library/Android/sdk ANDROID_SDK_ROOT=/Users/yu-ga/Library/Android/sdk ./gradlew testDebugUnitTest`
- Published `andcode-icon.png` responds with `200 image/png`
