### PR TITLE
fix(notifications): stop announcing aborted, failed or stray idles as completed

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
@@ -39,6 +39,7 @@ data class RuntimeActivityState(
     val completedSessionIds: Set<String> = emptySet(),
     /** Sessions whose current run has ended; late stream events must not resurrect them. */
     val settledSessionIds: Set<String> = emptySet(),
+    val mutedSessionIds: Set<String> = emptySet(),
     val permissions: List<PermissionRequest> = emptyList(),
     val logs: List<RuntimeEventLog> = emptyList(),
     val streamError: String? = null,
@@ -189,9 +190,20 @@ class RuntimeActivityRepository(
                 activeSessionIds = current.activeSessionIds + sessionId,
                 completedSessionIds = current.completedSessionIds - sessionId,
                 settledSessionIds = current.settledSessionIds - sessionId,
+                mutedSessionIds = current.mutedSessionIds - sessionId,
             )
         }
         persistUnread()
+    }
+
+    fun markSessionAborted(sessionId: String) {
+        if (sessionId.isBlank()) return
+        mutableState.update { current ->
+            current.copy(
+                activeSessionIds = current.activeSessionIds - sessionId,
+                mutedSessionIds = current.mutedSessionIds + sessionId,
+            )
+        }
     }
 
     /** Records that a run finished, leaving the chat unread until it is opened. */
