### PR TITLE
fix(chat): surface provider errors in the chat

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
@@ -101,8 +101,6 @@ data class OpenCodePart(
     val tool: String? = null,
     val callID: String? = null,
     val state: Map<String, JsonElement>? = null,
-    /** Present on `retry` parts, which carry the provider error that triggered the retry. */
-    val error: OpenCodeMessageError? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
@@ -3,6 +3,7 @@ package com.yugahashimoto.andcode.core.api
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 data class OpenCodeHealth(
@@ -69,7 +70,23 @@ data class OpenCodeMessageInfo(
     val agent: String? = null,
     val model: OpenCodeModelReference? = null,
     val tokens: OpenCodeSessionTokens? = null,
+    /** Provider/session failure recorded on the message, e.g. `ApiError` with `statusCode` 429. */
+    val error: OpenCodeMessageError? = null,
 )
+
+/** A typed message error, e.g. `ApiError`; rendered in the chat when a turn fails. */
+@Serializable
+data class OpenCodeMessageError(
+    val name: String? = null,
+    val data: Map<String, JsonElement>? = null,
+) {
+    val message: String?
+        get() =
+            data?.get("message")
+                ?.takeIf { it is JsonPrimitive }
+                ?.let { (it as JsonPrimitive).content }
+                ?.takeIf { it.isNotBlank() }
+}
 
 @Serializable
 data class OpenCodePart(
@@ -84,6 +101,8 @@ data class OpenCodePart(
     val tool: String? = null,
     val callID: String? = null,
     val state: Map<String, JsonElement>? = null,
+    /** Present on `retry` parts, which carry the provider error that triggered the retry. */
+    val error: OpenCodeMessageError? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -21,6 +21,10 @@ sealed interface TimelineEntry {
         override val id: String get() = "image:${part.id}"
     }
 
+    data class Error(val part: ChatPart.Error) : TimelineEntry {
+        override val id: String get() = "error:${part.id}"
+    }
+
     data class Activity(override val id: String, val parts: List<ChatPart>) : TimelineEntry
 
     data class Todo(override val id: String, val todos: List<TodoItem>) : TimelineEntry
@@ -136,6 +140,11 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
                     flush()
                     entries += TimelineEntry.Image(message.id, part)
                 }
+                part is ChatPart.Error -> {
+                    flush()
+                    flushTurnFooter()
+                    entries += TimelineEntry.Error(part)
+                }
                 part !is ChatPart.Text -> pending += part
                 part.text.isNotBlank() -> {
                     flush()
@@ -186,6 +195,7 @@ fun summarizeActivity(parts: List<ChatPart>): ActivitySummary {
             }
             is ChatPart.Text -> Unit
             is ChatPart.Image -> Unit
+            is ChatPart.Error -> Unit
         }
     }
     return ActivitySummary(counts = counts, reasoningCount = reasoning, running = running, hasError = hasError)

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -142,8 +142,9 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
                 }
                 part is ChatPart.Error -> {
                     flush()
-                    flushTurnFooter()
+                    // Footer must trail the error card the way it trails a body text entry.
                     entries += TimelineEntry.Error(part)
+                    flushTurnFooter()
                 }
                 part !is ChatPart.Text -> pending += part
                 part.text.isNotBlank() -> {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
@@ -180,6 +180,7 @@ fun AssistantActivitySheet(
                     is ChatPart.Patch -> PatchCard(part)
                     is ChatPart.Text -> Unit
                     is ChatPart.Image -> Unit
+                    is ChatPart.Error -> Unit
                 }
             }
             item { Column(modifier = Modifier.padding(bottom = 32.dp)) {} }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -400,6 +400,7 @@ fun ChatHomeScreen(
                                         is TimelineEntry.Image -> null
                                         is TimelineEntry.Activity -> null
                                         is TimelineEntry.Todo -> null
+                                        is TimelineEntry.Error -> null
                                         is TimelineEntry.Footer -> null
                                     }
                                 Box(

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -3,6 +3,7 @@ package com.yugahashimoto.andcode.feature.chat
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
@@ -22,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -170,6 +173,7 @@ fun TimelineEntryRow(
         is TimelineEntry.UserMessage -> MessageBubble(entry.message, onImageClick)
         is TimelineEntry.Body -> MarkdownText(entry.part.text, onImageClick = onImageClick)
         is TimelineEntry.Image -> ImagePartView(entry.part, onImageClick)
+        is TimelineEntry.Error -> ErrorPartCard(entry.part)
         is TimelineEntry.Activity ->
             AssistantActivityRow(
                 parts = entry.parts,
@@ -177,6 +181,37 @@ fun TimelineEntryRow(
             )
         is TimelineEntry.Todo -> TodoTimelineCard(entry.todos)
         is TimelineEntry.Footer -> MessageFooter(entry)
+    }
+}
+
+/** An assistant turn that failed (provider error, retries exhausted, ...) surfaced in the chat. */
+@Composable
+private fun ErrorPartCard(part: ChatPart.Error) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.45f)),
+        shape = RoundedCornerShape(18.dp),
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    Icons.Default.ErrorOutline,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+                Text(
+                    text = stringResource(R.string.error_session_failed),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(text = part.message, color = MaterialTheme.colorScheme.onSurface)
+        }
     }
 }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -9,6 +9,7 @@ import com.yugahashimoto.andcode.core.api.ConnectionQualityMonitor
 import com.yugahashimoto.andcode.core.api.OpenCodeCommand
 import com.yugahashimoto.andcode.core.api.OpenCodeEvent
 import com.yugahashimoto.andcode.core.api.OpenCodeMessage
