### PR TITLE
fix: align Android release metadata with v1.2.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,8 +103,8 @@ android {
         applicationId = "com.yugahashimoto.andcode"
         minSdk = 26
         targetSdk = 35
-        versionCode = 41
-        versionName = "1.2.2"
+        versionCode = 42
+        versionName = "1.2.3"
         buildConfigField("String", "GITHUB_CLIENT_ID", "\"$githubClientId\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/test/java/com/yugahashimoto/andcode/ReleaseMetadataTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/ReleaseMetadataTest.kt
@@ -1,0 +1,24 @@
+package com.yugahashimoto.andcode
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class ReleaseMetadataTest {
+    @Test
+    fun `android package metadata matches the release tag`() {
+        val releaseVersion = repositoryRoot().resolve(".release-version").readText().trim().removePrefix("v")
+
+        assertEquals(releaseVersion, BuildConfig.VERSION_NAME)
+        assertEquals(42, BuildConfig.VERSION_CODE)
+    }
+
+    private fun repositoryRoot(): File {
+        val workingDirectory = System.getProperty("user.dir") ?: error("Test working directory is unavailable")
+        var directory = File(workingDirectory)
+        while (true) {
+            if (directory.resolve(".release-version").isFile) return directory
+            directory = directory.parentFile ?: error("Could not locate .release-version from $workingDirectory")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- align Android versionName/versionCode with the existing v1.2.3 release tag
- add a regression test so Crashlytics can distinguish repaired builds

## Verification
- `./gradlew testDebugUnitTest lintDebug assembleRelease spotlessCheck`
- release APK reports versionName 1.2.3 and versionCode 42