### PR TITLE
fix(antigravity): parse the two-column models output of agy 1.1.17

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityModels.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityModels.kt
@@ -8,12 +8,11 @@ import com.yugahashimoto.andcode.core.api.ProviderCatalog
  * Models offered for Antigravity, read from `agy models`.
  *
  * Unlike Claude Code, the official CLI does enumerate what the signed-in account can actually use.
- * The pinned official release (1.1.7, [AntigravityManifest.VERSION]) prints one lowercase, hyphenated
- * slug per line - `gemini-3.1-pro-high`, `claude-opus-4-6-thinking`, `claude-sonnet-4-6` - confirmed
- * live against a signed-in install of that exact version. Earlier builds of this parser were tested
- * against a different locally-installed `agy` version (1.1.1) that prints `Title Case (Variant)`
- * labels instead; that format does not appear in the version this app actually ships, which is why
- * the model picker previously showed nothing useful.
+ * Since 1.1.17 each line is two whitespace-separated columns - the lowercase hyphenated slug the
+ * CLI accepts on `--model`, then a human label: `gemini-3.7-flash-low Gemini 3.7 Flash (Low)`. The
+ * 1.1.x releases before that printed the bare slug only (`gemini-3.1-pro-high`), and 1.1.1 printed
+ * `Title Case (Variant)` labels with no slug at all; [parse] handles all three by treating
+ * everything after the first token as the label.
  */
 object AntigravityModels {
     const val PROVIDER_ID = "antigravity"
@@ -31,29 +30,42 @@ object AntigravityModels {
      */
     private val EFFORT_SUFFIXES = setOf("high", "medium", "low")
 
-    data class Entry(val base: String, val variant: String?) {
-        /** The line the CLI printed, and the id the picker shows. */
+    /** The reasoning efforts a slug's trailing segment may carry, joined for messages. */
+    private val WHITESPACE = Regex("\\s+")
+
+    data class Entry(
+        val base: String,
+        val variant: String?,
+        /** The CLI's own display name for the model, or null when the line carried no label. */
+        val label: String? = null,
+    ) {
+        /** The slug the CLI prints and accepts on `--model` — never contains whitespace. */
         val slug: String get() = if (variant != null) "$base-$variant" else base
     }
 
     /**
      * Parses one model per non-blank line.
      *
-     * A slug's last hyphen-separated segment splits off only when it is a reasoning effort;
-     * `claude-sonnet-4-6`'s last segment is `6` and `claude-opus-4-6-thinking`'s is `thinking`, so
-     * both stay whole - splitting on every hyphen would cut version numbers like `4-6` apart.
+     * The first whitespace-delimited token is always the slug; anything after it is the CLI's
+     * display label for the picker. Within a bare slug (the pre-1.1.17 format), the last
+     * hyphen-separated segment splits off only when it is a reasoning effort; `claude-sonnet-4-6`'s
+     * last segment is `6` and `claude-opus-4-6-thinking`'s is `thinking`, so both stay whole -
+     * splitting on every hyphen would cut version numbers like `4-6` apart.
      */
     fun parse(output: String): List<Entry> =
         output.lineSequence()
             .map(String::trim)
             .filter(String::isNotEmpty)
-            .map { slug ->
+            .map { line ->
+                val firstBreak = WHITESPACE.find(line)?.range?.first ?: line.length
+                val slug = line.take(firstBreak)
+                val label = line.drop(firstBreak).trim().takeIf(String::isNotEmpty)
                 val segments = slug.split('-')
                 val last = segments.last()
                 if (segments.size > 1 && last in EFFORT_SUFFIXES) {
-                    Entry(segments.dropLast(1).joinToString("-"), last)
+                    Entry(segments.dropLast(1).joinToString("-"), last, label)
                 } else {
-                    Entry(slug, null)
+                    Entry(slug, null, label)
                 }
             }
             .toList()
@@ -83,11 +95,12 @@ object AntigravityModels {
         // a separate effort chip. A model that has efforts *requires* one - the CLI rejects
         // `--model gemini-3.1-pro` with `--effort ""` - so an effort left unselected in another
         // control is not a valid state to be able to reach. Listing whole ids also keeps the picker
-        // a one-to-one view of `agy models`.
+        // a one-to-one view of `agy models`. The CLI's own label (1.1.17+) names the row and the
+        // bare slug stays the id/subtitle; older releases printed no label, so the id fills in.
         val models =
             entries.associate { entry ->
                 val id = entry.slug
-                id to OpenCodeModel(id = id, providerId = PROVIDER_ID, name = id)
+                id to OpenCodeModel(id = id, providerId = PROVIDER_ID, name = entry.label ?: id)
             }
         return ProviderCatalog(
             all = listOf(OpenCodeProvider(PROVIDER_ID, "Antigravity", models)),
@@ -115,7 +128,10 @@ object AntigravityModels {
         if (selected == FALLBACK_MODEL) return emptyList()
         // The picker's id is a whole CLI slug, so the effort is split back out of it here rather
         // than taken from [variant] - which is the chat's separate effort control and can legally be
-        // unset. Reading it from the id means the pair sent to the CLI is always complete.
+        // unset. Reading it from the id means the pair sent to the CLI is always complete. Sessions
+        // recorded while 1.1.17's two-column output was parsed whole carry a trailing display label
+        // in the id; [parse] reads only the first token as the slug, so the label never reaches
+        // `--model`.
         val entry = parse(selected).single()
         val effort = entry.variant ?: variant?.trim()?.lowercase()?.takeIf { it in EFFORT_SUFFIXES }
         return listOf("--model", entry.base) + (effort?.let { listOf("--effort", it) } ?: emptyList())

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityModels.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityModels.kt
@@ -30,7 +30,7 @@ object AntigravityModels {
      */
     private val EFFORT_SUFFIXES = setOf("high", "medium", "low")
 
-    /** The reasoning efforts a slug's trailing segment may carry, joined for messages. */
+    /** Splits a `models` line into its leading slug token and the display label after it. */
     private val WHITESPACE = Regex("\\s+")
 
     data class Entry(

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityModelsTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravityModelsTest.kt
@@ -5,9 +5,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * [output] is captured verbatim from `agy models` run on a signed-in real device with the exact
- * official 1.1.7 release this app pins - not the differently-formatted output an unrelated locally
- * installed 1.1.1 build printed, which an earlier version of this parser was built against.
+ * [output] is captured verbatim from `agy models` run on a signed-in real device - the bare-slug
+ * format of the 1.1.7 release, and the two-column `slug + label` format 1.1.17 prints. An earlier
+ * version of this parser was built against the differently-formatted output of an unrelated locally
+ * installed 1.1.1 build.
  */
 class AntigravityModelsTest {
     private val output =
@@ -25,12 +26,46 @@ class AntigravityModelsTest {
         gpt-oss-120b-medium
         """.trimIndent()
 
+    /** Verbatim shape of 1.1.17: one slug per line, followed by the CLI's own display label. */
+    private val labelledOutput =
+        """
+        gemini-3.7-flash-low Gemini 3.7 Flash (Low)
+        gemini-3.7-flash-medium Gemini 3.7 Flash
+        gemini-3.7-flash-high Gemini 3.7 Flash (High)
+        claude-opus-4-6-thinking Claude Opus 4.6 (Thinking)
+        gpt-oss-120b-medium GPT-OSS 120B
+        """.trimIndent()
+
     @Test
     fun `parses the real agy models output`() {
         val entries = AntigravityModels.parse(output)
         assertEquals(11, entries.size)
         assertEquals(AntigravityModels.Entry("gemini-3.6-flash", "high"), entries.first())
         assertEquals(AntigravityModels.Entry("gpt-oss-120b", "medium"), entries.last())
+    }
+
+    @Test
+    fun `parses 1 1 17 two-column lines into slug and label`() {
+        val entries = AntigravityModels.parse(labelledOutput)
+        assertEquals(5, entries.size)
+        assertEquals(
+            AntigravityModels.Entry("gemini-3.7-flash", "low", "Gemini 3.7 Flash (Low)"),
+            entries.first(),
+        )
+        assertEquals(
+            AntigravityModels.Entry("claude-opus-4-6-thinking", null, "Claude Opus 4.6 (Thinking)"),
+            entries[3],
+        )
+    }
+
+    @Test
+    fun `the picker names a model by its CLI label and ids it by its slug`() {
+        val catalog = AntigravityModels.catalog(AntigravityModels.parse(labelledOutput))
+        val provider = catalog.all.single()
+        assertEquals(5, provider.models.size)
+        assertEquals("Gemini 3.7 Flash (Low)", provider.models.getValue("gemini-3.7-flash-low").name)
+        assertEquals("GPT-OSS 120B", provider.models.getValue("gpt-oss-120b-medium").name)
+        assertEquals("gemini-3.7-flash-low", catalog.default[AntigravityModels.PROVIDER_ID])
     }
 
     @Test
@@ -90,6 +125,22 @@ class AntigravityModelsTest {
     fun `a model with no effort is sent alone`() {
         assertEquals(listOf("--model", "claude-sonnet-4-6"), AntigravityModels.cliArgs("claude-sonnet-4-6", null))
         assertEquals(listOf("--model", "claude-opus-4-6-thinking"), AntigravityModels.cliArgs("claude-opus-4-6-thinking", null))
+    }
+
+    /**
+     * Sessions recorded while 1.1.17's two-column output was parsed whole carry the display label
+     * inside the stored id; only the leading slug may reach `--model`.
+     */
+    @Test
+    fun `an id polluted with a display label still sends a clean slug`() {
+        assertEquals(
+            listOf("--model", "gemini-3.7-flash", "--effort", "high"),
+            AntigravityModels.cliArgs("gemini-3.7-flash-high Gemini 3.7 Flash (High)", null),
+        )
+        assertEquals(
+            listOf("--model", "gpt-oss-120b", "--effort", "medium"),
+            AntigravityModels.cliArgs("gpt-oss-120b-medium GPT-OSS 120B", "low"),
+        )
     }
 
     @Test


### PR DESCRIPTION
agy 1.1.17 で `models` 出力が「<slug> <表示名>」の2列形式に変わり、旧パーサー(行全体をslug扱い)が壊れた問題の修正です。

## 症状

- モデルピッカーの各行に slug+表示名がタイトルとサブタイトルに二重表示される
- `--model` に空白入り文字列が渡り、CLIが拒否する可能性(送信失敗)

## 修正 (AntigravityModels)

- `parse()`: 行の最初の空白トークンをslug、それ以降をCLI自身の表示ラベルとして保持。effort接尾辞の分割はslugトークンのみに適用
- `catalog()`: ピッカーのタイトルにCLIのラベル(`Gemini 3.7 Flash (Low)`)、idはクリーンなslug。旧形式(bare slug, label無し)は従来通り id=name
- `cliArgs()`: 表示名入りの汚染idがセッションに保存されていても、先頭トークンから正しいslug/effortを復元して送信

## テスト

- 1.1.17形式のパース / catalog命名 / 汚染idからのcliArgs復元 を追加
- ローカルゲート全通過: :app:testDebugUnitTest(全件) / lintDebug / spotlessCheck / detekt

<!-- pre-pr-review: approved -->
## Pre-PR review

```
判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- AntigravityModels.kt:33 — WHITESPACE の KDoc が「The reasoning efforts a slug's trailing segment may carry, joined for messages.」と EFFORT_SUFFIXES 用の説明のコピーになっており、実体（slug 列と表示ラベル列を分ける最初の空白区切り）と不一致。誤解を招くので、区切り文字列である旨に修正を推奨。

## チェック済み項目
- 差分範囲: git diff origin/main...HEAD を全ハンク読了。ブランチは origin/main 直上の単一コミット（worktree 規則に合致）。
- パーサー正しさ: 先頭トークン抽出は Regex("\\s+") の最初のマッチ位置ベースで、タブ・連続空白・前後空白にも正しく対応。effort 接尾辞の分割対象が slug トークンのみに限定され、2 列行 gemini-3.7-flash-low Gemini 3.7 Flash (Low) → base=gemini-3.7-flash / variant=low / label 保持を確認。
- 後方互換: bare slug 行では label=null → catalog の name = entry.label ?: id が旧挙動（name=id）と完全一致。既存テスト（11 行フォーマット）も無変更で成立。
- 汚染 id 回復: cliArgs が parse(selected) の先頭トークンのみで slug/effort を復元することを確認し、表示名入りの保存済みセッション id からクリーンな --model/--effort を送ることを新規テストが担保。
- 呼び出し側検証: AntigravityRuntime.models()/send()/summarizeTitle()（cheapest?.slug は常にクリーン）、AntigravityTarget.listProviders()/listMessages() を確認。ピッカー（ModelAndRuntimePickerSheet.kt:372-378）と ModelVisibilityScreen は既に name=タイトル / id=サブタイトル描画で、お気に入り・履歴・非表示キーは providerId/modelId（id ベース）のため表示名変更の影響なし。UI 変更不要な構成を確認。
- Entry へのデフォルト付き第3引数追加: 全コンストラクト箇所（main/tests）は位置引数 2〜3 個で互換、destructure や exhaustive な利用なし。
- i18n: strings.xml 等リソース無変更、ハードコードされた UI 文言の追加なし（モデル表示名は CLI 出力由来のデータ）。KDoc/ログは英語維持。
- DI/ViewModel: 本差分に ViewModel への依存追加なし。
- テスト: 新形式パース・catalog 命名・汚染 id の cliArgs をカバーし、挙動変更に対するテスト更新あり。

APPROVE
```

※ 提案1(KDoc修正)は適用済みです。
