### PR TITLE
ci(review): disable broken OCR bot and request Copilot reviews instead

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,38 @@
+name: Copilot PR Review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+on:
+  # pull_request_target so the job can add a reviewer even on fork PRs
+  # (GITHUB_TOKEN is read-only for pull_request events from forks).
+  # Safe because the job only touches reviewer metadata and never executes
+  # PR code.
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  code-review:
+    # Copilot reviews on its own schedule once requested; this only asks for
+    # it. The reviewer request fails with 422 until "Copilot in the code
+    # review" is enabled for the repository (Settings > Copilot > Code
+    # review), which has no API - so the failure is logged, not failed.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if gh pr edit "$PR_NUMBER" --add-reviewer copilot-pull-request-reviewer; then
+            echo "Copilot requested as reviewer on #$PR_NUMBER"
+          else
+            echo "::warning::Could not request Copilot (is 'Copilot in the code review' enabled for this repository?)"
+          fi

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -10,7 +10,7 @@ on:
   # Safe because the job only touches reviewer metadata and never executes
   # PR code.
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,15 +1,16 @@
 name: OCR PR Review
 
+# DISABLED 2026-08: OpenCode Zen's free tier keeps failing with
+# "Upstream request failed: Model is unavailable", so every PR went red on a
+# check that had produced no findings at all. Automated review moved to
+# copilot-review.yml; restore the pull_request_target trigger below once the
+# free tier is dependable again.
+on:
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
-on:
-  # pull_request_target so the job can post comments even on fork PRs
-  # (GITHUB_TOKEN is read-only for pull_request events from forks).
-  # Safe because OCR only reads the diff and never executes PR code.
-  pull_request_target:
-    types: [opened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 内容

CI の `code-review` チェック（alibaba/open-code-review ボット）が、OpenCode Zen フリーティアの障害（`Upstream request failed: Model is unavailable`）で毎PR赤くなり、findings も常に0件のため対応しました。

- **ocr-review.yml を自動実行オフに**（`workflow_dispatch` 専用へ）。ジョブ本体と設定は保持し、復元方法のコメントを追記。復旧したらトリガーを戻すだけ。
- **copilot-review.yml を新設**。PR の open / reopened / ready_for_review / synchronize で GitHub Copilot（`copilot-pull-request-reviewer`）をレビュアーとして自動要求する。OCR と同じく `pull_request_target` + 最小権限（reviewer メタデータ操作のみ、PR コードは実行しない）。Copilot コードレビューがリポジトリ設定で無効な場合は 422 になるため、失敗させず `::warning::` で記録する。
  - ※ 初回有効化に必要なリポジトリ設定: Settings → Copilot → Code review（APIからは変更不可のため一度手動でオンにしてください）

備考: `main` にブランチ保護はなく必須ステータスチェックも無いため、OCR の無効化でマージが詰まることはない。

## テスト

- 両 YAML のパース検証（js-yaml）
- 差分は `.github/workflows/` 配下2ファイルのみ（アプリコード・リソース無変更）
- `./gradlew detekt spotlessCheck` 成功

<!-- pre-pr-review: approved -->
## Pre-PR review

```
判定: APPROVE

## ブロッカー
なし

## 提案（非ブロッキング）
- .github/workflows/ocr-review.yml:5 — 無効化後も `concurrency.group` の `github.event.pull_request.number || github.ref` が残っていますが、トリガーが `workflow_dispatch` のみのため常に `github.ref` にフォールバックするだけで害はありません。復活させる際にそのまま使えるので、このままでも問題ありません。

## チェック済み項目
- スコープ確認: `git fetch origin main` 後、`git log origin/main..HEAD` で2コミット（9a979d1, 93e7b9a）、`git diff --stat origin/main...HEAD` で変更は `.github/workflows/copilot-review.yml` と `ocr-review.yml` の2ファイルのみ。前回承認からの追加は `git show 93e7b9a` で1行（types への `synchronize` 追加）のみと確認。
- セキュリティ: `pull_request_target` + `synchronize` の追加に伴い、ワークフロー全体を再確認。checkout ステップや PR コードの実行は一切なく、`gh pr edit --add-reviewer` の reviewer メタデータ操作のみのため、fork PR でもコード実行リスクなし。権限は `contents: read` / `pull-requests: write` の最小構成のまま。
- 動作面: `synchronize` 追加により push ごとに再リクエストが走るが、reviewer 再リクエストは冪等（既に要求済みなら成功または422）。422 時も `::warning::` でログするのみでジョブは落とさない設計を確認。`concurrency` の cancel-in-progress（PR番号単位）により連続 push でも古い実行はキャンセルされる。
- 影響範囲: リポジトリ全体を `ocr-review` / `OCR PR Review` で検索し、無効化されたワークフローへの参照が他にないことを確認（定義ファイル自身のみ）。アプリコード・リソース・テストへの影響なし。i18n / spotless / detekt / unit test の各ゲートは本差分（GitHub Actions YAML のみ）の対象外。
```
