### PR TITLE
fix(chat): keep interrupted turn's partial answer and stop flagging deliberate aborts as errors

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
@@ -74,6 +74,13 @@ data class OpenCodeMessageInfo(
     val error: OpenCodeMessageError? = null,
 )
 
+/**
+ * Names the runtimes give an error that only records a turn being stopped on purpose — by the stop
+ * button, or by a replacement prompt sent mid-turn. Stopping a run is a decision, not a failure, so
+ * these must never read as one.
+ */
+val AbortErrorNames: Set<String> = setOf("MessageAbortedError", "AbortError")
+
 /** A typed message error, e.g. `ApiError`; rendered in the chat when a turn fails. */
 @Serializable
 data class OpenCodeMessageError(
@@ -89,7 +96,7 @@ data class OpenCodeMessageError(
 
     /** OpenCode records a stop the user asked for as an error; it is not a failure to report. */
     val isAbort: Boolean
-        get() = name == "MessageAbortedError" || name == "AbortError"
+        get() = name in AbortErrorNames
 }
 
 @Serializable
@@ -347,7 +354,15 @@ sealed interface OpenCodeEvent {
     /** Replacement for the deprecated `session.idle`: status is `idle`, `busy` or `retry`. */
     data class SessionStatusChanged(val sessionId: String, val status: String) : OpenCodeEvent
 
-    data class SessionError(val sessionId: String?, val message: String?) : OpenCodeEvent
+    /**
+     * A run stopped on purpose — stop button, or interrupted by a replacement prompt — is a decision,
+     * not a failure. The error that arrives here must never read as one.
+     */
+    data class SessionError(val sessionId: String?, val message: String?, val name: String? = null) : OpenCodeEvent {
+        /** An abort the user asked for arrives here too; it must not read as a failure. */
+        val isAbort: Boolean
+            get() = name in AbortErrorNames
+    }
 
     data class Unknown(val type: String, val rawJson: String) : OpenCodeEvent
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeEventParser.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeEventParser.kt
@@ -109,11 +109,14 @@ class OpenCodeEventParser(
                         sessionId = properties["sessionID"]!!.jsonPrimitive.content,
                         status = properties["status"]!!.jsonObject["type"]!!.jsonPrimitive.content,
                     )
-                "session.error" ->
+                "session.error" -> {
+                    val errorObject = properties["error"] as? JsonObject
                     OpenCodeEvent.SessionError(
                         sessionId = (properties["sessionID"] as? JsonPrimitive)?.content,
                         message = describeError(properties["error"]),
+                        name = (errorObject?.get("name") as? JsonPrimitive)?.content,
                     )
+                }
                 else -> OpenCodeEvent.Unknown(type, raw)
             }
         }.getOrElse { OpenCodeEvent.Unknown(type, raw) }

--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/RuntimeActivityRepository.kt
@@ -487,6 +487,10 @@ class RuntimeActivityRepository(
                         )
                     }
                 }
+                // Stopping a run on purpose is a decision, not a failure: reporting it as an error
+                // left a red card up forever and notified the user of every stop. The abort paths
+                // settle their own state; there is nothing to log or notify here.
+                if (event.isAbort) return
                 appendLog(messages.eventError, event.message, event.sessionId)
                 onSessionError?.invoke(event.sessionId, event.message, target.id)
             }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/AndCodeVoiceSession.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/assistant/AndCodeVoiceSession.kt
