### PR TITLE
fix(schedule): settle runs from the transcript and stop opening session-less chats

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -804,6 +804,12 @@ class ChatViewModel(
         parent: ParentSessionRef? = null,
     ) {
         val currentBackend = backend ?: return
+        // A blank id is not a session: loading it would ask the runtime for `session//message` and
+        // render its parameter error in place of the transcript. Open an empty chat instead.
+        if (sessionId.isBlank()) {
+            newSession()
+            return
+        }
         // Switching away from whatever chat was previously loaded here must drop its running
         // state too — otherwise the composer opens the new chat already stuck on the stop button
         // because the old chat happened to be mid-turn when the user navigated away.

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
@@ -24,6 +24,7 @@ import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
 import com.yugahashimoto.andcode.runtime.RuntimeType
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
@@ -31,23 +32,30 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Executes a scheduled prompt in the foreground.
  *
  * Woken by an exact alarm (or by "Run now"), it boots the local runtime if needed, creates a
- * session, sends the prompt and watches the event stream until the run finishes - then records
- * the outcome, re-arms the next alarm and stops itself.
+ * session, sends the prompt and watches both the event stream and the transcript until the run
+ * finishes - then records the outcome, re-arms the next alarm and stops itself.
  */
 class ScheduleExecutionService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var app: AndCodeApplication
     private var inForeground = false
     private var executionJob: Job? = null
+
+    /** Why the event stream stopped, when it stopped before the run settled. */
+    @Volatile
+    private var streamFailure: String? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -125,7 +133,7 @@ class ScheduleExecutionService : Service() {
                 recordSkipped(schedule, getString(R.string.schedule_runtime_not_ready))
                 return
             }
-            if (target.connect().isFailure) {
+            if (!connectWithRetry(target)) {
                 recordSkipped(schedule, getString(R.string.schedule_runtime_connection_failed))
                 return
             }
@@ -137,36 +145,106 @@ class ScheduleExecutionService : Service() {
             val run = app.scheduleRepository.recordRunStarted(schedule, session.id, target.id)
             activeRun = run
             updateForegroundNotification(app.getString(R.string.schedule_notification_running))
-
-            val autoAccept = schedule.autoAcceptPermissions ?: app.settings.autoAcceptPermissions
-            // Subscribe before sending: fast runtimes can emit idle during sendMessage itself.
-            val watcher: Deferred<ScheduleCompletion> =
-                scope.async(start = CoroutineStart.UNDISPATCHED) {
-                    watchForCompletion(target, schedule, run, autoAccept)
-                }
-            try {
-                target.sendMessage(
-                    session.id,
-                    PromptRequest(
-                        text = schedule.prompt,
-                        providerId = schedule.providerId,
-                        modelId = schedule.modelId,
-                        agent = schedule.agentId,
-                    ),
-                )
-                when (val completion = withTimeoutOrNull(COMPLETION_TIMEOUT_MS) { watcher.await() }) {
-                    ScheduleCompletion.Completed -> recordCompleted(run)
-                    is ScheduleCompletion.Failed -> recordFailed(run, completion.message)
-                    null -> recordFailed(run, getString(R.string.schedule_completion_timeout))
-                }
-            } finally {
-                watcher.cancel()
-            }
+            runPrompt(target, schedule, run)
         } catch (error: Exception) {
             activeRun?.let { recordFailed(it, error.message ?: error.javaClass.simpleName) }
         } finally {
             // A cron schedule arms its next alarm when this run settles, whatever the outcome.
             app.scheduleManager.rescheduleAll()
+        }
+    }
+
+    /**
+     * Connects the runtime, giving a refused first attempt a few more tries.
+     *
+     * An alarm fires the moment the device wakes, which is when the agent is least likely to
+     * answer: the local runtime reports Ready as soon as its process is up, before the HTTP server
+     * accepts connections, and a remote one is reached over a network the device has only just
+     * re-joined. A single refused health check used to skip the whole run.
+     */
+    private suspend fun connectWithRetry(target: RuntimeTarget): Boolean {
+        repeat(CONNECT_ATTEMPTS) { attempt ->
+            if (target.connect().isSuccess) return true
+            if (attempt < CONNECT_ATTEMPTS - 1) delay(CONNECT_RETRY_DELAY_MS * (attempt + 1))
+        }
+        return false
+    }
+
+    /**
+     * Sends the prompt and records what the run did.
+     *
+     * The run settles on whichever watcher sees it first: the event stream, which is immediate, or
+     * the transcript poll, which keeps working after the stream drops.
+     */
+    private suspend fun runPrompt(
+        target: RuntimeTarget,
+        schedule: Schedule,
+        run: ScheduleRun,
+    ) {
+        val autoAccept = schedule.autoAcceptPermissions ?: app.settings.autoAcceptPermissions
+        streamFailure = null
+        // Subscribe before sending: fast runtimes can emit idle during sendMessage itself.
+        val watcher: Deferred<ScheduleCompletion> =
+            scope.async(start = CoroutineStart.UNDISPATCHED) {
+                awaitStreamCompletion(target, schedule, run, autoAccept)
+            }
+        // The poll sleeps before its first read, so it only ever sees this prompt's own turn.
+        val transcriptPoll: Deferred<ScheduleCompletion> = scope.async { pollForCompletion(target, run) }
+        try {
+            target.sendMessage(
+                run.sessionId,
+                PromptRequest(
+                    text = schedule.prompt,
+                    providerId = schedule.providerId,
+                    modelId = schedule.modelId,
+                    agent = schedule.agentId,
+                ),
+            )
+            val completion =
+                withTimeoutOrNull(COMPLETION_TIMEOUT_MS) {
+                    select<ScheduleCompletion> {
+                        watcher.onAwait { it }
+                        transcriptPoll.onAwait { it }
+                    }
+                }
+            if (completion == null) {
+                // A stream that stopped early explains the silence better than the timeout does.
+                recordFailed(run, streamFailure ?: getString(R.string.schedule_completion_timeout))
+            } else {
+                settle(target, schedule, run, completion)
+            }
+        } finally {
+            watcher.cancel()
+            transcriptPoll.cancel()
+        }
+    }
+
+    /** Records the outcome, announcing it unless the user is already looking at this runtime. */
+    private suspend fun settle(
+        target: RuntimeTarget,
+        schedule: Schedule,
+        run: ScheduleRun,
+        completion: ScheduleCompletion,
+    ) {
+        val notifyUser = target.id != app.runtimeRegistry.selected.value?.id
+        when (completion) {
+            ScheduleCompletion.Completed -> {
+                if (notifyUser) {
+                    val title =
+                        runCatching { target.session(run.sessionId).title }
+                            .getOrDefault(schedule.displayName)
+                    app.notifications.notifySessionComplete(run.sessionId, title, target.id)
+                }
+                recordCompleted(run)
+            }
+            is ScheduleCompletion.Failed -> {
+                // Stopping the run by hand settles it as MessageAbortedError; the user made that
+                // decision, so it is not announced as a failure.
+                if (notifyUser && !completion.silent) {
+                    app.notifications.notifySessionError(run.sessionId, completion.message, target.id)
+                }
+                recordFailed(run, completion.message)
+            }
         }
     }
 
@@ -188,15 +266,74 @@ class ScheduleExecutionService : Service() {
     }
 
     /**
-     * Streams events for the run's session until it settles. Returns normally on completion or
-     * failure, so [execute] never mistakes a settled run for a crashed one.
+     * Waits for the event stream to settle the run.
+     *
+     * A stream that stops before the run does is not itself a failed run - the agent keeps working
+     * on the runtime - so this hands the outcome to [pollForCompletion] and suspends, leaving the
+     * reason behind for the timeout message.
+     */
+    private suspend fun awaitStreamCompletion(
+        target: RuntimeTarget,
+        schedule: Schedule,
+        run: ScheduleRun,
+        autoAccept: Boolean,
+    ): ScheduleCompletion {
+        val reason =
+            try {
+                watchForCompletion(target, schedule, run, autoAccept)?.let { return it }
+                getString(R.string.schedule_event_stream_ended)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (error: Exception) {
+                error.message?.takeIf(String::isNotBlank) ?: error.javaClass.simpleName
+            }
+        Log.w(TAG, "Event stream stopped before the run settled: $reason")
+        streamFailure = reason
+        awaitCancellation()
+    }
+
+    /**
+     * Settles the run from its transcript, which survives what the event stream cannot: a doze
+     * window, a runtime restart, a dropped socket. Without it a run whose `session.idle` was lost
+     * failed on the completion timeout even though the agent had answered long before.
+     */
+    private suspend fun pollForCompletion(
+        target: RuntimeTarget,
+        run: ScheduleRun,
+    ): ScheduleCompletion {
+        var settling: String? = null
+        while (true) {
+            delay(TRANSCRIPT_POLL_INTERVAL_MS)
+            val messages =
+                runCatching { target.listMessages(run.sessionId) }
+                    .onFailure { error -> Log.w(TAG, "Could not read the run transcript", error) }
+                    .getOrNull()
+                    ?: continue
+            val newest = messages.lastOrNull()?.info
+            val outcome = scheduleCompletionOf(messages)
+            if (newest == null || outcome == null) {
+                settling = null
+                continue
+            }
+            // A turn can finish one message and open another (a tool step, a subagent hop). The
+            // event stream knows the difference; the transcript only shows it a read later, so a
+            // run counts as settled once the same finished message is still the newest one.
+            val fingerprint = "${newest.id}:${newest.time.completed}:${newest.error?.name}"
+            if (settling == fingerprint) return outcome
+            settling = fingerprint
+        }
+    }
+
+    /**
+     * Streams events for the run's session until it settles, or returns null when the stream ends
+     * without settling it.
      */
     private suspend fun watchForCompletion(
         target: RuntimeTarget,
         schedule: Schedule,
         run: ScheduleRun,
         autoAccept: Boolean,
-    ): ScheduleCompletion {
+    ): ScheduleCompletion? {
         val targetSessionId = run.sessionId
         val notifyUser = target.id != app.runtimeRegistry.selected.value?.id
 
@@ -205,23 +342,12 @@ class ScheduleExecutionService : Service() {
                 when (event) {
                     is OpenCodeEvent.SessionIdle -> {
                         if (event.sessionId == targetSessionId) {
-                            if (notifyUser) {
-                                val title =
-                                    runCatching { target.session(targetSessionId).title }
-                                        .getOrDefault(schedule.displayName)
-                                app.notifications.notifySessionComplete(targetSessionId, title, target.id)
-                            }
                             throw CompletionSignal(ScheduleCompletion.Completed)
                         }
                     }
                     is OpenCodeEvent.SessionError -> {
                         if (event.sessionId == null || event.sessionId == targetSessionId) {
-                            // Stopping the run by hand reaches here as MessageAbortedError; the
-                            // user made that decision, so it is not announced as a failure.
-                            if (notifyUser && !event.isAbort) {
-                                app.notifications.notifySessionError(targetSessionId, event.message, target.id)
-                            }
-                            throw CompletionSignal(ScheduleCompletion.Failed(event.message))
+                            throw CompletionSignal(ScheduleCompletion.Failed(event.message, silent = event.isAbort))
                         }
                     }
                     is OpenCodeEvent.PermissionAsked -> {
@@ -251,7 +377,7 @@ class ScheduleExecutionService : Service() {
             // The run settled; the event stream is drained.
             return signal.result
         }
-        return ScheduleCompletion.Failed(getString(R.string.schedule_event_stream_ended))
+        return null
     }
 
     private fun recordCompleted(run: ScheduleRun) {
@@ -309,12 +435,6 @@ class ScheduleExecutionService : Service() {
     }
 
     /** Thrown to unwind the event collector once the run has settled. */
-    private sealed interface ScheduleCompletion {
-        data object Completed : ScheduleCompletion
-
-        data class Failed(val message: String?) : ScheduleCompletion
-    }
-
     private class CompletionSignal(val result: ScheduleCompletion) : Exception()
 
     companion object {
@@ -324,6 +444,9 @@ class ScheduleExecutionService : Service() {
         private const val NOTIFICATION_ID = 4201
         private const val LOCAL_RUNTIME_START_TIMEOUT_MS = 5 * 60_000L
         private const val COMPLETION_TIMEOUT_MS = 30 * 60_000L
+        private const val CONNECT_ATTEMPTS = 3
+        private const val CONNECT_RETRY_DELAY_MS = 3_000L
+        private const val TRANSCRIPT_POLL_INTERVAL_MS = 30_000L
 
         /**
          * Starts a run, returning false when the platform refused the foreground start.

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleRunOutcome.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleRunOutcome.kt
@@ -1,0 +1,35 @@
+package com.yugahashimoto.andcode.feature.schedule
+
+import com.yugahashimoto.andcode.core.api.OpenCodeMessage
+
+/** How a scheduled run ended. */
+sealed interface ScheduleCompletion {
+    data object Completed : ScheduleCompletion
+
+    /**
+     * @param silent the turn was stopped on purpose (the stop button, a replacement prompt), so the
+     * outcome is recorded but never announced as a failure.
+     */
+    data class Failed(val message: String?, val silent: Boolean = false) : ScheduleCompletion
+}
+
+/**
+ * Reads a run's outcome off its transcript, or null while the turn is still in flight.
+ *
+ * The event stream is how a run normally settles, but it is a single long-lived connection: a doze
+ * window, a runtime restart or a dropped socket swallows the `session.idle` that ends the run, and
+ * the run then failed on the completion timeout long after the agent had actually answered.
+ * Polling the transcript settles those runs from the same signal the chat already trusts - the
+ * newest message being a finished assistant reply.
+ */
+fun scheduleCompletionOf(messages: List<OpenCodeMessage>): ScheduleCompletion? {
+    val newest = messages.lastOrNull()?.info ?: return null
+    // The prompt itself is the newest message until the agent starts replying.
+    if (newest.role == "user") return null
+    val error = newest.error
+    return when {
+        error != null -> ScheduleCompletion.Failed(error.message ?: error.name, silent = error.isAbort)
+        newest.time.completed != null -> ScheduleCompletion.Completed
+        else -> null
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleRunsScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleRunsScreen.kt
@@ -148,8 +148,11 @@ private fun RunRow(
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
     val color = statusColor(run.status)
+    // A run skipped before its session existed has no chat behind it; tapping it used to open the
+    // chat on a blank session id, which the runtime answers with a raw request error.
+    val hasSession = run.sessionId.isNotBlank()
     Surface(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().clickable(enabled = hasSession, onClick = onClick),
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
     ) {
@@ -196,7 +199,7 @@ private fun RunRow(
                     )
                 }
             }
-            if (run.sessionId.isNotBlank()) {
+            if (hasSession) {
                 Text(
                     text = stringResource(R.string.schedule_open_chat),
                     style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -717,6 +717,8 @@ fun AndCodeApp(
         title: String,
         runtimeId: String?,
     ) {
+        // Nothing to open: a caller with no session would land the chat on a blank id.
+        if (sessionId.isBlank()) return
         if (runtimeId != null && runtimeId != selectedRuntime?.id) {
             app.runtimeRegistry.select(runtimeId)
         }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/schedule/ScheduleRunOutcomeTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/schedule/ScheduleRunOutcomeTest.kt
@@ -1,0 +1,93 @@
+package com.yugahashimoto.andcode.feature.schedule
+
+import com.yugahashimoto.andcode.core.api.OpenCodeMessage
+import com.yugahashimoto.andcode.core.api.OpenCodeMessageError
+import com.yugahashimoto.andcode.core.api.OpenCodeMessageInfo
+import com.yugahashimoto.andcode.core.api.OpenCodeTime
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScheduleRunOutcomeTest {
+    @Test
+    fun `an empty transcript is still running`() {
+        assertNull(scheduleCompletionOf(emptyList()))
+    }
+
+    @Test
+    fun `the prompt alone is still running`() {
+        assertNull(scheduleCompletionOf(listOf(message(role = "user"))))
+    }
+
+    @Test
+    fun `an unfinished reply is still running`() {
+        assertNull(scheduleCompletionOf(listOf(message(role = "user"), message(id = "msg-2", completed = null))))
+    }
+
+    @Test
+    fun `a finished reply completes the run`() {
+        val outcome = scheduleCompletionOf(listOf(message(role = "user"), message(id = "msg-2", completed = 42L)))
+
+        assertEquals(ScheduleCompletion.Completed, outcome)
+    }
+
+    @Test
+    fun `only the newest turn decides the outcome`() {
+        val messages =
+            listOf(
+                message(id = "msg-1", completed = 1L),
+                message(id = "msg-2", role = "user"),
+            )
+
+        assertNull(scheduleCompletionOf(messages))
+    }
+
+    @Test
+    fun `a failed reply fails the run and is announced`() {
+        val outcome =
+            scheduleCompletionOf(
+                listOf(message(id = "msg-1", error = error("ApiError", "Free promotion has ended"))),
+            )
+
+        assertEquals(ScheduleCompletion.Failed("Free promotion has ended", silent = false), outcome)
+    }
+
+    @Test
+    fun `a stopped reply fails the run quietly`() {
+        val outcome =
+            scheduleCompletionOf(
+                listOf(message(id = "msg-1", error = error("MessageAbortedError", "aborted"))),
+            )
+
+        assertEquals(ScheduleCompletion.Failed("aborted", silent = true), outcome)
+    }
+
+    @Test
+    fun `a failure without a message falls back to its name`() {
+        val outcome = scheduleCompletionOf(listOf(message(id = "msg-1", error = OpenCodeMessageError(name = "UnknownError"))))
+
+        assertEquals(ScheduleCompletion.Failed("UnknownError", silent = false), outcome)
+    }
+
+    private fun message(
+        id: String = "msg-1",
+        role: String = "assistant",
+        completed: Long? = null,
+        error: OpenCodeMessageError? = null,
+    ) = OpenCodeMessage(
+        info =
+            OpenCodeMessageInfo(
+                id = id,
+                sessionId = "ses_1",
+                role = role,
+                time = OpenCodeTime(created = 1, completed = completed),
+                error = error,
+            ),
+    )
+
+    private fun error(
+        name: String,
+        message: String,
+    ) = OpenCodeMessageError(name = name, data = mapOf("message" to JsonPrimitive(message)))
+}


### PR DESCRIPTION
## 背景

定期実行の履歴に出ていた 3 種類の症状のうち、アプリ側のバグを直します。

| 症状 | 原因 |
| --- | --- |
| `Scheduled run timed out`（失敗） | 完了判定が `session.idle` イベント頼み。SSE が切れる（Doze・ランタイム再起動）と idle を取り逃がし、実際には応答済みでも 30 分のタイムアウトで失敗扱いになる |
| `Runtime connection failed`（スキップ） | アラーム起床直後の health check が 1 回失敗しただけで実行そのものをスキップ |
| チャットに `OpenCode request failed (HTTP 400) … Expected a string starting with "ses", got "message" at ["sessionID"]` | セッション作成前にスキップされた実行は `sessionId` が空。それでも行全体がタップ可能で、空 ID のままチャットを開き `session//message` を要求していた |

`Model not found` / `Free promotion has ended` はプロバイダ側の事情（スケジュールに固定したモデルが提供終了）で、コードの問題ではありません。

## 変更内容

- **実行の完了判定を二重化** — イベントストリームに加えてトランスクリプトをポーリングし、先に結果を見たほうで実行を確定させる (`ScheduleExecutionService.pollForCompletion`)。判定はチャットと同じ「最新メッセージが完了済みの assistant 応答か」で、`scheduleCompletionOf` に切り出してユニットテストを追加。
- **途中で別メッセージが始まるケースの誤判定を防止** — 同じ完了メッセージが次の読み取りでも最新のままだったときだけ確定させる。
- **ストリーム切断は即失敗にしない** — ポーリングに引き継ぎ、タイムアウトしたときだけ切断理由を記録する。
- **接続を 3 回までリトライ** (`connectWithRetry`) — 起床直後にローカルランタイムの HTTP サーバがまだ受け付けていない／再接続直後のネットワーク、を 1 回の失敗でスキップしない。
- **セッションを持たない実行のチャットを開かない** — 行のタップを無効化し、`openSessionInChat` と `ChatViewModel.openSession` でも空 ID を弾く。

イベント通知（完了・エラー）の送出は `settle()` に集約したため、どちらの経路で確定しても通知は 1 回だけです。`completed` を持たないローカルランタイム（Claude Code / Antigravity）はこれまで通りイベントストリームだけで確定します。

## テスト

- 追加: `ScheduleRunOutcomeTest`（未応答／未完了／完了／エラー／中断／最新ターン優先の 8 ケース）
- このセッションの環境には Android SDK がないため Gradle ビルドは実行できていません。`:app:testDebugUnitTest` / `detekt` / `spotlessCheck` は CI での確認になります。

## 注意: レビュー gate は未通過です

このセッションでは `repo-reviewer` サブエージェント（`.opencode/agents/repo-reviewer.md`）を起動できないため、`pre-pr-review` スキルを実行できていません。レビュー結果を捏造しないため、承認マーカーはこの説明に入れていません（初版では説明文の中にマーカー文字列をそのまま引用してしまい、PR Review Gate が文面マッチで誤って緑になっていました。この編集で取り除いています）。

OpenCode 側のセッションで `pre-pr-review` を回し、`repo-reviewer` のレポートと承認マーカーをこの説明に貼り付けてください。
