### PR TITLE
fix(chat): abort a wedged turn before sending the message that replaces it

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -380,6 +380,17 @@ class ChatViewModel(
 
     private val pullRequestRefs = MutableStateFlow<List<PullRequestRef>>(emptyList())
 
+    /**
+     * Sessions whose idles currently belong to a run this chat interrupted rather than to the prompt
+     * sent in its place.
+     *
+     * OpenCode reports one cancelled run as both `session.status: idle` and the deprecated
+     * `session.idle`, so counting idles would not do; the window instead stays open until the
+     * replacement run reports itself busy, and is closed by [closeInterruptWindow] if that turn ends
+     * without ever getting there.
+     */
+    private val pendingInterrupts = mutableSetOf<String>()
+
     private val messageQueue = MutableStateFlow<List<QueuedPrompt>>(emptyList())
     private val offlineMessageQueue = MutableStateFlow<List<QueuedPrompt>>(emptyList())
 
@@ -653,6 +664,7 @@ class ChatViewModel(
         // state too — otherwise the composer opens the new chat already stuck on the stop button
         // because the old chat happened to be mid-turn when the user navigated away.
         val switchingSession = _uiState.value.sessionId != sessionId
+        if (switchingSession) pendingInterrupts.clear()
         streamedParts.clear()
         messageRoles.clear()
         // Opening the chat is an explicit act of attention, so questions the user hid earlier are
@@ -741,6 +753,7 @@ class ChatViewModel(
         streamedParts.clear()
         messageRoles.clear()
         dismissedQuestionIds.clear()
+        pendingInterrupts.clear()
         _uiState.update {
             it.copy(
                 sessionId = null,
@@ -874,7 +887,7 @@ class ChatViewModel(
                     }
                     refreshContextUsage(targetSessionId)
                 }
-                if (interrupting) onSessionAborted(targetSessionId)
+                if (interrupting) interruptRunningTurn(currentBackend, targetSessionId)
                 currentBackend.sendMessage(
                     targetSessionId,
                     PromptRequest(
@@ -926,6 +939,7 @@ class ChatViewModel(
                                 }
                         }
                     }
+                closeInterruptWindow(targetSessionId)
                 // Some runtimes deliver the final message but drop session.idle. Do not
                 // leave the UI in the running state when the bounded fallback poll ends.
                 if (isStillActive() && (sessionCompleted || pollFinished == null)) {
@@ -961,6 +975,7 @@ class ChatViewModel(
                         }
                 }
             }.onFailure { error ->
+                capturedSessionId?.let(::closeInterruptWindow)
                 if (capturedSessionId == null || _uiState.value.sessionId == capturedSessionId) {
                     _uiState.update {
                         it.copy(
@@ -1015,6 +1030,7 @@ class ChatViewModel(
             messageQueue.update { it + QueuedPrompt(displayText, emptyList(), emptyList()) }
             return
         }
+        val interrupting = _uiState.value.isRunning
 
         val userMessage =
             ChatMessage(
@@ -1052,6 +1068,8 @@ class ChatViewModel(
                     }
                     onSessionCreated()
                 }
+
+                if (interrupting) interruptRunningTurn(currentBackend, targetSessionId)
 
                 // The command endpoint on OpenCode runs the whole turn before answering, so it is
                 // fired in its own coroutine: the poll loop below (and the SSE stream) drive the UI
@@ -1097,6 +1115,7 @@ class ChatViewModel(
                                 }
                         }
                     }
+                closeInterruptWindow(targetSessionId)
                 if (isStillActive() && (sessionCompleted || pollFinished == null)) {
                     runCatching { currentBackend.listMessages(targetSessionId) }
                         .onSuccess { serverMessages ->
@@ -1122,6 +1141,7 @@ class ChatViewModel(
                         }
                 }
             }.onFailure { error ->
+                capturedSessionId?.let(::closeInterruptWindow)
                 if (capturedSessionId == null || _uiState.value.sessionId == capturedSessionId) {
                     _uiState.update {
                         it.copy(
@@ -1421,6 +1441,9 @@ class ChatViewModel(
     fun abort() {
         val currentBackend = backend ?: return
         val sessionId = _uiState.value.sessionId ?: return
+        // Stopping by hand ends the turn outright, so the idle it produces is the one the chat is
+        // waiting for rather than a leftover to skip past.
+        closeInterruptWindow(sessionId)
         viewModelScope.launch {
             onSessionAborted(sessionId)
             runCatching { currentBackend.abortSession(sessionId) }
@@ -1433,6 +1456,50 @@ class ChatViewModel(
                     _uiState.update { it.copy(error = error.safeMessage("OpenCode operation failed")) }
                 }
         }
+    }
+
+    /**
+     * Ends the turn in flight before the prompt that replaces it is sent.
+     *
+     * Sending alone is not enough on a runtime that drops a prompt arriving mid-turn (see
+     * [com.yugahashimoto.andcode.runtime.RuntimeCapabilities.abortsBeforeInterrupt]): OpenCode
+     * stores the message, hands it to a session runner that is already running, and never starts a
+     * run for it. That is the "sent a message and nothing came back" case, and it is why stopping
+     * the wedged turn by hand and then sending again worked. Aborting here does that stop
+     * automatically.
+     */
+    private suspend fun interruptRunningTurn(
+        currentBackend: OpenCodeBackend,
+        sessionId: String,
+    ) {
+        // Reported whether or not this runtime is aborted below: a runtime that instead queues the
+        // prompt on the turn in flight still ends that turn with an idle of its own (Claude Code
+        // emits one per `result`), and announcing it as a completed run would be announcing the turn
+        // the user just replaced.
+        onSessionAborted(sessionId)
+        if ((currentBackend as? RuntimeTarget)?.capabilities?.abortsBeforeInterrupt != true) return
+        val aborted = runCatching { currentBackend.abortSession(sessionId) }.getOrDefault(false)
+        // A backend that had nothing to cancel reports no run aborted and emits no idle for one, so
+        // opening the window then would only cost the replacement turn its own end-of-turn idle.
+        if (!aborted) return
+        pendingInterrupts += sessionId
+        // Settling the cancelled run's bubble is normally the idle's job, and that idle is about to
+        // be skipped, so it is done here instead rather than leaving it spinning over work that has
+        // already stopped.
+        if (_uiState.value.sessionId != sessionId) return
+        _uiState.update { state ->
+            state.copy(
+                messages = state.messages.map { if (it.isStreaming) it.copy(isStreaming = false) else it },
+            )
+        }
+    }
+
+    /**
+     * Stops treating [sessionId]'s idles as leftovers of an interrupted run, so a turn that ends
+     * without the replacement run ever reporting busy cannot leave idles ignored for good.
+     */
+    private fun closeInterruptWindow(sessionId: String) {
+        pendingInterrupts -= sessionId
     }
 
     private fun handleEvent(event: OpenCodeEvent) {
@@ -1542,10 +1609,12 @@ class ChatViewModel(
                 if (event.sessionId != activeSession) return
                 when (event.status) {
                     "idle" -> handleSessionIdle(event.sessionId)
-                    "busy", "retry" ->
+                    "busy", "retry" -> {
+                        closeInterruptWindow(event.sessionId)
                         if (!_uiState.value.isRunning) {
                             _uiState.update { it.copy(isRunning = true) }
                         }
+                    }
                 }
             }
             is OpenCodeEvent.SessionIdle -> {
@@ -1554,6 +1623,7 @@ class ChatViewModel(
             }
             is OpenCodeEvent.SessionError -> {
                 if (event.sessionId != null && event.sessionId != activeSession) return
+                event.sessionId?.let(::closeInterruptWindow)
                 _uiState.update {
                     it.copy(
                         isRunning = false,
@@ -1569,6 +1639,10 @@ class ChatViewModel(
     }
 
     private fun handleSessionIdle(sessionId: String) {
+        // An idle answering an interrupt belongs to the run that was just cancelled, not to the
+        // prompt sent in its place; acting on it would park the composer on the send button and
+        // drain another queued prompt over a turn that is only starting.
+        if (sessionId in pendingInterrupts) return
         streamedParts.clear()
         _uiState.update { state ->
             state.copy(
@@ -1734,16 +1808,8 @@ class ChatViewModel(
     private fun drainQueue() {
         val queued = messageQueue.value
         if (queued.isEmpty()) return
-        messageQueue.value = emptyList()
-        queued.forEach { queuedPrompt ->
-            _uiState.update {
-                it.copy(
-                    attachments = queuedPrompt.attachments,
-                    imagePreviews = queuedPrompt.imagePreviews,
-                )
-            }
-            sendMessage(queuedPrompt.text)
-        }
+        messageQueue.value = queued.drop(1)
+        sendQueued(queued.first())
     }
 
     private fun drainOfflineQueue() {
@@ -1751,15 +1817,25 @@ class ChatViewModel(
         if (queued.isEmpty()) return
         offlineMessageQueue.value = emptyList()
         _uiState.update { it.copy(offlineQueue = emptyList(), isOfflineQueued = false) }
-        queued.forEach { queuedPrompt ->
-            _uiState.update {
-                it.copy(
-                    attachments = queuedPrompt.attachments,
-                    imagePreviews = queuedPrompt.imagePreviews,
-                )
-            }
-            sendMessage(queuedPrompt.text)
+        messageQueue.update { it + queued.drop(1) }
+        sendQueued(queued.first())
+    }
+
+    /**
+     * Sends one held prompt and leaves the rest of the queue for the next idle.
+     *
+     * Firing a whole queue at once only worked while a send could not interrupt: the first prompt
+     * marks the chat as running, so every prompt after it would now abort the turn the one before it
+     * just started and take its place. See [interruptRunningTurn].
+     */
+    private fun sendQueued(queuedPrompt: QueuedPrompt) {
+        _uiState.update {
+            it.copy(
+                attachments = queuedPrompt.attachments,
+                imagePreviews = queuedPrompt.imagePreviews,
+            )
         }
+        sendMessage(queuedPrompt.text)
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/RuntimeCapabilities.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/RuntimeCapabilities.kt
@@ -16,4 +16,15 @@ data class RuntimeCapabilities(
      * [com.yugahashimoto.andcode.runtime.local.AntigravityRuntime.send] for the failure this avoids.
      */
     val forcesQueue: Boolean = false,
+    /**
+     * True when interrupting a running turn means aborting it before the new prompt is sent, because
+     * the runtime silently drops a prompt that arrives while a turn is still in flight.
+     *
+     * OpenCode's `prompt_async` stores the message and then asks its session runner to run; when the
+     * runner is already running it attaches to the run in flight instead of starting one for the new
+     * message. If that run is wedged (a tool that never returns) or is already unwinding, the stored
+     * prompt is never picked up: the server answers `204 No Content` and the chat waits forever.
+     * Aborting first puts the runner back to idle so the prompt starts a run of its own.
+     */
+    val abortsBeforeInterrupt: Boolean = false,
 )

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeTarget.kt
@@ -49,7 +49,8 @@ class LocalRuntimeTarget(
     override val agent: LocalAgent = LocalAgent.OPEN_CODE
     override val type: RuntimeType = RuntimeType.LOCAL
     override val kind: BackendKind = BackendKind.LOCAL
-    override val capabilities = RuntimeCapabilities(permissions = true, providerModelList = true)
+    override val capabilities =
+        RuntimeCapabilities(permissions = true, providerModelList = true, abortsBeforeInterrupt = true)
 
     private val mutableState = MutableStateFlow(mapStatus(runtimeManager.status()))
     override val state: StateFlow<RuntimeState> = mutableState.asStateFlow()

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt
@@ -42,7 +42,8 @@ class RemoteRuntimeTarget(
     override val displayName: String = profile.name
     override val type: RuntimeType = RuntimeType.REMOTE
     override val kind: BackendKind = BackendKind.REMOTE
-    override val capabilities = RuntimeCapabilities(permissions = true, providerModelList = true)
+    override val capabilities =
+        RuntimeCapabilities(permissions = true, providerModelList = true, abortsBeforeInterrupt = true)
 
     private val mutableState = MutableStateFlow<RuntimeState>(RuntimeState.Disconnected)
     override val state: StateFlow<RuntimeState> = mutableState.asStateFlow()

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -788,7 +788,7 @@ class ChatViewModelTest {
     @Test
     fun `a runtime that forces queue never interrupts a running turn`() =
         runTest(dispatcher) {
-            val backend = FakeQueueForcingBackend()
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities(forcesQueue = true))
             val viewModel = ChatViewModel(backend)
             advanceUntilIdle()
 
@@ -809,6 +809,119 @@ class ChatViewModelTest {
             advanceUntilIdle()
 
             assertEquals(listOf("first", "second"), backend.sentPrompts.map { it.second.text })
+        }
+
+    /**
+     * OpenCode drops a prompt that arrives while a turn is still in flight: it stores the message
+     * and hands it to a session runner that is already running, which attaches to the run instead of
+     * starting one for the new message. A wedged turn - a tool that never returns - therefore
+     * swallowed the send, and the chat waited for a reply that was never coming. Interrupting has to
+     * abort the wedged run first, which is what stopping by hand and re-sending used to do.
+     */
+    @Test
+    fun `interrupting a running turn aborts it before the replacement prompt is sent`() =
+        runTest(dispatcher) {
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities(abortsBeforeInterrupt = true))
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+
+            viewModel.sendMessage("first")
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.isRunning)
+
+            viewModel.sendMessage("second")
+            advanceUntilIdle()
+
+            assertEquals(listOf("prompt:first", "abort:s1", "prompt:second"), backend.calls)
+            assertTrue(viewModel.uiState.value.isRunning)
+        }
+
+    /**
+     * The abort above makes the server report the cancelled run as idle - as both `session.status`
+     * and the deprecated `session.idle`, for one and the same run. Those arrive after the
+     * replacement prompt has gone out, so treating either as the end of a turn would park the
+     * composer on the send button while the new run is only starting.
+     */
+    @Test
+    fun `idles answering an interrupt do not end the turn that replaced it`() =
+        runTest(dispatcher) {
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities(abortsBeforeInterrupt = true))
+            val viewModel = ChatViewModel(backend, backend.events)
+            advanceUntilIdle()
+
+            // Time is only ever run to the next suspension point: letting it run free would expire
+            // the send's fallback poll, which closes the window on its way out.
+            viewModel.sendMessage("first")
+            runCurrent()
+            viewModel.sendMessage("second")
+            runCurrent()
+
+            backend.events.tryEmit(OpenCodeEvent.SessionStatusChanged("s1", "idle"))
+            backend.events.tryEmit(OpenCodeEvent.SessionIdle("s1"))
+            runCurrent()
+            assertTrue(viewModel.uiState.value.isRunning)
+
+            // The replacement run reporting itself closes the window, so its own end-of-turn idle
+            // lands as usual.
+            backend.events.tryEmit(OpenCodeEvent.SessionStatusChanged("s1", "busy"))
+            backend.events.tryEmit(OpenCodeEvent.SessionIdle("s1"))
+            runCurrent()
+            assertFalse(viewModel.uiState.value.isRunning)
+        }
+
+    /**
+     * Messages held while the runtime was unreachable used to all go out the moment it came back.
+     * Now that a send interrupts, each one would abort the turn the one before it just started, so
+     * they have to be spread over the turns instead.
+     */
+    @Test
+    fun `messages queued offline are sent one turn at a time`() =
+        runTest(dispatcher) {
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities(abortsBeforeInterrupt = true))
+            val viewModel = ChatViewModel(backend, backend.events)
+
+            // Sent before the first health check lands, so the chat is still offline and holds them.
+            viewModel.sendMessage("first")
+            viewModel.sendMessage("second")
+            viewModel.sendMessage("third")
+            advanceUntilIdle()
+            assertEquals(emptyList<String>(), backend.calls)
+
+            backend.events.tryEmit(OpenCodeEvent.ServerConnected)
+            advanceUntilIdle()
+            assertEquals(listOf("prompt:first"), backend.calls)
+
+            backend.events.tryEmit(OpenCodeEvent.SessionIdle("s1"))
+            advanceUntilIdle()
+            assertEquals(listOf("prompt:first", "prompt:second"), backend.calls)
+
+            backend.events.tryEmit(OpenCodeEvent.SessionIdle("s1"))
+            advanceUntilIdle()
+            assertEquals(listOf("prompt:first", "prompt:second", "prompt:third"), backend.calls)
+        }
+
+    /**
+     * Runtimes that accept a prompt mid-turn (Claude Code queues it on the process it already has
+     * open) must not have that process killed and resumed on every interrupting send. They still
+     * report the interrupt: the superseded turn ends with an idle of its own - Claude Code emits one
+     * per `result` - and announcing that as a completed run would announce the turn the user just
+     * replaced.
+     */
+    @Test
+    fun `a runtime that accepts prompts mid-turn is reported interrupted but not aborted`() =
+        runTest(dispatcher) {
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities())
+            val aborted = mutableListOf<String>()
+            val viewModel = ChatViewModel(backend, onSessionAborted = { aborted += it })
+            advanceUntilIdle()
+
+            viewModel.sendMessage("first")
+            advanceUntilIdle()
+            viewModel.sendMessage("second")
+            advanceUntilIdle()
+
+            assertEquals(listOf("prompt:first", "prompt:second"), backend.calls)
+            assertEquals(listOf("s1"), aborted)
         }
 
     @Test
@@ -1050,21 +1163,25 @@ class ChatViewModelTest {
     }
 
     /**
-     * A [RuntimeTarget] whose [RuntimeCapabilities.forcesQueue] is set - the same shape
-     * [com.yugahashimoto.andcode.runtime.local.AntigravityTarget] exposes - to verify the chat
-     * ViewModel queues a send instead of interrupting a running turn for such a backend, independent
-     * of whatever the user's sendBehavior preference is set to.
+     * A [RuntimeTarget] declaring whichever [RuntimeCapabilities] a test needs, so send behaviour
+     * that keys off a capability - queueing for
+     * [com.yugahashimoto.andcode.runtime.local.AntigravityTarget], aborting before an interrupt for
+     * the OpenCode targets - can be exercised without standing up a real runtime.
      */
-    private class FakeQueueForcingBackend : RuntimeTarget {
-        override val id: String = "fake-queue-forcing"
-        override val displayName: String = "Fake queue-forcing"
+    private class FakeRuntimeTargetBackend(
+        override val capabilities: RuntimeCapabilities,
+    ) : RuntimeTarget {
+        override val id: String = "fake-runtime-target"
+        override val displayName: String = "Fake runtime target"
         override val kind: BackendKind = BackendKind.LOCAL
         override val type: RuntimeType = RuntimeType.LOCAL
         override val agent: LocalAgent? = null
-        override val capabilities: RuntimeCapabilities = RuntimeCapabilities(forcesQueue = true)
         override val state: StateFlow<RuntimeState> = MutableStateFlow<RuntimeState>(RuntimeState.Connected("test")).asStateFlow()
         val events = MutableSharedFlow<OpenCodeEvent>(extraBufferCapacity = 20)
         val sentPrompts = mutableListOf<Pair<String, PromptRequest>>()
+
+        /** Aborts and prompt sends in the order the ViewModel issued them. */
+        val calls = mutableListOf<String>()
 
         override suspend fun connect(): Result<OpenCodeHealth> = Result.success(OpenCodeHealth(true, "test"))
 
@@ -1092,9 +1209,13 @@ class ChatViewModelTest {
             request: PromptRequest,
         ) {
             sentPrompts += sessionId to request
+            calls += "prompt:${request.text}"
         }
 
-        override suspend fun abortSession(sessionId: String): Boolean = true
+        override suspend fun abortSession(sessionId: String): Boolean {
+            calls += "abort:$sessionId"
+            return true
+        }
 
         override suspend fun respondToPermission(
             sessionId: String,


### PR DESCRIPTION
## 症状

OpenCode でメッセージを送っても返事が来ないことがある。UI 上はツール実行中に見えるが、実際にはかなり前からツールは動いていない。一度メッセージを送って停止ボタンをすぐ押し、もう一度送ると読み取られる。

## 原因

OpenCode サーバー側の `prompt_async` の挙動。メッセージを保存したあとセッションランナーに実行を委ねるが、ランナーが既に `Running` のときは **実行中の run に相乗りするだけで、新しいメッセージ用の run を開始しない**（`SessionRunState.ensureRunning` の `Running` ケースは新しい work を捨てて既存 run の完了を待つ）。

そのため、ツールが固まったまま終わらない turn があると送信が握り潰される。`prompt_async` はエラーを握って 204 No Content を返すので、アプリ側からは成功に見えたまま何も起きない。

停止ボタンを押してから再送すると通ったのは、abort がランナーを idle に戻していたため。

## 修正

- **割り込み送信時に abort を先に走らせる。** それを必要とするランタイムだけに限定するため `RuntimeCapabilities.abortsBeforeInterrupt` を追加し、OpenCode の 2 ターゲット（`LocalRuntimeTarget` / `RemoteRuntimeTarget`）で有効にした。Claude Code は開いているプロセスの stdin にプロンプトをキューするだけなので、毎回プロセスを落として resume させないようそのまま送る。Antigravity は従来どおり `forcesQueue` でキュー経路に入る。
- **abort が返す idle を読み飛ばす。** 中断された run は `session.status: idle` と非推奨の `session.idle` の両方で報告され、しかも差し替えプロンプトの送信後に届く。そのため差し替え後の run が `busy` を報告するまで読み飛ばし、そこに到達せず turn が終わった場合に備えて閉じる経路（両送信経路のポーリング終了後・送信失敗時・`SessionError`・`abort()`・セッション切替）を用意した。
- **溜まったプロンプトは 1 ターンに 1 件ずつ流す。** キューを一斉に送れたのは送信が割り込まなかったからで、そのままでは 2 件目以降が直前の 1 件が始めた turn を潰してしまう。`drainQueue` / `drainOfflineQueue` を共通の `sendQueued()` 経由で先頭 1 件だけ送る形にした。
- 割り込みが起きたことは abort の有無に関わらず通知層へ伝える（`onSessionAborted`）。プロンプトを turn にキューするランタイムでも、差し替えられた側の turn は自前の idle で終わるため（Claude Code は `result` ごとに `SessionIdle` を発行）、これを完了として通知すると #234 が直したバグが再発する。

## テスト

`ChatViewModelTest` に 5 本追加・更新（784 tests / 0 failures）:

- 割り込み時に差し替えプロンプトより先に abort が走る
- 割り込みに応答する idle 群が差し替え後の turn を終わらせない
- プロンプトを mid-turn で受け付けるランタイムは abort されないが割り込みは報告される
- オフラインで溜めたメッセージが 1 ターンずつ送られる
- 既存の forcesQueue テストを capability 指定可能なフェイクに統合

<!-- pre-pr-review: approved -->
## Pre-PR review

```
判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- なし（前回の提案「中断された側のバブルにスピナーが残る」は d74d5fd で取り込み済み。見送りとした3点—2分フォールバック後の送信・窓が開いている間の drainQueue・abort 予告と実 abort の分離—は別PR送りで妥当）

## チェック済み項目
- 増分 `git diff 8dac7e2 HEAD` を確認。変更は `ChatViewModel.kt` の `interruptRunningTurn` 末尾のみで、`if (!aborted) return` → 窓を開く → `_uiState.value.sessionId != sessionId` で早期 return → `isStreaming` クリア、の順であること、およびクリア処理が `handleSessionIdle` の同等処理と同じ形（`messages.map { if (it.isStreaming) it.copy(isStreaming = false) else it }`）であることを確認。
- 副作用の確認: (1) abort は差し替えプロンプト送信の前に走るため、この時点で新ターンのアシスタントメッセージは存在せず、消してしまう対象は中断された側のバブルのみ。(2) ユーザーバブルは `updateStreamingMessage` が `isStreaming = !existing.isUser` としているので影響なし。(3) セッション一致ガードにより、送信中に別チャットへ切り替えた場合でも他チャットの transcript を書き換えない。(4) `streamedParts` は保持されるので、後続の part イベントによる再構築や `mergeReloadedMessages` の挙動は従来どおり。
- 静的解析: 追加行の最長は 104 文字で `maxLineLength=140`（`.editorconfig` / `config/detekt/detekt.yml`）以内。
- リベース後（base: origin/main = 0a9ed0d）の全体差分は 5 ファイルのままで、文字列リソースの変更・ハードコードのユーザー可視文字列はなし（i18n チェックに影響なし）。
- これまでの確認事項（`onSessionAborted` の無条件呼び出しと Claude Code の `result` ごとの `SessionIdle`、`abortsBeforeInterrupt` を OpenCode 2ターゲットに限定、窓を閉じる全経路、キューを1件ずつ流す `sendQueued`、#238 の `withMessageError`/`isAbort()` との噛み合わせ、新規テスト5本）はいずれも d74d5fd で維持されていることを再確認。
- ゲート: コーディネータ報告の `./gradlew :app:testDebugUnitTest detekt spotlessCheck` 成功 / 784 tests 0 failures を前提（当環境では JVM が起動できず未実行）。
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
