### PR TITLE
fix(chat): display generated image attachments

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatImageViewer.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatImageViewer.kt
@@ -266,7 +266,10 @@ private fun loadRemoteImage(source: ChatImageSource): ByteArray {
     connection.instanceFollowRedirects = false
     try {
         require(connection.responseCode in 200..299)
-        require(connection.contentType.orEmpty().substringBefore(';').startsWith("image/"))
+        // Image hosts used by generation tools occasionally return octet-stream (or no
+        // Content-Type) for a valid image. BitmapFactory remains the final format check.
+        val contentType = connection.contentType.orEmpty().substringBefore(';').trim()
+        require(contentType.isEmpty() || contentType == "application/octet-stream" || contentType.startsWith("image/"))
         return connection.inputStream.use(::readLimited)
     } finally {
         connection.disconnect()

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -216,7 +216,7 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
         "reasoning" -> ChatPart.Reasoning(partId, text.orEmpty())
         "file", "image" -> {
             val partUrl = url.orEmpty()
-            val partMime = imageMime(mime, partUrl) ?: if (type == "image") "image/*" else null
+            val partMime = imageMime(mime, partUrl)
             if (partMime != null && partUrl.isNotBlank()) {
                 ChatPart.Image(id = partId, mime = partMime, url = partUrl, filename = filename)
             } else {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -216,7 +216,7 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
         "reasoning" -> ChatPart.Reasoning(partId, text.orEmpty())
         "file", "image" -> {
             val partUrl = url.orEmpty()
-            val partMime = imageMime(mime, partUrl)
+            val partMime = imageMime(mime, partUrl) ?: if (type == "image") "image/*" else null
             if (partMime != null && partUrl.isNotBlank()) {
                 ChatPart.Image(id = partId, mime = partMime, url = partUrl, filename = filename)
             } else {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -214,10 +214,10 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
     return when (type) {
         "text" -> ChatPart.Text(partId, text.orEmpty())
         "reasoning" -> ChatPart.Reasoning(partId, text.orEmpty())
-        "file" -> {
-            val partMime = mime.orEmpty()
+        "file", "image" -> {
             val partUrl = url.orEmpty()
-            if (partMime.startsWith("image/") && partUrl.isNotBlank()) {
+            val partMime = imageMime(mime, partUrl)
+            if (partMime != null && partUrl.isNotBlank()) {
                 ChatPart.Image(id = partId, mime = partMime, url = partUrl, filename = filename)
             } else {
                 null
@@ -244,6 +244,25 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
             )
         }
         "patch" -> ChatPart.Patch(partId, extractPatchFiles(stateMap))
+        else -> null
+    }
+}
+
+/** Image-producing tools do not consistently include a MIME field in their file parts. */
+internal fun imageMime(
+    declaredMime: String?,
+    url: String,
+): String? {
+    declaredMime?.takeIf { it.startsWith("image/") }?.let { return it }
+    parseDataImageUri(url)?.mime?.let { return it }
+    val extension = url.substringBefore('?').substringBefore('#').substringAfterLast('.').lowercase()
+    return when (extension) {
+        "png" -> "image/png"
+        "jpg", "jpeg" -> "image/jpeg"
+        "webp" -> "image/webp"
+        "gif" -> "image/gif"
+        "bmp" -> "image/bmp"
+        "svg" -> "image/svg+xml"
         else -> null
     }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
@@ -110,6 +110,6 @@ class ChatImagePartTest {
     fun `uses wildcard mime for image part without metadata`() {
         val part = OpenCodePart(id = "p6", type = "image", url = "generated-image")
 
-        assertEquals("image/*", (part.toChatPart() as ChatPart.Image).mime)
+        assertNull(part.toChatPart())
     }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
@@ -105,4 +105,11 @@ class ChatImagePartTest {
 
         assertEquals("image/webp", (part.toChatPart() as ChatPart.Image).mime)
     }
+
+    @Test
+    fun `uses wildcard mime for image part without metadata`() {
+        val part = OpenCodePart(id = "p6", type = "image", url = "generated-image")
+
+        assertEquals("image/*", (part.toChatPart() as ChatPart.Image).mime)
+    }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatImagePartTest.kt
@@ -80,4 +80,29 @@ class ChatImagePartTest {
 
         assertNull(part.toChatPart())
     }
+
+    @Test
+    fun `infers image mime when generated file part omits mime`() {
+        val part =
+            OpenCodePart(
+                id = "p4",
+                type = "file",
+                url = "/workspace/generated-image.png",
+                filename = "generated-image.png",
+            )
+
+        assertEquals("image/png", (part.toChatPart() as ChatPart.Image).mime)
+    }
+
+    @Test
+    fun `accepts image part type with a data uri`() {
+        val part =
+            OpenCodePart(
+                id = "p5",
+                type = "image",
+                url = "data:image/webp;base64,abc",
+            )
+
+        assertEquals("image/webp", (part.toChatPart() as ChatPart.Image).mime)
+    }
 }


### PR DESCRIPTION
生成画像の添付パーツをチャット内で正しく表示できるようにしました。

変更内容:
- MIME 情報が省略された画像ファイルを拡張子から判定
- `type="image"` の画像パーツに対応
- 画像ホストが `application/octet-stream` または空の Content-Type を返す場合も読み込み
- 画像パーツの単体テストを追加

テスト:
- `./gradlew testDebugUnitTest --tests com.yugahashimoto.andcode.feature.chat.ChatImagePartTest`
- `./gradlew detekt spotlessCheck`

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
なし

## 提案（非ブロッキング）
なし

## チェック済み項目
- `origin/main...image-chat-display` の全差分・全ハンクを確認
- MIME または拡張子から画像種別を推定し、両方ない `type="image"` が `null` になることを確認
- 対応する `assertNull` テストを確認
- 呼び出し元、画像表示・保存処理、既存テストとの整合性を確認
- リソース変更がなく、i18nキー追加漏れがないことを確認
- `git diff --check` が成功することを確認