@@ -251,14 +263,18 @@ class RuntimeActivityRepository(
             }
             is OpenCodeEvent.SessionIdle -> {
                 markRuntimeIdle(event.sessionId)
+                var muted = false
                 mutableState.update { current ->
+                    muted = event.sessionId in current.mutedSessionIds
                     current.copy(
                         activeSessionIds = current.activeSessionIds - event.sessionId,
                         completedSessionIds = current.completedSessionIds + event.sessionId,
                         settledSessionIds = current.settledSessionIds + event.sessionId,
+                        mutedSessionIds = current.mutedSessionIds - event.sessionId,
                     )
                 }
                 appendLog(messages.eventCompleted, null, event.sessionId)
+                if (muted) return
                 parentResolutionOf(target, event.sessionId).onSuccess { parentId ->
                     if (parentId == null) {
                         onSessionIdle?.invoke(event.sessionId, sessionTitle(target, event.sessionId), target.id)
@@ -301,6 +317,7 @@ class RuntimeActivityRepository(
                             } else {
                                 current.settledSessionIds - event.sessionId
                             },
+                        mutedSessionIds = current.mutedSessionIds - event.sessionId,
                     )
                 }
                 if (event.status != "idle") {
@@ -314,6 +331,7 @@ class RuntimeActivityRepository(
                         current.copy(
                             activeSessionIds = current.activeSessionIds - sessionId,
                             settledSessionIds = current.settledSessionIds + sessionId,
+                            mutedSessionIds = current.mutedSessionIds + sessionId,
                         )
                     }
                 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -328,6 +328,7 @@ class ChatViewModel(
      * events arrive. Deriving it from events alone left every chat on the idle marker.
      */
     private val onRunStateChanged: (String, Boolean) -> Unit = { _, _ -> },
+    private val onSessionAborted: (String) -> Unit = {},
     private val draftRepo: DraftRepository? = null,
     /**
      * Starts the periodic connection probe. It runs an unbounded polling loop, which a virtual
@@ -793,6 +794,7 @@ class ChatViewModel(
             _uiState.update { it.copy(attachments = emptyList(), imagePreviews = emptyList()) }
             return
         }
+        val interrupting = _uiState.value.isRunning
 
         val userMessage =
             ChatMessage(
@@ -848,6 +850,7 @@ class ChatViewModel(
                     }
                     refreshContextUsage(targetSessionId)
                 }
+                if (interrupting) onSessionAborted(targetSessionId)
                 currentBackend.sendMessage(
                     targetSessionId,
                     PromptRequest(
@@ -1395,6 +1398,7 @@ class ChatViewModel(
         val currentBackend = backend ?: return
         val sessionId = _uiState.value.sessionId ?: return
         viewModelScope.launch {
+            onSessionAborted(sessionId)
             runCatching { currentBackend.abortSession(sessionId) }
                 .onSuccess {
                     _uiState.update {

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeRuntime.kt
@@ -9,6 +9,7 @@ import com.yugahashimoto.andcode.core.api.OpenCodeTodo
 import com.yugahashimoto.andcode.core.api.PromptAttachment
 import com.yugahashimoto.andcode.core.api.QuestionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -69,6 +70,7 @@ class ClaudeCodeRuntime(
     private class SessionProcess(
         val process: Process,
         val readerJob: Job,
+        val parser: ClaudeStreamJsonParser,
         val permissionMode: ClaudePermissionMode,
         val directory: String,
         val model: String?,
@@ -280,6 +282,7 @@ class ClaudeCodeRuntime(
     ): Result<Unit> =
         runCatching {
             val session = ensureProcess(sessionId, directory.ifBlank { "/workspace" }, permissionMode, model, effort)
+            session.parser.beginTurn()
             recordUserMessage(sessionId, prompt, attachments)
             session.process.outputStream.apply {
                 write((json.encodeToString(JsonObject.serializer(), userMessage(prompt, attachments)) + "\n").toByteArray())
@@ -382,20 +385,33 @@ class ClaudeCodeRuntime(
         val requestedModel = model
         val readerJob =
             scope.launch {
-                runCatching {
-                    process.inputStream.bufferedReader().forEachLine { line ->
-                        handleLine(sessionId, parser, line, requestedModel)
-                    }
-                }
+                val streamFailure =
+                    runCatching {
+                        process.inputStream.bufferedReader().forEachLine { line ->
+                            handleLine(sessionId, parser, line, requestedModel)
+                        }
+                    }.exceptionOrNull()
+                        .takeUnless { it is CancellationException }
                 messageStore.flush()
-                // A CLI that exits mid-turn would otherwise leave the chat spinning forever.
-                events.tryEmit(OpenCodeEvent.SessionIdle(sessionId))
                 synchronized(this@ClaudeCodeRuntime) {
                     if (sessions[sessionId]?.process === process) sessions.remove(sessionId)
                 }
+                // stop() cancels this job; the abort path owns the state transitions, and an idle
+                // emitted here would announce the killed run as completed.
+                if (!isActive) return@launch
+                // A CLI that exits before its result line would otherwise leave the chat spinning
+                // forever; that is a failure, not a completion. A finished turn already emitted its
+                // own idle, and repeating it on process exit would re-announce the old run.
+                if (!parser.turnFinished) {
+                    val exitCode = runCatching { process.exitValue() }.getOrNull()
+                    events.tryEmit(
+                        OpenCodeEvent.SessionError(sessionId, messages.processExited(exitCode, streamFailure?.message)),
+                    )
+                    events.tryEmit(OpenCodeEvent.SessionIdle(sessionId))
+                }
             }
 
-        return SessionProcess(process, readerJob, effectiveMode, directory, model, effort)
+        return SessionProcess(process, readerJob, parser, permissionMode, directory, model, effort)
             .also { sessions[sessionId] = it }
     }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeMessages.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeMessages.kt
@@ -19,6 +19,11 @@ interface ClaudeMessages {
 
     fun signInExited(exitCode: Int): String
 
+    fun processExited(
+        exitCode: Int?,
+        detail: String?,
+    ): String
+
     /** English fallbacks for unit tests and any construction path without a [Context]. */
     companion object Default : ClaudeMessages {
         override val runtimeMissing = "The Linux environment is not installed yet"
@@ -29,6 +34,14 @@ interface ClaudeMessages {
         override val updateFailed = "Claude Code update failed"
 
         override fun signInExited(exitCode: Int) = "Claude Code sign-in stopped (exit code $exitCode)"
+
+        override fun processExited(
+            exitCode: Int?,
+            detail: String?,
+        ): String {
+            val cause = detail ?: exitCode?.let { "exit code $it" } ?: "process exited"
+            return "Claude Code stopped before finishing the turn ($cause)"
+        }
     }
 }
 
@@ -41,4 +54,12 @@ class AndroidClaudeMessages(private val context: Context) : ClaudeMessages {
     override val updateFailed get() = context.getString(R.string.claude_error_update_failed)
 
     override fun signInExited(exitCode: Int): String = context.getString(R.string.claude_error_sign_in_exit, exitCode)
+
+    override fun processExited(
+        exitCode: Int?,
+        detail: String?,
+    ): String {
+        val cause = detail ?: exitCode?.let { "exit code $it" } ?: "process exited"
+        return context.getString(R.string.claude_error_process_exited, cause)
+    }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParser.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParser.kt
@@ -45,6 +45,14 @@ class ClaudeStreamJsonParser(
 
     private var currentMessageId: String? = null
 
+    @Volatile
+    var turnFinished: Boolean = false
+        private set
+
+    fun beginTurn() {
+        turnFinished = false
+    }
+
     /** Tool calls that have not received a matching tool_result from Claude Code yet. */
     private val openTools = linkedMapOf<String, OpenTool>()
     private val messagesById = linkedMapOf<String, OpenCodeMessage>()
@@ -157,6 +165,7 @@ class ClaudeStreamJsonParser(
     }
 
     private fun parseResult(root: JsonObject): Parsed {
+        turnFinished = true
         val claudeSessionId = root.string("session_id")
         val isError = root["is_error"]?.jsonPrimitive?.contentOrNull == "true"
         val subtype = root.string("subtype")

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -279,6 +279,7 @@ fun AndCodeApp(
                         onPermissionResolved = app.activityRepository::resolvePermission,
                         onQuestionResolved = app.notifications::cancelQuestion,
                         onSessionCreated = app.catalogRepository::refreshSessionsOnly,
+                        onSessionAborted = app.activityRepository::markSessionAborted,
                         onRunStateChanged = { sessionId, running ->
                             if (running) {
                                 app.activityRepository.markSessionRunning(sessionId)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -897,6 +897,7 @@
     <string name="claude_error_submit_code">تعذّر إرسال الرمز</string>
     <string name="claude_error_install_failed">فشل تثبيت Claude Code</string>
     <string name="claude_error_update_failed">فشل تحديث Claude Code</string>
+    <string name="claude_error_process_exited">توقف Claude Code قبل إنهاء الدور (%1$s)</string>
     <string name="setup_download_agents_description">تحضير بيئة Linux المشتركة والوكلاء الذين اخترتهم.</string>
     <string name="settings_agents_row">الوكلاء</string>
     <string name="settings_agents_section">الوكلاء</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -897,6 +897,7 @@
     <string name="claude_error_submit_code">No se pudo enviar el código</string>
     <string name="claude_error_install_failed">Falló la instalación de Claude Code</string>
     <string name="claude_error_update_failed">Falló la actualización de Claude Code</string>
+    <string name="claude_error_process_exited">Claude Code se detuvo antes de terminar el turno (%1$s)</string>
     <string name="setup_download_agents_description">Prepara el entorno Linux compartido y los agentes que eligió.</string>
     <string name="settings_agents_row">Agentes</string>
     <string name="settings_agents_section">Agentes</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -897,6 +897,7 @@
     <string name="claude_error_submit_code">Impossible d’envoyer le code</string>
     <string name="claude_error_install_failed">L’installation de Claude Code a échoué</string>
     <string name="claude_error_update_failed">La mise à jour de Claude Code a échoué</string>
+    <string name="claude_error_process_exited">Claude Code s’est arrêté avant de terminer le tour (%1$s)</string>
     <string name="setup_download_agents_description">Prépare l’environnement Linux partagé et les agents que vous avez choisis.</string>
     <string name="settings_agents_row">Agents</string>
     <string name="settings_agents_section">Agents</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -943,6 +943,7 @@
     <string name="claude_error_submit_code">コードを送信できませんでした</string>
     <string name="claude_error_install_failed">Claude Codeのインストールに失敗しました</string>
     <string name="claude_error_update_failed">Claude Codeの更新に失敗しました</string>
+    <string name="claude_error_process_exited">Claude Codeがターンを完了する前に停止しました（%1$s）</string>
     <string name="setup_download_agents_description">共有のLinux環境と、選んだエージェントを準備します。</string>
     <string name="settings_agents_row">エージェント</string>
     <string name="settings_agents_section">エージェント</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -897,6 +897,7 @@
     <string name="claude_error_submit_code">Não foi possível enviar o código</string>
     <string name="claude_error_install_failed">A instalação do Claude Code falhou</string>
     <string name="claude_error_update_failed">A atualização do Claude Code falhou</string>
+    <string name="claude_error_process_exited">O Claude Code parou antes de concluir o turno (%1$s)</string>
     <string name="setup_download_agents_description">Prepara o ambiente Linux compartilhado e os agentes escolhidos.</string>
     <string name="settings_agents_row">Agentes</string>
     <string name="settings_agents_section">Agentes</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -897,6 +897,7 @@
     <string name="claude_error_submit_code">Не удалось отправить код</string>
     <string name="claude_error_install_failed">Не удалось установить Claude Code</string>
     <string name="claude_error_update_failed">Не удалось обновить Claude Code</string>
+    <string name="claude_error_process_exited">Claude Code остановился, не завершив ход (%1$s)</string>
     <string name="setup_download_agents_description">Подготовка общей среды Linux и выбранных агентов.</string>
     <string name="settings_agents_row">Агенты</string>
     <string name="settings_agents_section">Агенты</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -897,6 +897,7 @@
     <string name="claude_error_submit_code">无法提交代码</string>
     <string name="claude_error_install_failed">Claude Code 安装失败</string>
     <string name="claude_error_update_failed">Claude Code 更新失败</string>
+    <string name="claude_error_process_exited">Claude Code 在完成本轮前退出（%1$s）</string>
     <string name="setup_download_agents_description">准备共享的 Linux 环境以及你选择的智能体。</string>
     <string name="settings_agents_row">智能体</string>
     <string name="settings_agents_section">智能体</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -943,6 +943,7 @@
     <string name="claude_error_submit_code">Could not submit the code</string>
     <string name="claude_error_install_failed">Claude Code installation failed</string>
     <string name="claude_error_update_failed">Claude Code update failed</string>
+    <string name="claude_error_process_exited">Claude Code stopped before finishing the turn (%1$s)</string>
     <string name="setup_download_agents_description">Prepare the shared Linux environment and the agents you picked.</string>
     <string name="settings_agents_row">Agents</string>
     <string name="settings_agents_section">Agents</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepositoryTest.kt
@@ -406,6 +406,121 @@ class RuntimeActivityRepositoryTest {
         }
 
     @Test
+    fun `session idle without a resolvable session does not notify`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val completed = mutableListOf<String>()
+            RuntimeActivityRepository(
+                registry = registry,
+                scope = TestScope(dispatcher),
+                onSessionIdle = { sessionId, _, _ -> completed += sessionId },
+            )
+            advanceUntilIdle()
+
+            target.eventFlow.emit(OpenCodeEvent.SessionIdle("unknown"))
+            advanceUntilIdle()
+
+            assertTrue(completed.isEmpty())
+        }
+
+    @Test
+    fun `a session error mutes the completion callback for the trailing idle`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            target.sessions = listOf(OpenCodeSession(id = "ses_1", title = "Main"))
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val completed = mutableListOf<String>()
+            val repository =
+                RuntimeActivityRepository(
+                    registry = registry,
+                    scope = TestScope(dispatcher),
+                    onSessionIdle = { sessionId, _, _ -> completed += sessionId },
+                )
+            advanceUntilIdle()
+
+            target.eventFlow.emit(OpenCodeEvent.SessionError("ses_1", "boom"))
+            advanceUntilIdle()
+            target.eventFlow.emit(OpenCodeEvent.SessionIdle("ses_1"))
+            advanceUntilIdle()
+
+            assertTrue(completed.isEmpty())
+            assertTrue(repository.state.value.mutedSessionIds.isEmpty())
+        }
+
+    @Test
+    fun `a muted session notifies again once a new run starts`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            target.sessions = listOf(OpenCodeSession(id = "ses_1", title = "Main"))
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val completed = mutableListOf<String>()
+            RuntimeActivityRepository(
+                registry = registry,
+                scope = TestScope(dispatcher),
+                onSessionIdle = { sessionId, _, _ -> completed += sessionId },
+            )
+            advanceUntilIdle()
+
+            target.eventFlow.emit(OpenCodeEvent.SessionError("ses_1", "boom"))
+            target.eventFlow.emit(OpenCodeEvent.SessionIdle("ses_1"))
+            advanceUntilIdle()
+            target.eventFlow.emit(OpenCodeEvent.SessionStatusChanged("ses_1", "busy"))
+            target.eventFlow.emit(OpenCodeEvent.SessionIdle("ses_1"))
+            advanceUntilIdle()
+
+            assertEquals(listOf("ses_1"), completed)
+        }
+
+    @Test
+    fun `markSessionAborted mutes the completion callback for the trailing idle`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget(requireConnected = false)
+            target.sessions = listOf(OpenCodeSession(id = "ses_1", title = "Main"))
+            val registry =
+                RuntimeRegistry(
+                    store = FakeStore(selectedRuntimeId = target.id),
+                    localTarget = target,
+                    remoteFactory = { error("unused") },
+                )
+            val completed = mutableListOf<String>()
+            val repository =
+                RuntimeActivityRepository(
+                    registry = registry,
+                    scope = TestScope(dispatcher),
+                    onSessionIdle = { sessionId, _, _ -> completed += sessionId },
+                )
+            advanceUntilIdle()
+
+            repository.markSessionRunning("ses_1")
+            repository.markSessionAborted("ses_1")
+            target.eventFlow.emit(OpenCodeEvent.SessionIdle("ses_1"))
+            advanceUntilIdle()
+
+            assertTrue(completed.isEmpty())
+            assertTrue(repository.state.value.activeSessionIds.isEmpty())
+        }
+
+    @Test
     fun `late tool events after a session error do not resurrect activity`() =
         runTest {
             val dispatcher = StandardTestDispatcher(testScheduler)

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -658,6 +658,22 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun `abort reports the session as aborted so its trailing idle does not notify`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val aborted = mutableListOf<String>()
+            val viewModel = ChatViewModel(backend, onSessionAborted = { aborted += it })
+            advanceUntilIdle()
+            viewModel.sendMessage("Do things")
+            advanceUntilIdle()
+
+            viewModel.abort()
+            advanceUntilIdle()
+
+            assertEquals(listOf("s1"), aborted)
+        }
+
+    @Test
     fun `history load maps tool parts alongside text parts`() =
         runTest(dispatcher) {
             val backend = FakeBackend()

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParserTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeStreamJsonParserTest.kt
@@ -4,6 +4,7 @@ import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -99,6 +100,16 @@ class ClaudeStreamJsonParserTest {
         assertTrue(parsed.turnFinished)
         assertNull(parsed.errorMessage)
         assertTrue(parsed.events.single() is OpenCodeEvent.SessionIdle)
+    }
+
+    @Test
+    fun `turnFinished tracks the live turn and resets on beginTurn`() {
+        val parser = parser()
+        parser.parse("""{"type":"result","subtype":"success","session_id":"abc"}""")
+        assertTrue(parser.turnFinished)
+
+        parser.beginTurn()
+        assertFalse(parser.turnFinished)
     }
 
     @Test


### PR DESCRIPTION
完了通知が「作業の完了」以外のidleでも飛んでいたケースを修正する。

- エラー終了: SessionError の後の trailing idle では完了通知を出さない (mute し、idle 消費で解除)
- 停止ボタン/中断送信: abort 時に mute し、kill されたランの idle を完了として通知しない
- サブエージェント判定: セッション取得に失敗したら通知しない (fail closed)
- Claude CLI がターン途中で死亡: bare idle ではなく SessionError + idle を発行し、チャットにもエラーとして表示

mute は one-shot で、trailing idle か新しいラン (markSessionRunning / busy status) で解除される。

Tests: RuntimeActivityRepositoryTest (+4), ChatViewModelTest (+1), ClaudeStreamJsonParserTest (+1). testDebugUnitTest / lintDebug / detekt / spotlessCheck 通過済み。

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- `RuntimeActivityRepository.kt` — `var notify` を `mutableState.update{}` のラムダ内で副作用として書き換えている。`update` の CAS リトライで最後に実行されたラムダの値が採用されるため結果は正しいが、慣習として外部変数への副作用は読みにくい。`mutedSessionIds` を退出前のスナップショットとして別途比較する構成にすると追跡性が上がる（振る舞いは等価）。
- `ClaudeCodeRuntime.kt` — リーダーJobの終了処理で、プロセスが mid-turn で終了し、かつ直後に同じ sessionId で新プロセスが start されたレアケースでは、旧Jobが発する `SessionError` が新ランのUIに一時的に表示されうる。mute機構で後続idle通知は正しく抑止されるため通知面は無害だが、`error` メッセージが一瞬出うる。実害は小さい。
- `ChatViewModel.kt` — 中断送信時に `onSessionAborted` を呼ぶが、Claudeバックエンドでは明示的なabortなしに新プロンプトがstdin追記される。Claudeが旧ターンを完了してから新ターンを処理する限り二重idleとなり最初がmute・二つ目が通知される設計は正しい。CLIが単一idleにマージするフローはないと想定するが、ドッグフーディングで要観察。

## チェック済み項目
- 正しさ: mute はone-shot設計（SessionIdle ハンドラと markSessionRunning/SessionStatusChanged でクリア）。error→idle ペア、abort、mid-turn exit の各ケースで通知が正しく抑止され、次回正常ランで再通知されることを確認。turnFinished フラグは @Volatile、beginTurn()→parseResult のライフサイクルが正確。stop() の cancel は CancellationException フィルタと !isActive ガードで確実に早期リターン。
- 隣接挙動の回帰: 旧コードは正常完了でも parser idle + リーダーJob末端の idle の二重発火だった。新コードは正常完了時に末端idleを発火しないため改善。abort 時の handleSessionIdle 副作用が走らなくなるが onSuccess で補完済み。
- i18n: claude_error_process_exited が values + ar/es/fr/ja/pt-rBR/ru/zh-rCN の8ロケール全てに存在し %1$s も一致。
- Compose/状態: mutedSessionIds は不変フィールドで copy() 経由のみ更新。DI は AndCodeApp で onSessionAborted を正しく接続。ChatViewModel の新パラメータはデフォルト値あり。
- 並行性: markSessionAborted/markSessionRunning は MutableStateFlow.update でアトミック。リーダーJobと stop() の競合は synchronized + !isActive ガードで整序。
- リソース漏れ: なし。
- セキュリティ: シークレットなし。
- テスト: RuntimeActivityRepositoryTest +4, ChatViewModelTest +1(abort発火), ClaudeStreamJsonParserTest +1(turnFinished リセット)。
- 慣習: processExited は ClaudeMessages interface + Default + AndroidClaudeMessages の既存パターンに準拠。