### PR TITLE
fix(schedule): show favorites and visibility settings in agent/model picker

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
@@ -89,6 +89,10 @@ fun ScheduleEditorScreen(
     runtimeTargets: List<RuntimeTarget>,
     providers: List<OpenCodeProvider>,
     workspaces: List<WorkspaceRef>,
+    favoriteModelKeys: Set<String> = emptySet(),
+    recentModelKeys: List<String> = emptyList(),
+    hiddenModelKeys: Set<String> = emptySet(),
+    onToggleFavorite: (String, String) -> Unit = { _, _ -> },
     onSave: (Schedule) -> Unit,
     onBack: () -> Unit,
 ) {
@@ -531,6 +535,10 @@ fun ScheduleEditorScreen(
                 modelId = newModelId
                 showModelPicker = false
             },
+            favoriteModelKeys = favoriteModelKeys,
+            recentModelKeys = recentModelKeys,
+            hiddenModelKeys = hiddenModelKeys,
+            onToggleFavorite = onToggleFavorite,
             onDismiss = { showModelPicker = false },
         )
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleEditorScreen.kt
@@ -537,6 +537,8 @@ fun ScheduleEditorScreen(
             },
             favoriteModelKeys = favoriteModelKeys,
             recentModelKeys = recentModelKeys,
+            // Unlike the chat picker, applied unconditionally: visibility keys come from the
+            // OpenCode-managed catalog and never collide with agent pseudo-catalog provider ids.
             hiddenModelKeys = hiddenModelKeys,
             onToggleFavorite = onToggleFavorite,
             onDismiss = { showModelPicker = false },

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -1190,6 +1190,10 @@ fun AndCodeApp(
                         runtimeTargets = runtimeTargets,
                         providers = settingsState.providers,
                         workspaces = workspaceState.workspaces,
+                        favoriteModelKeys = settingsState.favoriteModelKeys,
+                        recentModelKeys = settingsState.recentModelKeys,
+                        hiddenModelKeys = settingsState.hiddenModelKeys,
+                        onToggleFavorite = settingsViewModel::toggleFavoriteModel,
                         onSave = { built ->
                             if (scheduleId != null) {
                                 scheduleViewModel.update(built)


### PR DESCRIPTION
## Summary
- スケジュールエディターのエージェント/モデルピッカー（`ModelAndRuntimePickerSheet`）に、お気に入り・最近使用・非表示モデル（表示設定）のキーと `onToggleFavorite` コールバックが渡されておらず、チャットのモデル一覧と異なり星マークのお気に入りが出ず、表示設定で隠したモデルも表示される状態だった。
- `ScheduleEditorScreen` に `favoriteModelKeys` / `recentModelKeys` / `hiddenModelKeys` / `onToggleFavorite` を追加し、`AndCodeApp.kt` の schedule edit ルートからチャットと同じ `settingsState` / `settingsViewModel::toggleFavoriteModel` を渡すようにした。

## Notes
- スケジュール側のモデル選択は意図的にローカル state への保存のみ（グローバルな `selectModel` を経由しないため、スケジュールでの選択は「最近使用」に記録されない。チャット設定を書き換えない仕様）。
- `hiddenModelKeys` はチャット側の `providerModelList` ゲートとは異なり無条件で適用。可視性キーは OpenCode 管理カタログ由来で、エージェント擬似カタログのプロバイダー ID（`claude-code` / `antigravity`) と衝突しないため（コード内コメント参照）。
- リソース変更なし（i18n 影響なし）。

## Verification
- `./gradlew detekt spotlessCheck` ✅
- `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest` ✅

<!-- pre-pr-review: approved -->
## Pre-PR review

```
判定: APPROVE

## ブロッカー
なし

## 提案（非ブロッキング）
- なし

## チェック済み項目
- 追加コミットの検証: ae90131 は ScheduleEditorScreen.kt の `hiddenModelKeys = hiddenModelKeys,` 直前に説明コメント2行を追加したのみ。他の変更は一切なし（diff --stat で前回 +12 行 → 今回 +14 行、差分はコメント2行のみを確認）。
- コメント内容の正確性: 「visibility keys come from the OpenCode-managed catalog」は ModelVisibilityScreen への供給元が `availableProviders = managed.all`（管理カタログ、SettingsViewModel.kt:180）であること、「never collide with agent pseudo-catalog provider ids」は Claude 側 `PROVIDER_ID = "claude-code"`（ClaudeModels.kt:20）、Antigravity 側 `PROVIDER_ID = "antigravity"`（AntigravityModels.kt:19）に対し可視性キーは実プロバイダーID由来であること、の両点を前回確認済みのコードと突き合わせて妥当と判断。
- 規約適合: コメントは英語・非自明な決定の説明という本リポジトリの方針（hard rule 5）に合致。インデント・行長は ktlint/detekt（MaxLineLength 140）に問題なし。動作変更はないためテスト影響なし。コミットメッセージ `docs(schedule): ...` は commitlint パターンに適合。
- 全差分の再確認: b78ec76（機能修正）+ ae90131（コメント）の合計差分に対し、前回レビューでの検証事項——シグネチャ一致（ModelAndRuntimePickerSheet.kt:72〜75）、SettingsUiState フィールドの実在と供給経路（SettingsViewModel.kt:82〜84/215〜217）、`toggleFavoriteModel` の `(String, String) -> Unit` 適合、呼び出し元は AndCodeApp.kt:1188 のみ、i18n 影響なし（リソース非接触）、CI ゲート（ktlint 形式・detekt LongParameterList 10 パラメータちょうどで超過なし）——すべて不変のまま成立していることを再確認。
- ワークツリー規約: ブランチは origin/main 基準のまま（ahead 2）、main 作業ツリーは未変更。
```

APPROVE です。前回指摘した非ブロッキング提案のうちコメント追記が反映され、残る1点（スケジュール選択が「最近使用」に記録されない件の PR 説明への明記）は任意対応です。このまま PR を作成できます。PR 説明には承認済みレビューレポート（`<!-- pre-pr-review: approved -->`）の添付を忘れないでください。