### PR TITLE
fix(antigravity): refresh the model catalog after an install or update

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
@@ -137,6 +137,9 @@ class AntigravityController(
             }
                 .onSuccess {
                     target.runtime.invalidateVersion()
+                    // The cached catalog was read by the binary that just got replaced; keeping it
+                    // would leave the picker on the old release's model list until a restart.
+                    target.runtime.invalidateModels()
                     target.connect()
                     val version =
                         target.state.value.let { (it as? com.yugahashimoto.andcode.runtime.RuntimeState.Connected)?.version }
@@ -179,6 +182,10 @@ class AntigravityController(
                 }
             }.onSuccess { version ->
                 target.runtime.invalidateVersion()
+                // Same as install: the catalog belongs to the binary that was just replaced, so a
+                // stale cache would keep showing the previous release's models (e.g. no
+                // gemini-3.7-flash after moving from 1.1.x) until the app restarted.
+                target.runtime.invalidateModels()
                 mutableState.value =
                     mutableState.value.copy(
                         installed = true,

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
@@ -184,8 +184,10 @@ class AntigravityController(
                 target.runtime.invalidateVersion()
                 // Same as install: the catalog belongs to the binary that was just replaced, so a
                 // stale cache would keep showing the previous release's models (e.g. no
-                // gemini-3.7-flash after moving from 1.1.x) until the app restarted.
-                target.runtime.invalidateModels()
+                // gemini-3.7-flash after moving from 1.1.x) until the app restarted. Skipped only
+                // when the guest verifiably ran this release already; an unknown "before" still
+                // invalidates — one redundant `agy models` fetch is cheap.
+                if (before == null || before != version) target.runtime.invalidateModels()
                 mutableState.value =
                     mutableState.value.copy(
                         installed = true,


### PR DESCRIPTION
Antigravity のモデルピッカーが、更新後の新しいCLIが知っているモデル(gemini-3.7-flash など)ではなく、旧バイナリが取得したキャッシュ済みカタログを出し続ける問題を修正します。

## 問題

`AntigravityRuntime.models()` は `@Volatile` のメモリキャッシュを持ち、`agy models` の結果を保持します。update/install で agy バイナリを置き換えた後もこのキャッシュは無効化されないため、アプリを再起動するまでピッカーは旧リリースのモデル一覧を表示し続けます(#251 で動的更新が入った結果、顕在化)。

## 修正

- `install()` / `update()` 成功時に `runtime.invalidateModels()` を呼ぶ
- update 時はゲストが検証可能な形で同一リリースを実行していた場合(AlreadyLatest)のみ再フェッチをスキップし、不要な `agy models` 実行(ProcessGate 直列化・最大45秒)を避ける

## テスト

ローカルゲート通過: compileDebugKotlin / spotlessCheck / detekt。コントローラ層はテストハーネスが存在しない(具象クラス依存)ため既存構造のまま。レビュー済み。

<!-- pre-pr-review: approved -->
## Pre-PR review

```
判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- AntigravityController.kt:188 — update() の onSuccess ではバイナリが実際に置き換わったかに関係なく invalidateModels() が走ります。AlreadyLatest（置き換えなし）のときも次回ピッカー表示時に不要な `agy models` 実行（ProcessGate 直列化・最大45秒）が発生し、再取得まで summarizeTitle の cheapest-model 選択が空になります。`antigravityUpdateResult(before, version)` が `Updated` の場合のみ無効化するようゲートすると無駄を省けます（before が null/古いケースの扱いに注意）。動作は正しいのでマージ阻害ではありません。
- 本変更（install/update 後のキャッシュ無効化）にはリグレッションテストがありません。ただし AntigravityController のテストハーネスは現状存在せず、AntigravityTarget/AntigravityRuntime がプロセス・ファイル依存の具象クラスのため既存構造では単体検証困難で、リポジトリの現状（コントローラ層のテストなし）と整合しています。今後シームを導入する際のテスト追加を検討する価値はあります。

## チェック済み項目
- 差分範囲: git diff origin/main...HEAD は AntigravityController.kt への +7 行のみ（install() onSuccess と update() onSuccess に invalidateModels() 追加）を確認
- API 実在と効果: AntigravityRuntime.invalidateModels()（150行目）が @Volatile cachedModels を null にすること、models() が空結果をキャッシュしないガード（147行目）を持つことを確認。モデルピッカーは AntigravityTarget.listProviders() → runtime.models() 経由で毎回キャッシュを読むため、無効化後の次回参照で新バイナリのカタログが取れることを呼び出しチェーンで確認
- 網羅性: LocalRuntimeInstaller.updateAntigravity の呼び出し元は AntigravityController.update() のみ。バイナリ置換パスはこの2経路で全てカバー。セットアップガイド経由の新規環境プロビジョニングは runtime 未使用状態（空結果は非キャッシュ）のため影響なし。サインイン/サインアウト時の無効化は既存実装済み（85行目・210行目）
- AntigravityRuntime が AndCodeApplication でプロセス単位シングルトンとして生成されることを確認し、「アプリ再起動まで旧カタログが出続ける」というバグ前提が成立することを検証
- 並行性: invalidateModels() は @Volatile フィールドへの null 代入のみで、Dispatchers.IO 上の scope.launch 内から呼ばれており競合なし
- i18n: strings.xml 未変更、ユーザー可視文字列の追加なし、コメントは英語（ログ/プロンプトへの影響なし）
- 既存テストへの影響: AntigravityUpdateTest 等は純粋関数（shouldReplaceInstalledAntigravity / antigravityUpdateResult）とインストーラマーカーIOのみを検証しており、本変更で破綻するテストはないことを確認
- spotlessCheck / detekt / compileDebugKotlin は作成者により通過報告済み。差分は ktlint 的にも自明に整形済み（コメントインデント・行長）を目視確認

APPROVE
```

※ 提案1(AlreadyLatest時のスキップ)は 13fd7f9 で適用済み。before が null(未知)の場合は冗長フェッチを優先して無効化する方針。