+import com.yugahashimoto.andcode.core.api.OpenCodeMessageError
 import com.yugahashimoto.andcode.core.api.OpenCodePart
 import com.yugahashimoto.andcode.core.api.OpenCodeSkill
 import com.yugahashimoto.andcode.core.api.PermissionRequest
@@ -80,6 +81,9 @@ sealed interface ChatPart {
         val url: String,
         val filename: String? = null,
     ) : ChatPart
+
+    /** The model/provider failed; carries the human-readable error reported by the runtime. */
+    data class Error(override val id: String, val message: String) : ChatPart
 }
 
 data class ChatMessage(
@@ -211,8 +215,32 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
             )
         }
         "patch" -> ChatPart.Patch(partId, extractPatchFiles(stateMap))
+        "retry" -> {
+            // A failed assistant message is persisted with a `retry` part holding the provider
+            // error that exhausted the retries, so the turn is not silently swallowed.
+            val message = error?.message
+            if (message.isNullOrBlank()) {
+                null
+            } else {
+                ChatPart.Error(partId, message)
+            }
+        }
         else -> null
     }
+}
+
+/**
+ * Appends the message-level error reported by the runtime when the turn itself carries no error
+ * part. A failed provider request is persisted with the error on the message (`info.error`) and
+ * often nothing else, so without this the transcript would silently drop the failed turn.
+ */
+internal fun List<ChatPart>.withMessageError(
+    messageId: String,
+    error: OpenCodeMessageError?,
+): List<ChatPart> {
+    val message = error?.message ?: return this
+    if (any { it is ChatPart.Error }) return this
+    return this + ChatPart.Error("$messageId-error", message)
 }
 
 private fun JsonElement.jsonPrimitiveOrNull(): String? = (this as? JsonPrimitive)?.contentOrNull ?: (this as? JsonPrimitive)?.content
