### PR TITLE
fix(chat): make URLs in markdown tables tappable

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -278,6 +279,29 @@ private fun InlineText(
 }
 
 @Composable
+private fun RowScope.TableCellText(
+    text: String,
+    style: TextStyle,
+    linkColor: Color,
+    codeBackground: Color,
+) {
+    val inlines = remember(text) { MarkdownLite.parseInline(text) }
+    Box(
+        modifier =
+            Modifier
+                .weight(1f)
+                .padding(end = 8.dp),
+    ) {
+        InlineText(
+            inlines = inlines,
+            style = style,
+            linkColor = linkColor,
+            codeBackground = codeBackground,
+        )
+    }
+}
+
+@Composable
 private fun LinkedText(
     text: String,
     linkColor: Color,
@@ -447,14 +471,11 @@ private fun MarkdownText(
                         ) {
                             Row(modifier = Modifier.fillMaxWidth()) {
                                 block.headers.forEach { header ->
-                                    Text(
+                                    TableCellText(
                                         text = header,
-                                        modifier =
-                                            Modifier
-                                                .weight(1f)
-                                                .padding(end = 8.dp),
-                                        fontWeight = FontWeight.SemiBold,
-                                        style = MaterialTheme.typography.bodyMedium,
+                                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                        linkColor = linkColor,
+                                        codeBackground = codeInlineBackground,
                                     )
                                 }
                             }
@@ -465,13 +486,11 @@ private fun MarkdownText(
                                         List((block.headers.size - row.size).coerceAtLeast(0)) { "" }
                                 Row(modifier = Modifier.fillMaxWidth()) {
                                     padded.forEach { cell ->
-                                        Text(
+                                        TableCellText(
                                             text = cell,
-                                            modifier =
-                                                Modifier
-                                                    .weight(1f)
-                                                    .padding(end = 8.dp),
                                             style = MaterialTheme.typography.bodyMedium,
+                                            linkColor = linkColor,
+                                            codeBackground = codeInlineBackground,
                                         )
                                     }
                                 }


### PR DESCRIPTION
## Problem

Markdown table cells were rendered with plain `Text`, bypassing inline markdown parsing (`parseInline`). As a result, URLs in table cells were displayed as non-clickable plain text, unlike every other block type (paragraphs, headings, lists, blockquotes).

## Fix

Added a `RowScope.TableCellText` composable that parses each cell's content via `MarkdownLite.parseInline()` and renders through `InlineText` — the same component used by all other block types. This makes bare URLs, markdown links, inline code, bold, etc. all render and be tappable inside table cells.

Headers and body cells now both use `TableCellText`, with the header style preserving the existing `SemiBold` weight.

## Changes
- `ChatMessageComponents.kt`:
  - Added `RowScope.TableCellText` helper (parses inline markdown + delegates to `InlineText` with `weight(1f)`)
  - Replaced plain `Text` calls in the `MarkdownBlock.Table` branch with `TableCellText`
  - Added `RowScope` import

## Notes
- `parseInline` is cached per-cell via `remember(text)` to avoid re-parsing on recomposition
- No data model change — `MarkdownBlock.Table` still stores raw strings, parsing happens at render time (same pattern as `LinkedText`)