@@ -274,6 +274,9 @@ class AndCodeVoiceSession(context: Context) :
                             }
                             is OpenCodeEvent.SessionError -> {
                                 if (event.sessionId == null || event.sessionId == sessionId) {
+                                    // A deliberate stop arrives here too; it is a decision, not a
+                                    // failure, and the idle that follows settles the turn.
+                                    if (event.isAbort) return@collect
                                     showError(event.message ?: context.getString(R.string.voice_processing_failed))
                                 }
                             }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -1057,6 +1057,10 @@ class ChatViewModel(
                             // transcript then. Another fetch here would merge against a stream
                             // cache it has already cleared and drop what only this client has.
                             if (!isStillActive() || !_uiState.value.isRunning) return@withTimeoutOrNull
+                            // Snapshotted before the fetch: the idle can clear the stream cache
+                            // while it is in flight, and merging against an empty live view would
+                            // drop what only this client has.
+                            val retainIds = streamedParts.keys.toSet()
                             runCatching { currentBackend.listMessages(targetSessionId) }
                                 .onSuccess { serverMessages ->
                                     if (!isStillActive()) return@onSuccess
@@ -1065,7 +1069,7 @@ class ChatViewModel(
                                             serverMessages.mapNotNull(::toUiMessage),
                                             _uiState.value.messages,
                                             pendingPreviewsByFilename,
-                                            streamedParts.keys,
+                                            retainIds,
                                         )
                                     if (uiMessages.isNotEmpty() && uiMessages != _uiState.value.messages) {
                                         _uiState.update { it.copy(messages = uiMessages) }
@@ -1250,6 +1254,10 @@ class ChatViewModel(
                             // transcript then. Another fetch here would merge against a stream
                             // cache it has already cleared and drop what only this client has.
                             if (!isStillActive() || !_uiState.value.isRunning) return@withTimeoutOrNull
+                            // Snapshotted before the fetch: the idle can clear the stream cache
+                            // while it is in flight, and merging against an empty live view would
+                            // drop what only this client has.
+                            val retainIds = streamedParts.keys.toSet()
                             runCatching { currentBackend.listMessages(targetSessionId) }
                                 .onSuccess { serverMessages ->
                                     if (!isStillActive()) return@onSuccess
@@ -1257,7 +1265,7 @@ class ChatViewModel(
                                         mergeReloadedMessages(
                                             serverMessages.mapNotNull(::toUiMessage),
                                             _uiState.value.messages,
-                                            retainIds = streamedParts.keys,
+                                            retainIds = retainIds,
                                         )
                                     if (uiMessages.isNotEmpty() && uiMessages != _uiState.value.messages) {
                                         _uiState.update { it.copy(messages = uiMessages) }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -110,36 +110,68 @@ data class ChatMessage(
         get() = parts.filterIsInstance<ChatPart.Text>().joinToString("") { it.text }
 }
 
-/** Keeps optimistic image data when a runtime replaces the transcript with its persisted copy. */
+/**
+ * Rebuilds the timeline from the runtime's persisted transcript, keeping what only this client has.
+ *
+ * [retainIds] names messages streamed here that the transcript may not carry yet. A turn interrupted
+ * by a replacement prompt is finalized asynchronously, and some runtimes never persist its partial
+ * output at all; reloading wholesale dropped the bubble the user had been reading, so anything
+ * listed here survives until the transcript produces its own copy under the same id (which then
+ * wins, keeping the two from doubling up).
+ */
 internal fun mergeReloadedMessages(
     reloaded: List<ChatMessage>,
     existing: List<ChatMessage>,
     previewsByFilename: Map<String, Bitmap> = emptyMap(),
+    retainIds: Set<String> = emptySet(),
 ): List<ChatMessage> {
+    // Nothing persisted yet means nothing to reconcile against: keeping what is on screen is both
+    // correct and what callers did with an empty result before this could ever retain anything.
+    if (reloaded.isEmpty()) return existing
     val usedExisting = mutableSetOf<Int>()
-    return reloaded.map { message ->
-        val existingIndex =
-            existing.indices.firstOrNull { it !in usedExisting && existing[it].id == message.id }
-                ?: existing.indices.firstOrNull { index ->
-                    val candidate = existing[index]
-                    index !in usedExisting &&
-                        message.isUser && candidate.isUser &&
-                        candidate.text == message.text &&
-                        (message.text.isNotBlank() || candidate.attachments.isNotEmpty())
+    val merged =
+        reloaded.map { message ->
+            val existingIndex =
+                existing.indices.firstOrNull { it !in usedExisting && existing[it].id == message.id }
+                    ?: existing.indices.firstOrNull { index ->
+                        val candidate = existing[index]
+                        index !in usedExisting &&
+                            message.isUser && candidate.isUser &&
+                            candidate.text == message.text &&
+                            (message.text.isNotBlank() || candidate.attachments.isNotEmpty())
+                    }
+            val previous = existingIndex?.let { index -> existing[index].also { usedExisting += index } }
+            val reloadedImageNames = message.attachments.filter { it.mime.startsWith("image/") }.map { it.filename }.toSet()
+            val missingImages =
+                previous?.attachments.orEmpty().filter {
+                    it.mime.startsWith("image/") && it.filename !in reloadedImageNames
                 }
-        val previous = existingIndex?.let { index -> existing[index].also { usedExisting += index } }
-        val reloadedImageNames = message.attachments.filter { it.mime.startsWith("image/") }.map { it.filename }.toSet()
-        val missingImages =
-            previous?.attachments.orEmpty().filter {
-                it.mime.startsWith("image/") && it.filename !in reloadedImageNames
+            val attachments = message.attachments + missingImages
+            val previews =
+                previous?.imagePreviews.orEmpty().ifEmpty {
+                    attachments.mapNotNull { previewsByFilename[it.filename] }
+                }
+            message.copy(attachments = attachments, imagePreviews = previews)
+        }.toMutableList()
+    if (retainIds.isNotEmpty()) {
+        val reloadedIds = reloaded.map { it.id }.toSet()
+        existing
+            .asSequence()
+            .filter { message ->
+                !message.isUser && message.parts.isNotEmpty() && message.id in retainIds && message.id !in reloadedIds
             }
-        val attachments = message.attachments + missingImages
-        val previews =
-            previous?.imagePreviews.orEmpty().ifEmpty {
-                attachments.mapNotNull { previewsByFilename[it.filename] }
+            .forEach { message ->
+                // The bubble belongs where it streamed, ahead of everything that came after it,
+                // not pinned to the bottom of a timeline that has moved on.
+                val index = merged.indexOfFirst { it.timestamp > message.timestamp }
+                if (index >= 0) {
+                    merged.add(index, message)
+                } else {
+                    merged.add(message)
+                }
             }
-        message.copy(attachments = attachments, imagePreviews = previews)
     }
+    return merged
 }
 
 data class PendingQuestionUi(
@@ -169,7 +201,7 @@ data class PendingQuestionUi(
 }
 
 private const val MAX_TOOL_OUTPUT_CHARS = 4000
-private const val RESPONSE_POLL_INTERVAL_MS = 3000L
+internal const val RESPONSE_POLL_INTERVAL_MS = 3000L
 private const val RESPONSE_POLL_TIMEOUT_MS = 120_000L
 internal const val TRANSIENT_RECOVERY_DELAY_MS = 5000L
 internal const val TRANSIENT_RECOVERY_RETRY_DELAY_MS = 3000L
@@ -1030,6 +1062,7 @@ class ChatViewModel(
                                             serverMessages.mapNotNull(::toUiMessage),
                                             _uiState.value.messages,
                                             pendingPreviewsByFilename,
+                                            streamedParts.keys,
                                         )
                                     if (uiMessages.isNotEmpty() && uiMessages != _uiState.value.messages) {
                                         _uiState.update { it.copy(messages = uiMessages) }
@@ -1057,6 +1090,10 @@ class ChatViewModel(
                                     message.info.role == "assistant" && message.info.id !in messageIdsBeforeSend
                                 }
                             if (!sessionCompleted && !hasResponse) return@onSuccess
+                            // Captured before the stream cache is cleared: the final reload must
+                            // keep what this client streamed that the transcript still does not
+                            // carry, not drop it the way it otherwise would.
+                            val retainedIds = streamedParts.keys.toSet()
                             streamedParts.clear()
                             // Re-attach the in-memory previews the same way the polling loop does:
                             // the final reload otherwise drops them, and a runtime whose attachment
@@ -1067,6 +1104,7 @@ class ChatViewModel(
                                     serverMessages.mapNotNull(::toUiMessage),
                                     _uiState.value.messages,
                                     pendingPreviewsByFilename,
+                                    retainedIds,
                                 )
                             _uiState.update {
                                 it.copy(
@@ -1213,6 +1251,7 @@ class ChatViewModel(
                                         mergeReloadedMessages(
                                             serverMessages.mapNotNull(::toUiMessage),
                                             _uiState.value.messages,
+                                            retainIds = streamedParts.keys,
                                         )
                                     if (uiMessages.isNotEmpty() && uiMessages != _uiState.value.messages) {
                                         _uiState.update { it.copy(messages = uiMessages) }
@@ -1234,6 +1273,7 @@ class ChatViewModel(
                                     message.info.role == "assistant" && message.info.id !in messageIdsBeforeSend
                                 }
                             if (!sessionCompleted && !hasResponse) return@onSuccess
+                            val retainedIds = streamedParts.keys.toSet()
                             streamedParts.clear()
                             _uiState.update {
                                 it.copy(
@@ -1241,6 +1281,7 @@ class ChatViewModel(
                                         mergeReloadedMessages(
                                             serverMessages.mapNotNull(::toUiMessage),
                                             it.messages,
+                                            retainIds = retainedIds,
                                         ),
                                     isRunning = false,
                                     isThinking = false,
@@ -1828,6 +1869,12 @@ class ChatViewModel(
             }
             is OpenCodeEvent.SessionError -> {
                 if (event.sessionId != null && event.sessionId != activeSession) return
+                // Stopping a run on purpose - the stop button, or a replacement prompt sent
+                // mid-turn - makes the runtime emit this same event carrying an abort error.
+                // That is a decision, not a failure: painting it red left the card up forever,
+                // outliving every later turn, and nothing the turn did next ever cleared it.
+                // The abort paths settle their own state; there is nothing to report here.
+                if (event.isAbort) return
                 event.sessionId?.let(::closeInterruptWindow)
                 _uiState.update {
                     it.copy(
@@ -1848,6 +1895,10 @@ class ChatViewModel(
         // prompt sent in its place; acting on it would park the composer on the send button and
         // drain another queued prompt over a turn that is only starting.
         if (sessionId in pendingInterrupts) return
+        // Captured before the stream cache is cleared: a bubble this client streamed that the
+        // transcript still does not carry (an interrupted turn some runtimes never persist) must
+        // survive the reload below, not vanish with the cache.
+        val retainedIds = streamedParts.keys.toSet()
         streamedParts.clear()
         _uiState.update { state ->
             state.copy(
@@ -1860,17 +1911,25 @@ class ChatViewModel(
             )
         }
         refreshContextUsage(sessionId)
-        refreshMessages(sessionId)
+        refreshMessages(sessionId, retainedIds)
         onSessionCreated()
         drainQueue()
     }
 
-    private fun refreshMessages(sessionId: String) {
+    private fun refreshMessages(
+        sessionId: String,
+        retainIds: Set<String> = emptySet(),
+    ) {
         val currentBackend = backend ?: return
         viewModelScope.launch {
             runCatching { currentBackend.listMessages(sessionId) }
                 .onSuccess { messages ->
-                    val uiMessages = mergeReloadedMessages(messages.mapNotNull(::toUiMessage), _uiState.value.messages)
+                    val uiMessages =
+                        mergeReloadedMessages(
+                            messages.mapNotNull(::toUiMessage),
+                            _uiState.value.messages,
+                            retainIds = retainIds,
+                        )
                     if (uiMessages.isNotEmpty()) {
                         _uiState.update { it.copy(messages = uiMessages) }
                     }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -1053,7 +1053,10 @@ class ChatViewModel(
                     withTimeoutOrNull(RESPONSE_POLL_TIMEOUT_MS) {
                         while (isStillActive() && _uiState.value.isRunning) {
                             delay(RESPONSE_POLL_INTERVAL_MS)
-                            if (!isStillActive()) return@withTimeoutOrNull
+                            // The turn can end while this slept; the idle handler owns the
+                            // transcript then. Another fetch here would merge against a stream
+                            // cache it has already cleared and drop what only this client has.
+                            if (!isStillActive() || !_uiState.value.isRunning) return@withTimeoutOrNull
                             runCatching { currentBackend.listMessages(targetSessionId) }
                                 .onSuccess { serverMessages ->
                                     if (!isStillActive()) return@onSuccess
@@ -1243,7 +1246,10 @@ class ChatViewModel(
                     withTimeoutOrNull(RESPONSE_POLL_TIMEOUT_MS) {
                         while (isStillActive() && _uiState.value.isRunning) {
                             delay(RESPONSE_POLL_INTERVAL_MS)
-                            if (!isStillActive()) return@withTimeoutOrNull
+                            // The turn can end while this slept; the idle handler owns the
+                            // transcript then. Another fetch here would merge against a stream
+                            // cache it has already cleared and drop what only this client has.
+                            if (!isStillActive() || !_uiState.value.isRunning) return@withTimeoutOrNull
                             runCatching { currentBackend.listMessages(targetSessionId) }
                                 .onSuccess { serverMessages ->
                                     if (!isStillActive()) return@onSuccess

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -1759,10 +1759,16 @@ class ChatViewModel(
                     viewModelScope.launch {
                         runCatching { currentBackend.listMessages(session) }
                             .onSuccess { messages ->
+                                val retainedIds = streamedParts.keys.toSet()
                                 streamedParts.clear()
                                 _uiState.update {
                                     it.copy(
-                                        messages = mergeReloadedMessages(messages.mapNotNull(::toUiMessage), it.messages),
+                                        messages =
+                                            mergeReloadedMessages(
+                                                messages.mapNotNull(::toUiMessage),
+                                                it.messages,
+                                                retainIds = retainedIds,
+                                            ),
                                     )
                                 }
                             }
@@ -2181,9 +2187,17 @@ class ChatViewModel(
             if (session != null) {
                 runCatching { currentBackend.listMessages(session) }
                     .onSuccess { messages ->
+                        val retainedIds = streamedParts.keys.toSet()
                         streamedParts.clear()
                         _uiState.update {
-                            it.copy(messages = mergeReloadedMessages(messages.mapNotNull(::toUiMessage), it.messages))
+                            it.copy(
+                                messages =
+                                    mergeReloadedMessages(
+                                        messages.mapNotNull(::toUiMessage),
+                                        it.messages,
+                                        retainIds = retainedIds,
+                                    ),
+                            )
                         }
                     }
                     .isSuccess

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
@@ -205,7 +205,11 @@ class ScheduleExecutionService : Service() {
                     }
                     is OpenCodeEvent.SessionError -> {
                         if (event.sessionId == null || event.sessionId == targetSessionId) {
-                            if (notifyUser) app.notifications.notifySessionError(targetSessionId, event.message, target.id)
+                            // Stopping the run by hand reaches here as MessageAbortedError; the
+                            // user made that decision, so it is not announced as a failure.
+                            if (notifyUser && !event.isAbort) {
+                                app.notifications.notifySessionError(targetSessionId, event.message, target.id)
+                            }
                             throw CompletionSignal(ScheduleCompletion.Failed(event.message))
                         }
                     }

--- a/app/src/test/java/com/yugahashimoto/andcode/core/api/OpenCodeEventParserTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/core/api/OpenCodeEventParserTest.kt
@@ -2,6 +2,8 @@ package com.yugahashimoto.andcode.core.api
 
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -239,5 +241,29 @@ class OpenCodeEventParserTest {
 
         assertEquals("s1", event.sessionId)
         assertEquals("ProviderAuthError: missing api key", event.message)
+        assertEquals("ProviderAuthError", event.name)
+        assertFalse(event.isAbort)
+    }
+
+    @Test
+    fun `session error for a deliberate stop is recognized as an abort`() {
+        val event =
+            parser.parse(
+                """{"type":"session.error","properties":{"sessionID":"s1","error":{"name":"MessageAbortedError","data":{"message":"Aborted"}}}}""",
+            ) as OpenCodeEvent.SessionError
+
+        assertTrue(event.isAbort)
+    }
+
+    @Test
+    fun `session error without a typed error object is not an abort`() {
+        val event =
+            parser.parse(
+                """{"type":"session.error","properties":{"sessionID":"s1","error":"boom"}}""",
+            ) as OpenCodeEvent.SessionError
+
+        assertEquals("boom", event.message)
+        assertNull(event.name)
+        assertFalse(event.isAbort)
     }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatTranscriptReloadTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatTranscriptReloadTest.kt
@@ -1,0 +1,147 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The transcript reload must never discard what only this client has: a turn interrupted by a
+ * replacement prompt is finalized asynchronously, and some runtimes never persist its partial
+ * output at all. These tests pin the retention rules of [mergeReloadedMessages] directly.
+ */
+class ChatTranscriptReloadTest {
+    private fun assistant(
+        id: String,
+        text: String,
+        timestamp: Long,
+    ) = ChatMessage(
+        id = id,
+        isUser = false,
+        parts = listOf(ChatPart.Text(id = "$id-t", text = text)),
+        timestamp = timestamp,
+    )
+
+    private fun user(
+        id: String,
+        text: String,
+        timestamp: Long,
+    ) = ChatMessage(
+        id = id,
+        isUser = true,
+        parts = listOf(ChatPart.Text(id = "$id-t", text = text)),
+        timestamp = timestamp,
+    )
+
+    @Test
+    fun `keeps a streamed bubble the transcript does not carry yet, ahead of later messages`() {
+        val interrupted =
+            assistant("m-aborted", "partial answer", timestamp = 200)
+                .let { it.copy(isStreaming = false) }
+        val reloaded =
+            listOf(
+                user("u1", "first", timestamp = 100),
+                user("u2", "second", timestamp = 300),
+            )
+
+        val merged =
+            mergeReloadedMessages(
+                reloaded = reloaded,
+                existing = listOf(interrupted),
+                retainIds = setOf("m-aborted"),
+            )
+
+        assertEquals(listOf("u1", "m-aborted", "u2"), merged.map { it.id })
+    }
+
+    @Test
+    fun `appends a retained bubble when nothing in the transcript is newer`() {
+        val interrupted = assistant("m-aborted", "partial answer", timestamp = 500)
+        val reloaded = listOf(user("u1", "first", timestamp = 100))
+
+        val merged =
+            mergeReloadedMessages(
+                reloaded = reloaded,
+                existing = listOf(interrupted),
+                retainIds = setOf("m-aborted"),
+            )
+
+        assertEquals(listOf("u1", "m-aborted"), merged.map { it.id })
+    }
+
+    @Test
+    fun `a bubble the transcript now carries under its own id is not doubled up`() {
+        val streamedEarlier = assistant("m-aborted", "partial answer", timestamp = 200)
+        val persisted = assistant("m-aborted", "final answer", timestamp = 200)
+
+        val merged =
+            mergeReloadedMessages(
+                reloaded = listOf(persisted),
+                existing = listOf(streamedEarlier),
+                retainIds = setOf("m-aborted"),
+            )
+
+        assertEquals(listOf("m-aborted"), merged.map { it.id })
+        assertEquals("final answer", merged.single().text)
+    }
+
+    @Test
+    fun `ids outside the retain set are still dropped as before`() {
+        val stale = assistant("m-stale", "gone", timestamp = 150)
+
+        val merged =
+            mergeReloadedMessages(
+                reloaded = listOf(user("u1", "first", timestamp = 100)),
+                existing = listOf(stale),
+                retainIds = setOf("m-kept"),
+            )
+
+        assertEquals(listOf("u1"), merged.map { it.id })
+    }
+
+    @Test
+    fun `an empty transcript leaves the screen untouched instead of wiping it`() {
+        val onScreen =
+            listOf(
+                user("u1", "first", timestamp = 100),
+                assistant("m-aborted", "partial answer", timestamp = 200),
+            )
+
+        val merged =
+            mergeReloadedMessages(
+                reloaded = emptyList(),
+                existing = onScreen,
+                retainIds = setOf("m-aborted"),
+            )
+
+        assertEquals(onScreen, merged)
+    }
+
+    @Test
+    fun `retention never keeps user bubbles`() {
+        val optimistic = user("u-local", "second", timestamp = 300)
+
+        val merged =
+            mergeReloadedMessages(
+                reloaded = listOf(user("u1", "first", timestamp = 100)),
+                existing = listOf(optimistic),
+                retainIds = setOf("u-local"),
+            )
+
+        assertEquals(listOf("u1"), merged.map { it.id })
+    }
+
+    @Test
+    fun `a retained bubble keeps its streamed content`() {
+        val interrupted = assistant("m-aborted", "partial answer", timestamp = 200)
+        assertTrue(interrupted.parts.isNotEmpty())
+
+        val merged =
+            mergeReloadedMessages(
+                reloaded = listOf(user("u2", "second", timestamp = 300)),
+                existing = listOf(interrupted),
+                retainIds = setOf("m-aborted"),
+            )
+
+        assertEquals("partial answer", (merged.first { it.id == "m-aborted" }).text)
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -944,8 +944,16 @@ class ChatViewModelTest {
             runCurrent()
             assertEquals(listOf("prompt:first", "abort:s1", "prompt:second"), backend.calls)
 
-            // The poll loop refetches the transcript while the replacement runs; it reports
-            // nothing persisted yet. Then the replacement ends and its idle reloads again.
+            // The transcript now carries the two prompts (the interrupted turn is not persisted
+            // yet), so the polls reconcile against a real, non-empty transcript.
+            backend.transcript =
+                listOf(
+                    sessionUserMessage("s1", "u1", "first", created = 100),
+                    sessionUserMessage("s1", "u2", "second", created = 101),
+                )
+
+            // The poll loop refetches the transcript while the replacement runs. Then the
+            // replacement ends and its idle reloads again.
             backend.events.tryEmit(OpenCodeEvent.SessionStatusChanged("s1", "busy"))
             advanceTimeBy(RESPONSE_POLL_INTERVAL_MS + 1L)
             backend.events.tryEmit(OpenCodeEvent.SessionIdle("s1"))
@@ -954,6 +962,7 @@ class ChatViewModelTest {
             val abortedBubble =
                 viewModel.uiState.value.messages.firstOrNull { it.id == "m-aborted" }
             assertEquals("partial answer", abortedBubble?.text)
+            assertTrue(viewModel.uiState.value.messages.map { it.id }.containsAll(listOf("u1", "u2")))
         }
 
     /**
@@ -1146,6 +1155,31 @@ class ChatViewModelTest {
                 sessionId = sessionId,
                 role = "assistant",
                 time = OpenCodeTime(created = 1),
+            ),
+        parts =
+            listOf(
+                OpenCodePart(
+                    id = "$messageId-p",
+                    sessionId = sessionId,
+                    messageId = messageId,
+                    type = "text",
+                    text = text,
+                ),
+            ),
+    )
+
+    private fun sessionUserMessage(
+        sessionId: String,
+        messageId: String,
+        text: String,
+        created: Long,
+    ) = OpenCodeMessage(
+        info =
+            OpenCodeMessageInfo(
+                id = messageId,
+                sessionId = sessionId,
+                role = "user",
+                time = OpenCodeTime(created = created),
             ),
         parts =
             listOf(

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -870,6 +870,93 @@ class ChatViewModelTest {
         }
 
     /**
+     * Stopping a run - by hand or by sending a replacement prompt mid-turn - makes the runtime
+     * report the cancelled turn as a session error named MessageAbortedError. That is the user's own
+     * decision arriving back at them: painting it red left an error card up forever, outliving every
+     * later turn, and nothing that happened next ever cleared it.
+     */
+    @Test
+    fun `an abort reported as a session error does not surface as a failure`() =
+        runTest(dispatcher) {
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities(abortsBeforeInterrupt = true))
+            val viewModel = ChatViewModel(backend, backend.events)
+            advanceUntilIdle()
+
+            viewModel.sendMessage("first")
+            runCurrent()
+            viewModel.sendMessage("second")
+            runCurrent()
+
+            backend.events.tryEmit(
+                OpenCodeEvent.SessionError("s1", "MessageAbortedError: Aborted", name = "MessageAbortedError"),
+            )
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.error)
+            assertTrue(viewModel.uiState.value.isRunning)
+        }
+
+    /** A session error that is not a deliberate stop keeps its existing failure reporting. */
+    @Test
+    fun `a real session error still surfaces and ends the run`() =
+        runTest(dispatcher) {
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities(abortsBeforeInterrupt = true))
+            val viewModel = ChatViewModel(backend, backend.events)
+            advanceUntilIdle()
+
+            viewModel.sendMessage("first")
+            runCurrent()
+
+            backend.events.tryEmit(
+                OpenCodeEvent.SessionError("s1", "ProviderAuthError: missing api key", name = "ProviderAuthError"),
+            )
+            advanceUntilIdle()
+
+            assertEquals("ProviderAuthError: missing api key", viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.isRunning)
+        }
+
+    /**
+     * The bubble of a turn interrupted mid-stream must survive the transcript reloads that start
+     * with the replacement prompt. The interrupted turn is finalized asynchronously and some
+     * runtimes never persist its partial output at all, so reloading wholesale dropped what the
+     * user had been reading — the "sent a message and my answer vanished" report.
+     */
+    @Test
+    fun `the partial answer of an interrupted turn survives transcript reloads`() =
+        runTest(dispatcher) {
+            val backend = FakeRuntimeTargetBackend(RuntimeCapabilities(abortsBeforeInterrupt = true))
+            val viewModel = ChatViewModel(backend, backend.events)
+            advanceUntilIdle()
+
+            viewModel.sendMessage("first")
+            runCurrent()
+            // The interrupted turn has streamed some output when the replacement prompt lands.
+            backend.events.tryEmit(
+                OpenCodeEvent.MessagePartUpdated(
+                    OpenCodePart(id = "p1", sessionId = "s1", messageId = "m-aborted", type = "text", text = "partial answer"),
+                ),
+            )
+            runCurrent()
+            assertTrue(viewModel.uiState.value.messages.any { it.id == "m-aborted" })
+
+            viewModel.sendMessage("second")
+            runCurrent()
+            assertEquals(listOf("prompt:first", "abort:s1", "prompt:second"), backend.calls)
+
+            // The poll loop refetches the transcript while the replacement runs; it reports
+            // nothing persisted yet. Then the replacement ends and its idle reloads again.
+            backend.events.tryEmit(OpenCodeEvent.SessionStatusChanged("s1", "busy"))
+            advanceTimeBy(RESPONSE_POLL_INTERVAL_MS + 1L)
+            backend.events.tryEmit(OpenCodeEvent.SessionIdle("s1"))
+            advanceUntilIdle()
+
+            val abortedBubble =
+                viewModel.uiState.value.messages.firstOrNull { it.id == "m-aborted" }
+            assertEquals("partial answer", abortedBubble?.text)
+        }
+
+    /**
      * Messages held while the runtime was unreachable used to all go out the moment it came back.
      * Now that a send interrupts, each one would abort the turn the one before it just started, so
      * they have to be spread over the turns instead.
@@ -1183,6 +1270,9 @@ class ChatViewModelTest {
         /** Aborts and prompt sends in the order the ViewModel issued them. */
         val calls = mutableListOf<String>()
 
+        /** What the transcript endpoint reports; defaults to nothing being persisted. */
+        var transcript: List<OpenCodeMessage> = emptyList()
+
         override suspend fun connect(): Result<OpenCodeHealth> = Result.success(OpenCodeHealth(true, "test"))
 
         override fun disconnect() = Unit
@@ -1198,7 +1288,7 @@ class ChatViewModelTest {
             directory: String?,
         ): OpenCodeSession = OpenCodeSession(id = "s1", title = title ?: "", directory = directory, time = OpenCodeTime(created = 1))
 
-        override suspend fun listMessages(sessionId: String): List<OpenCodeMessage> = emptyList()
+        override suspend fun listMessages(sessionId: String): List<OpenCodeMessage> = transcript
 
         override suspend fun listProviders(): ProviderCatalog = ProviderCatalog()
 


### PR DESCRIPTION
## 問題

実行中のターン途中でメッセージを送ると（割り込み送信）、次の2つの不具合が起きる:

1. **中断されたターンの部分ストリーミング内容が消える** — 送信後、3秒ごとのトランスクリプト再取得がサーバーに未永続化のストリーミング済みバブルを含むメッセージリストをまるごと置換し、「読んでいた回答」が消失する。中断ターンは非同期で確定し、ランタイムによっては部分出力を永続化しないため二度と戻らない。
2. **`MessageAbortedError: Aborted` の赤いエラーカードがずっと残る** — 意図的な停止（ストップボタン・割り込み送信）でもランタイムは `session.error`(MessageAbortedError) を発するが、それが失敗扱いで表示され、以後のターンが何もクリアしない。

## 修正

- **abort エラーの抑制**: `OpenCodeEvent.SessionError` に `name` を追加し `isAbort` 判別できるように（パーサーが `error.name` を抽出）。チャットUIでは abort を失敗として描画しない。アクティビティ通知 (`RuntimeActivityRepository`)、音声セッション、スケジュール実行のエラー通知も同様に抑制（セッション状態の確定処理は従来どおり実行）。
- **部分メッセージの保持**: `mergeReloadedMessages` に `retainIds` を導入。トランスクリプトにまだ存在しない、このクライアントがストリーミングしたアシスタントバブルを、時刻順の位置を保って生き残らせる。サーバーが同じIDのコピーを出したらそちらが勝つ（二重表示なし）。全8呼び出しサイトのうち該当7サイトで適用。
- **ポールループの競合潰し**: idle が `streamedParts` をクリアした後にポールの残りイテレーションがマージしてバブルを落とす経路を2件修正（delay 後の isRunning 再確認、フェッチ前の retention id スナップショット）。

## テスト

- `ChatTranscriptReloadTest`（新規7ケース）: 保持・挿入位置・重複排除・空トランスクリプト・ユーザーバブル非保持
- `ChatViewModelTest` 3ケース追加: abort session error 非表示 / 実エラーは従来どおり表示 / 中断ターンの部分回答がポールとidle後の再取得で存続
- `OpenCodeEventParserTest` 2ケース追加: `session.error` の name 抽出と abort 判別
- `./gradlew :app:testDebugUnitTest detekt spotlessCheck :app:lintDebug` 全成功

<!-- pre-pr-review: approved -->
## Pre-PR review

```
判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- ChatViewModel.kt:1063 / 1260 — スナップショット後〜マージ間にSSEで新しいメッセージIDが生成され、かつそのフェッチのサーバー応答にまだ存在しない場合、そのIDがretainIdsに含まれず1ポール周期（最大3秒）画面から落ちる窓が残ります。次のpart deltaで updateStreamingMessage が再追加するため自己修復的で、修正対象の「中断バブルの恒久消失」より桁違いに軽微です。完全に塞ぐならマージ時に `snapshot + streamedParts.keys` の和集合を渡す形も可能ですが、現状のままでマージ可です。
- このレース自体は時間依存のため単体テスト困難ですが、ChatTranscriptReloadTest が保持ルール（二重表示なし、retainセット外は落下、ユーザーバブル不保持）をピン留めしており十分なカバレッジです。

## チェック済み項目
- c02d4ec の差分が説明通り ChatViewModel.kt のみ・2ハンクであることを git diff 4027ba5..c02d4ec で確認
- スナップショット→フェッチ→idleクリア→onSuccessマージの順序でバブルが保持されることをコード追跡で確認。idle側 refreshMessages のマージと本マージが両方 existing から同一IDを保持するため二重化・消失なし（id !in reloadedIds ガード確認）
- 第1ループは位置引数 (reloaded, existing, previewsByFilename, retainIds)、第2ループは名前付き引数で、mergeReloadedMessages のシグネチャと一致
- c02d4ec はリソース・UI文字列無変更のためi18n影響なし（ブランチ全体でも res/ 配下の変更なし）
- 位置引数の渡し順、detekt/spotless 形式（インデント・コメント）を目視確認。testDebugUnitTest/detekt/spotlessCheck/lintDebug の成功報告と矛盾する要素なし

HEAD c02d4ec を承認します。残る提案は自己修復的な軽微なUIフリッカーの窓のみで、ブロッカーではありません。このままPRを作成して問題ありません。
```