@@ -1621,7 +1649,7 @@ class ChatViewModel(
 
     private fun toUiMessage(message: OpenCodeMessage): ChatMessage? {
         messageRoles[message.info.id] = message.info.role
-        val parts = message.parts.mapNotNull { it.toChatPart() }
+        val parts = message.parts.mapNotNull { it.toChatPart() }.withMessageError(message.info.id, message.info.error)
         val attachments =
             message.parts.mapNotNull { part ->
                 if (part.type != "file") return@mapNotNull null

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -215,16 +215,6 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
             )
         }
         "patch" -> ChatPart.Patch(partId, extractPatchFiles(stateMap))
-        "retry" -> {
-            // A failed assistant message is persisted with a `retry` part holding the provider
-            // error that exhausted the retries, so the turn is not silently swallowed.
-            val message = error?.message
-            if (message.isNullOrBlank()) {
-                null
-            } else {
-                ChatPart.Error(partId, message)
-            }
-        }
         else -> null
     }
 }
@@ -233,15 +223,21 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
  * Appends the message-level error reported by the runtime when the turn itself carries no error
  * part. A failed provider request is persisted with the error on the message (`info.error`) and
  * often nothing else, so without this the transcript would silently drop the failed turn.
+ *
+ * User-initiated aborts are excluded: OpenCode records them as `MessageAbortedError`, and stopping
+ * a turn is not a failure the chat should flag red.
  */
 internal fun List<ChatPart>.withMessageError(
     messageId: String,
     error: OpenCodeMessageError?,
 ): List<ChatPart> {
-    val message = error?.message ?: return this
+    if (error == null || error.isAbort()) return this
+    val message = error.message ?: return this
     if (any { it is ChatPart.Error }) return this
     return this + ChatPart.Error("$messageId-error", message)
 }
