### PR TITLE
fix(runtime): hold a wake lock while the local runtime runs

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
@@ -7,6 +7,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import android.os.PowerManager
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -66,6 +67,29 @@ internal fun localRuntimeInstallAgents(ids: Array<String>?): Set<LocalAgent> =
         ?.takeIf(Set<LocalAgent>::isNotEmpty)
         ?: setOf(LocalAgent.OPEN_CODE)
 
+/**
+ * Whether the runtime is live enough to be worth keeping the CPU out of suspend for.
+ *
+ * A foreground service only stops the app from being killed; it does nothing to stop the device
+ * from suspending once the screen goes off, and the agent runs as a proot child of this process, so
+ * suspending freezes it mid-run - the symptom being work that "stopped by itself" in the background.
+ * The states that carry no running process - stopped, broken, never installed, unsupported - hold
+ * nothing, since keeping a dead runtime's device awake only costs battery.
+ */
+internal fun localRuntimeNeedsWakeLock(status: LocalRuntimeStatus): Boolean =
+    when (status) {
+        is LocalRuntimeStatus.Installing,
+        is LocalRuntimeStatus.Starting,
+        is LocalRuntimeStatus.Updating,
+        is LocalRuntimeStatus.Ready,
+        -> true
+        LocalRuntimeStatus.NotInstalled,
+        is LocalRuntimeStatus.Stopped,
+        is LocalRuntimeStatus.Broken,
+        is LocalRuntimeStatus.UnsupportedAbi,
+        -> false
+    }
+
 internal class RestartBackoff(
     private val nowMillis: () -> Long = System::currentTimeMillis,
     private val baseDelayMs: Long = 1_000L,
@@ -114,6 +138,7 @@ class LocalRuntimeService : Service() {
     private lateinit var manager: LocalRuntimeManager
     private val backoff = RestartBackoff()
     private var inForeground = false
+    private var wakeLock: PowerManager.WakeLock? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -126,10 +151,12 @@ class LocalRuntimeService : Service() {
                 .onFailure { error -> Log.w(TAG, "Could not enter the foreground", error) }
                 .isSuccess
         if (!inForeground) return
+        syncWakeLock(manager.status())
         scope.launch {
             manager.state.collectLatest { status ->
                 getSystemService(NotificationManager::class.java)
                     .notify(NOTIFICATION_ID, notification(status))
+                syncWakeLock(status)
                 if (status is LocalRuntimeStatus.Ready) {
                     backoff.reset()
                 }
@@ -222,6 +249,7 @@ class LocalRuntimeService : Service() {
         exitMonitorJob?.cancel()
         watchdogJob?.cancel()
         scope.cancel()
+        releaseWakeLock()
         super.onDestroy()
     }
 
@@ -241,11 +269,44 @@ class LocalRuntimeService : Service() {
                     delay(WATCHDOG_INTERVAL_MILLIS)
                     if (!autoRestartEnabled) continue
                     val status = manager.status()
+                    // Re-arms the wake lock's timeout well inside it, so a run lasting hours keeps
+                    // the CPU up while a service that died without onDestroy still lets it lapse.
+                    syncWakeLock(status)
                     if (watchdog.observe(status)) {
                         manager.ensureRunning()
                     }
                 }
             }
+    }
+
+    /**
+     * Holds or drops the CPU wake lock to match [status]; see [localRuntimeNeedsWakeLock].
+     *
+     * Synchronized because both the status collector on the main thread and the watchdog on an IO
+     * one call it. The lock is not reference counted, so an acquire on a status that already holds
+     * it only pushes the timeout back rather than stacking a release debt.
+     */
+    @Synchronized
+    private fun syncWakeLock(status: LocalRuntimeStatus) {
+        if (!localRuntimeNeedsWakeLock(status)) {
+            releaseWakeLock()
+            return
+        }
+        val lock =
+            wakeLock ?: getSystemService(PowerManager::class.java)
+                ?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG)
+                ?.apply { setReferenceCounted(false) }
+                ?.also { wakeLock = it }
+        runCatching { lock?.acquire(WAKELOCK_TIMEOUT_MILLIS) }
+            .onFailure { error -> Log.w(TAG, "Could not hold the CPU awake", error) }
+    }
+
+    @Synchronized
+    private fun releaseWakeLock() {
+        val lock = wakeLock ?: return
+        if (!lock.isHeld) return
+        runCatching { lock.release() }
+            .onFailure { error -> Log.w(TAG, "Could not let the CPU sleep", error) }
     }
 
     private fun notification(status: LocalRuntimeStatus): android.app.Notification {
@@ -348,6 +409,8 @@ class LocalRuntimeService : Service() {
         private const val CHANNEL_ID = "local_opencode_runtime"
         private const val NOTIFICATION_ID = 4107
         private const val WATCHDOG_INTERVAL_MILLIS = 5_000L
+        private const val WAKELOCK_TAG = "opencode:runtime"
+        private const val WAKELOCK_TIMEOUT_MILLIS = 10 * 60 * 1000L
         const val ACTION_INSTALL_AND_START = "com.yugahashimoto.andcode.local.INSTALL_AND_START"
         const val ACTION_START = "com.yugahashimoto.andcode.local.START"
         const val ACTION_STOP = "com.yugahashimoto.andcode.local.STOP"

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
@@ -139,6 +139,7 @@ class LocalRuntimeService : Service() {
     private val backoff = RestartBackoff()
     private var inForeground = false
     private var wakeLock: PowerManager.WakeLock? = null
+    private var shuttingDown = false
 
     override fun onCreate() {
         super.onCreate()
@@ -249,7 +250,7 @@ class LocalRuntimeService : Service() {
         exitMonitorJob?.cancel()
         watchdogJob?.cancel()
         scope.cancel()
-        releaseWakeLock()
+        shutDownWakeLock()
         super.onDestroy()
     }
 
@@ -267,11 +268,13 @@ class LocalRuntimeService : Service() {
                 val watchdog = LocalRuntimeWatchdog()
                 while (isActive) {
                     delay(WATCHDOG_INTERVAL_MILLIS)
-                    if (!autoRestartEnabled) continue
                     val status = manager.status()
                     // Re-arms the wake lock's timeout well inside it, so a run lasting hours keeps
                     // the CPU up while a service that died without onDestroy still lets it lapse.
+                    // Ahead of the auto-restart check so that a runtime left running by a path that
+                    // never enables it - an unknown action, a stop that threw - still stays awake.
                     syncWakeLock(status)
+                    if (!autoRestartEnabled) continue
                     if (watchdog.observe(status)) {
                         manager.ensureRunning()
                     }
@@ -288,7 +291,7 @@ class LocalRuntimeService : Service() {
      */
     @Synchronized
     private fun syncWakeLock(status: LocalRuntimeStatus) {
-        if (!localRuntimeNeedsWakeLock(status)) {
+        if (shuttingDown || !localRuntimeNeedsWakeLock(status)) {
             releaseWakeLock()
             return
         }
@@ -307,6 +310,20 @@ class LocalRuntimeService : Service() {
         if (!lock.isHeld) return
         runCatching { lock.release() }
             .onFailure { error -> Log.w(TAG, "Could not let the CPU sleep", error) }
+    }
+
+    /**
+     * Drops the lock for good.
+     *
+     * [android.app.Service.onDestroy] cancelling the scope does not interrupt a watchdog tick that
+     * is already inside [syncWakeLock], so a plain release can be followed by that tick's acquire
+     * and leave the lock held past the service. The flag closes that window from inside the same
+     * monitor: whichever of the two runs first, the tick ends up a no-op.
+     */
+    @Synchronized
+    private fun shutDownWakeLock() {
+        shuttingDown = true
+        releaseWakeLock()
     }
 
     private fun notification(status: LocalRuntimeStatus): android.app.Notification {

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeServiceCommandTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeServiceCommandTest.kt
@@ -1,7 +1,10 @@
 package com.yugahashimoto.andcode.runtime.local
 
 import com.yugahashimoto.andcode.runtime.LocalAgent
+import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LocalRuntimeServiceCommandTest {
@@ -67,5 +70,35 @@ class LocalRuntimeServiceCommandTest {
         assertEquals(setOf(LocalAgent.OPEN_CODE), localRuntimeInstallAgents(null))
         assertEquals(setOf(LocalAgent.OPEN_CODE), localRuntimeInstallAgents(emptyArray()))
         assertEquals(setOf(LocalAgent.OPEN_CODE), localRuntimeInstallAgents(arrayOf("not-an-agent")))
+    }
+
+    /**
+     * A state with a live process behind it has to keep the device out of suspend: the agent is a
+     * proot child of this process, so a screen-off suspend freezes a run that is still going.
+     */
+    @Test
+    fun `a running runtime keeps the CPU awake`() {
+        assertTrue(localRuntimeNeedsWakeLock(LocalRuntimeStatus.Ready(version = "1.0.0", port = 4096)))
+        assertTrue(localRuntimeNeedsWakeLock(LocalRuntimeStatus.Starting(version = "1.0.0", port = 4096)))
+        assertTrue(localRuntimeNeedsWakeLock(LocalRuntimeStatus.Installing(progress = 0.5f, step = "unpacking")))
+        assertTrue(
+            localRuntimeNeedsWakeLock(
+                LocalRuntimeStatus.Updating(
+                    currentVersion = "1.0.0",
+                    targetVersion = "1.1.0",
+                    progress = null,
+                    step = "downloading",
+                ),
+            ),
+        )
+    }
+
+    /** Keeping a runtime that holds no process awake would only cost battery. */
+    @Test
+    fun `a runtime with nothing running lets the device sleep`() {
+        assertFalse(localRuntimeNeedsWakeLock(LocalRuntimeStatus.NotInstalled))
+        assertFalse(localRuntimeNeedsWakeLock(LocalRuntimeStatus.Stopped(version = "1.0.0", port = 4096)))
+        assertFalse(localRuntimeNeedsWakeLock(LocalRuntimeStatus.Broken(reason = "missing rootfs")))
+        assertFalse(localRuntimeNeedsWakeLock(LocalRuntimeStatus.UnsupportedAbi(abi = "x86")))
     }
 }


### PR DESCRIPTION
## 何が問題だったか

`LocalRuntimeService` はフォアグラウンドサービスでありながら `PARTIAL_WAKE_LOCK` を取得していませんでした。フォアグラウンドサービスは「アプリが kill されにくくなる」だけで、**画面消灯後に端末がサスペンドするのを止める効果はありません**。

エージェントはこのプロセスの proot 子プロセスとして動くため、サスペンドすると実行中のまま凍結します。これがバックグラウンド実行が「勝手に止まる」症状の一因でした。

## 変更内容

- `localRuntimeNeedsWakeLock(status)` を追加。ライブなプロセスを持つ状態（`Installing` / `Starting` / `Updating` / `Ready`）で wake lock を保持し、持たない状態（`Stopped` / `Broken` / `NotInstalled` / `UnsupportedAbi`）では解放します。死んだランタイムのために端末を起こし続けても電池を食うだけなので。
- 取得・解放を `syncWakeLock(status)` に集約し、状態フローの collector（状態変化への即応）と watchdog の5秒ティック（タイムアウトの再アーム）の両方から呼びます。
- タイムアウトは既存の `WakeWordService` に合わせて10分。watchdog が5秒ごとに再アームするので長時間の実行でも切れませんが、**サービスが `onDestroy` を通らずに死んだ場合は10分で自動失効**するため、恒久的なリークにはなりません。
- `setReferenceCounted(false)` により、同一状態での acquire 繰り返しはタイムアウトを延長するだけで release 債務を積み上げません。
- collector はメインスレッド、watchdog は IO スレッドから呼ぶため `@Synchronized`。

2コミット目はレビュー指摘の反映です。

- wake lock の再アームを `autoRestartEnabled` チェックの前に移動し、auto-restart フラグから独立させました（未知 action での起動や、`stopSelf` 到達前に例外で落ちた stop の場合でも、動いているランタイムは起きたままになります）。
- `shuttingDown` フラグを追加。`onDestroy` の `scope.cancel()` は既に `syncWakeLock` 内にいる watchdog ティックを中断しないため、単純な release の後にそのティックの acquire が成立してサービス破棄後もロックが残る窓がありました。同一モニタ内でフラグを立てることでこれを閉じています。

`android.permission.WAKE_LOCK` は既にマニフェストに宣言済みのため、権限の追加はありません。

## スコープ外

- **Android 12+ の phantom process killer**（proot 配下の子プロセスが CPU 使用量やプロセス数で SIGKILL される）はこの変更では回避できません。OS 側の制限であり、ADB での無効化が別途必要です。
- `Ready` かつエージェント未実行のアイドル時もロックを保持する設計です。実行中セッションの有無に紐付ける、あるいはアイドル N 分で解放する改善余地はレビューでも指摘されていますが、本 PR の目的（実行中の凍結を止める）とは分けて扱います。

## テスト

- `LocalRuntimeServiceCommandTest` に状態→wake lock 要否のケースを2本追加（全8状態を網羅）。
- `./gradlew detekt spotlessCheck :app:testDebugUnitTest :app:lintDebug` すべて BUILD SUCCESSFUL。

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
なし

## 提案（非ブロッキング）
- app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt:84 — （前回の3点目、今回スコープ外として了解）`Ready`（サーバ起動済み・エージェント未実行のアイドル）でもロックを保持し続ける設計。`RuntimeAutoStartInitializer.restoreIfConfigured()`（app/src/main/java/com/yugahashimoto/andcode/startup/RuntimeAutoStartInitializer.kt:87）がアプリプロセス生成のたびに `start()` を呼ぶため、ローカルランタイム利用者は実質「常時 PARTIAL_WAKE_LOCK 保持」になる。将来的には実行中セッション有無（`core/api` の session status `idle`/`busy`、app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt:326）に紐付けるか、アイドル N 分で解放する方向の余地がある。今回の PR 単体では「実行中の凍結を止める」という目的を満たしており、分割は妥当な判断。
- app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt:271 — 今回の並び替えの副作用として、`manager.status()` が `autoRestartEnabled == false` の間も5秒ごとに走るようになった。`LocalRuntimeManager.status()` は `computeStatus()` の結果を `mutableState` に書き戻す副作用を持つため、Stop/Delete 実行後 `onDestroy` までの数秒の窓で状態が再パブリッシュされうる。実害はほぼない（`stop()` は `processLauncher.stop()` 完了後に `Stopped` を設定するので `computeStatus()` も同値を返し、StateFlow は等値を再emitしない／コストも `Process.isAlive()` と localhost ソケットプローブのみで通常経路では元から毎ティック実行済み）が、`stop()` がプロセスを落としきれなかった場合に限り `Ready` が再パブリッシュされ、`stopForeground(STOP_FOREGROUND_REMOVE)` 後に通知が再掲される可能性が理屈上残る。気になるなら `syncWakeLock` 用に副作用のない状態取得（`manager.state.value`）を使う手もあるが、その場合 Installing/Starting/Updating の据え置き分岐との整合を別途確認する必要があるため、現状のままでも妥当。

## チェック済み項目
- 追加コミット 4916c43 の diff と `git diff origin/main...HEAD` 全体（2コミット / 2ファイル / +114 −1）を読み直し、`LocalRuntimeService.kt` の最終形（271-278行、292-326行）を実ファイルで確認。
- 指摘1の反映を確認：`val status = manager.status()` と `syncWakeLock(status)`（271, 276行）が `if (!autoRestartEnabled) continue`（277行）の前に移動し、wake lock の再アームが auto-restart フラグから独立した。
- 並び替えによる watchdog セマンティクスの非回帰を確認：`watchdog.observe(status)`（278行）は `continue` の後ろのままで、`LocalRuntimeWatchdog.consecutiveFailures` は auto-restart 有効時にしか進まない。「意図的な停止は失敗カウントに数えない」という LocalRuntimeWatchdog.kt:6-8 のコメント上の前提が保たれている。
- 指摘2の反映を確認：`shuttingDown`（142行）は `syncWakeLock`（294行）と `shutDownWakeLock`（324-325行）という同一モニタ（`@Synchronized` = インスタンスロック）内でのみ読み書きされ、`@Volatile` なしでも可視性が担保される。`onDestroy`（253行）が `releaseWakeLock()` ではなく `shutDownWakeLock()` を呼ぶため、`scope.cancel()` 後に既に `syncWakeLock` 内へ入っていた watchdog ティックは、先行・後行どちらの順序でも no-op に落ちる（後行なら `shuttingDown` で release パスへ、先行ならその acquire の後に `shutDownWakeLock` が release する）。ロックがサービス破棄後に残る窓は閉じている。
- `shuttingDown` をリセットする経路がないことは正しい：Service インスタンスは `onDestroy` 後に再利用されず、再起動時は新インスタンスが生成される。
- `releaseWakeLock()` の再入を確認：`syncWakeLock` / `shutDownWakeLock` から呼ばれるが、Java モニタは再入可能でデッドロックしない。`isHeld` ガード＋`runCatching` によりタイムアウト解放とのレース（under-locked 例外）も保護済み。
- 1コミット目の内容も再確認：AndroidManifest.xml:31 の `WAKE_LOCK` 権限、`localRuntimeNeedsWakeLock` の全8ケース網羅（sealed interface + when 式でケース追加時にコンパイルエラー）、`setReferenceCounted(false)` + `acquire(timeout)` による5秒ティックでのタイムアウト延長挙動、`WakeWordService.kt`（tag `opencode:*`、`10 * 60 * 1000L`）との実装パターン整合。
- テスト：追加2ケースのコンストラクタ引数が `LocalRuntimeStatus.kt` の実定義と一致。2コミット目はロジック分岐を増やしていない（フラグと順序のみ）ため、テスト追加なしで妥当。Robolectric 未導入のためサービス本体は純粋関数抽出でカバーする方針が引き続き適切。
- i18n：ユーザー可視文字列の追加なし（strings.xml 変更ゼロ）、ログ・KDoc は英語。i18n-check への影響なし。
- CI 影響：全行140字以内（detekt MaxLineLength=140）、`LocalRuntimeService` クラスの関数は12・ファイル計27で TooManyFunctions（クラス25／ファイル30）内、`shutDownWakeLock` は FunctionNaming パターン `[a-z][a-zA-Z0-9]*` に適合。コーディネータ報告のローカルゲート（`detekt spotlessCheck :app:testDebugUnitTest :app:lintDebug` すべて成功）と矛盾しない。
- ブランチが `origin/main` を祖先に持つ worktree（`.worktree/fix/runtime-wakelock`）上にあること、両コミットのメッセージが `fix(runtime): ...` 形式で commitlint 準拠であることを確認。

> レビュー実行についての注記: このリポジトリの `pre-pr-review` スキルは opencode の `repo-reviewer` サブエージェント（`.opencode/agents/repo-reviewer.md`）を指定していますが、今回は Claude Code セッションのため、同じエージェント定義を読み込ませたサブエージェントでレビューを実行しました。上記レポートはそのサブエージェントの実出力そのままです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