+
+private fun OpenCodeMessageError.isAbort(): Boolean = name == "MessageAbortedError" || name == "AbortError"
 
 private fun JsonElement.jsonPrimitiveOrNull(): String? = (this as? JsonPrimitive)?.contentOrNull ?: (this as? JsonPrimitive)?.content
 

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatErrorPartTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatErrorPartTest.kt
@@ -1,0 +1,105 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import com.yugahashimoto.andcode.core.api.OpenCodeMessageError
+import com.yugahashimoto.andcode.core.api.OpenCodePart
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatErrorPartTest {
+    @Test
+    fun `maps a retry part carrying a provider error to an error part`() {
+        val part =
+            OpenCodePart(
+                id = "p1",
+                type = "retry",
+                error =
+                    OpenCodeMessageError(
+                        name = "APIError",
+                        data = mapOf("message" to JsonPrimitive("Rate limit exceeded (HTTP 429)")),
+                    ),
+            )
+
+        val chat = part.toChatPart() as ChatPart.Error
+        assertEquals("p1", chat.id)
+        assertEquals("Rate limit exceeded (HTTP 429)", chat.message)
+    }
+
+    @Test
+    fun `drops a retry part without an error message`() {
+        val part = OpenCodePart(id = "p2", type = "retry", error = OpenCodeMessageError(name = "APIError"))
+
+        assertNull(part.toChatPart())
+    }
+
+    @Test
+    fun `drops an error part whose message is only whitespace`() {
+        val part =
+            OpenCodePart(
+                id = "p3",
+                type = "retry",
+                error = OpenCodeMessageError(name = "UnknownError", data = mapOf("message" to JsonPrimitive("   "))),
+            )
+
+        assertNull(part.toChatPart())
+    }
+
+    @Test
+    fun `surfaces a message level error when the turn has no retry part`() {
+        val error =
+            OpenCodeMessageError(
+                name = "APIError",
+                data = mapOf("message" to JsonPrimitive("Rate limit exceeded (HTTP 429)")),
+            )
+
+        val parts = emptyList<ChatPart>().withMessageError("m1", error)
+
+        val errorPart = parts.single() as ChatPart.Error
+        assertEquals("m1-error", errorPart.id)
+        assertEquals("Rate limit exceeded (HTTP 429)", errorPart.message)
+    }
+
+    @Test
+    fun `keeps a failed assistant message with only an error visible in the timeline`() {
+        val error =
+            OpenCodeMessageError(
+                name = "APIError",
+                data = mapOf("message" to JsonPrimitive("invalid api key")),
+            )
+        val message = ChatMessage(id = "m2", isUser = false, parts = emptyList<ChatPart>().withMessageError("m2", error))
+
+        val entries = groupConversationTimeline(listOf(message))
+
+        assertEquals(1, entries.size)
+        assertEquals("error:m2-error", entries.single().id)
+        assertTrue(entries.single() is TimelineEntry.Error)
+    }
+
+    @Test
+    fun `surfaces a message level error alongside streamed parts`() {
+        val error =
+            OpenCodeMessageError(
+                name = "APIError",
+                data =
+                    mapOf(
+                        "message" to JsonPrimitive("upstream provider exploded"),
+                        "statusCode" to JsonPrimitive(500),
+                    ),
+            )
+        val message =
+            ChatMessage(
+                id = "m3",
+                isUser = false,
+                parts =
+                    listOf(ChatPart.Text(id = "t1", text = "partial answer"))
+                        .withMessageError("m3", error),
+            )
+
+        val timeline = groupConversationTimeline(listOf(message))
+
+        assertTrue(timeline.filterIsInstance<TimelineEntry.Error>().isNotEmpty())
+        assertTrue(timeline.filterIsInstance<TimelineEntry.Body>().isNotEmpty())
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatErrorPartTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatErrorPartTest.kt
@@ -10,44 +10,7 @@ import org.junit.Test
 
 class ChatErrorPartTest {
     @Test
-    fun `maps a retry part carrying a provider error to an error part`() {
-        val part =
-            OpenCodePart(
-                id = "p1",
-                type = "retry",
-                error =
-                    OpenCodeMessageError(
-                        name = "APIError",
-                        data = mapOf("message" to JsonPrimitive("Rate limit exceeded (HTTP 429)")),
-                    ),
-            )
-
-        val chat = part.toChatPart() as ChatPart.Error
-        assertEquals("p1", chat.id)
-        assertEquals("Rate limit exceeded (HTTP 429)", chat.message)
-    }
-
-    @Test
-    fun `drops a retry part without an error message`() {
-        val part = OpenCodePart(id = "p2", type = "retry", error = OpenCodeMessageError(name = "APIError"))
-
-        assertNull(part.toChatPart())
-    }
-
-    @Test
-    fun `drops an error part whose message is only whitespace`() {
-        val part =
-            OpenCodePart(
-                id = "p3",
-                type = "retry",
-                error = OpenCodeMessageError(name = "UnknownError", data = mapOf("message" to JsonPrimitive("   "))),
-            )
-
-        assertNull(part.toChatPart())
-    }
-
-    @Test
-    fun `surfaces a message level error when the turn has no retry part`() {
+    fun `appends the message level error for a failed turn`() {
         val error =
             OpenCodeMessageError(
                 name = "APIError",
@@ -101,5 +64,35 @@ class ChatErrorPartTest {
 
         assertTrue(timeline.filterIsInstance<TimelineEntry.Error>().isNotEmpty())
         assertTrue(timeline.filterIsInstance<TimelineEntry.Body>().isNotEmpty())
+    }
+
+    @Test
+    fun `does not flag a user initiated abort as an error`() {
+        val error =
+            OpenCodeMessageError(
+                name = "MessageAbortedError",
+                data = mapOf("message" to JsonPrimitive("The operation was aborted.")),
+            )
+
+        assertTrue(emptyList<ChatPart>().withMessageError("m4", error).isEmpty())
+    }
+
+    @Test
+    fun `does not flag a turn that succeeded after retries as an error`() {
+        val error =
+            OpenCodeMessageError(
+                name = "ApiError",
+                data = mapOf("message" to JsonPrimitive("Rate limited, retrying…")),
+            )
+        val retryPart = OpenCodePart(id = "r1", type = "retry", error = error)
+
+        assertNull(retryPart.toChatPart())
+    }
+
+    @Test
+    fun `ignores a message level error without a message`() {
+        val error = OpenCodeMessageError(name = "UnknownError", data = null)
+
+        assertTrue(emptyList<ChatPart>().withMessageError("m5", error).isEmpty())
     }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatErrorPartTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatErrorPartTest.kt
@@ -79,12 +79,9 @@ class ChatErrorPartTest {
 
     @Test
     fun `does not flag a turn that succeeded after retries as an error`() {
-        val error =
-            OpenCodeMessageError(
-                name = "ApiError",
-                data = mapOf("message" to JsonPrimitive("Rate limited, retrying…")),
-            )
-        val retryPart = OpenCodePart(id = "r1", type = "retry", error = error)
+        // Retry parts are persisted even when the retry succeeds; they must never render as an
+        // error on their own, only the message-level info.error does.
+        val retryPart = OpenCodePart(id = "r1", type = "retry")
 
         assertNull(retryPart.toChatPart())
     }


### PR DESCRIPTION
<!-- pre-pr-review: approved -->
## Pre-PR review

レビュー完了。前回 APPROVE 後の差分（コミット `890985a`）を中心に、ブランチ全体（3コミット）を検証しました。

```
判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- なし

## チェック済み項目
- 差分スコープ: `git diff origin/main...HEAD` を全ハンク読了。前回 APPROVE 後の差分は `890985a`（`OpenCodePart.error` フィールド削除 + リトライテスト簡素化）のみで、working tree はクリーン、ブランチは `.worktree/fix/chat-error-display` 上で origin/main から ahead 3（worktree ルール遵守）
- デッドフィールド削除の安全性: `OpenCodePart.error` への本番参照が残っていないことを `rg` で確認（`AssistantActivityRow.kt:360` の `part.error` は `ChatPart.Tool.error`(String)、`ChatViewModel.kt:1648` の `message.info.error` は `OpenCodeMessageError` で別物）。`OpenCodeMessageError` 型自体は `OpenCodeMessageInfo.error` と `withMessageError` で引き続き使用
- シリアライズ互換性: `OpenCodeEventParser.kt:14` が `ignoreUnknownKeys = true` のため、retry パートに付く `error` キーは無視され安全。`OpenCodePart(...)` の全呼び出し（ClaudeCodeRuntime / AntigravityRuntime / 各 StreamJsonParser）は位置引数が `type` まで＋名前付き引数で、末尾デフォルト引数の削除による影響なし
- テスト整合性: `ChatErrorPartTest` の簡素化後も全 import が使用され、`OpenCodePart(id="r1", type="retry")` → `toChatPart()` が `else -> null` で null を返す検証は維持。アボート除外・メッセージ欠落除外・タイムライン可視性の各テストも健在
- i18n: 新規キー `error_session_failed` が全8ロケール（values, ar, es, fr, ja, pt-rBR, ru, zh-rCN）に存在することを確認。新規 UI コードにハードコード文字列なし（`ErrorPartCard` は `stringResource` 使用、`part.message` はランタイム由来データ）
- 網羅性: `ChatPart` / `TimelineEntry` の sealed 網羅 when を全箇所確認（`groupConversationTimeline`・`summarizeActivity`・`AssistantActivitySheet`・`ChatHomeScreen`・`TimelineEntryRow` は更新済み、`PullRequestLinks` と `ChatViewModel` の delta when は `else` 分岐ありで安全）
- 依存関係: `Icons.Default.ErrorOutline` は `AssistantActivityRow.kt` で既存使用、`material-icons-extended` 依存あり
- セキュリティ/リソース/並行性: 新規に秘密情報・レシーバ/ストリームリーク・コルーチンリークなし
- 注記: この環境では gradle 実行が許可されておらず（permission rule）、テストは静的検証のみ。差分がデッドコード削除＋テスト簡素化のみで material でないため、前回 APPROVE を最終判定として採用
```