### PR TITLE
Add settings to auto-archive inactive or excess chat sessions

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
@@ -28,6 +28,7 @@ import com.yugahashimoto.andcode.data.repository.ProviderCatalogCache
 import com.yugahashimoto.andcode.data.repository.PullRequestStatusRepository
 import com.yugahashimoto.andcode.data.repository.RuntimeActivityRepository
 import com.yugahashimoto.andcode.data.repository.RuntimeCatalogRepository
+import com.yugahashimoto.andcode.data.repository.SessionAutoArchiver
 import com.yugahashimoto.andcode.data.schedule.ScheduleRepository
 import com.yugahashimoto.andcode.data.settings.AppPreferencesRepository
 import com.yugahashimoto.andcode.di.appModule
@@ -430,6 +431,13 @@ class AndCodeApplication : Application() {
                 unreadStore = settings,
                 messages = AndroidRuntimeActivityMessages(this),
             )
+        SessionAutoArchiver(
+            registry = runtimeRegistry,
+            catalog = catalogRepository,
+            activeSessionIds = { activityRepository.state.value.activeSessionIds },
+            preferences = preferences.state,
+            scope = applicationScope,
+        ).start()
         // A chat or agent run in flight is real work happening on the runtime's proot process,
         // so it holds the device awake until the session settles - wired here rather than inside
         // the repository's own constructor, which has no reason to know about wake locks.

--- a/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/connection/SecureSettingsRepository.kt
@@ -442,6 +442,23 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
         get() = preferences.getStringSet(KEY_COLLAPSED_SIDEBAR_SECTIONS, emptySet()).orEmpty()
         set(value) = preferences.edit().putStringSet(KEY_COLLAPSED_SIDEBAR_SECTIONS, value).apply()
 
+    /** Off by default: archiving chats on the user's behalf is opt-in, never a surprise. */
+    var autoArchiveStaleEnabled: Boolean
+        get() = preferences.getBoolean(KEY_AUTO_ARCHIVE_STALE_ENABLED, false)
+        set(value) = preferences.edit().putBoolean(KEY_AUTO_ARCHIVE_STALE_ENABLED, value).apply()
+
+    var autoArchiveStaleDays: Int
+        get() = preferences.getInt(KEY_AUTO_ARCHIVE_STALE_DAYS, 30)
+        set(value) = preferences.edit().putInt(KEY_AUTO_ARCHIVE_STALE_DAYS, value).apply()
+
+    var autoArchiveMaxSessionsEnabled: Boolean
+        get() = preferences.getBoolean(KEY_AUTO_ARCHIVE_MAX_SESSIONS_ENABLED, false)
+        set(value) = preferences.edit().putBoolean(KEY_AUTO_ARCHIVE_MAX_SESSIONS_ENABLED, value).apply()
+
+    var autoArchiveMaxSessions: Int
+        get() = preferences.getInt(KEY_AUTO_ARCHIVE_MAX_SESSIONS, 50)
+        set(value) = preferences.edit().putInt(KEY_AUTO_ARCHIVE_MAX_SESSIONS, value).apply()
+
     companion object {
         fun readLanguage(context: Context): String =
             runCatching {
@@ -527,5 +544,9 @@ class SecureSettingsRepository(context: Context) : RuntimeConnectionStore, Unrea
         private const val KEY_LOCAL_RUNTIME_IDLE_STOP_ENABLED = "local_runtime_idle_stop_enabled"
         private const val KEY_LOCAL_RUNTIME_STOPPED_BY_USER = "local_runtime_stopped_by_user"
         private const val KEY_COLLAPSED_SIDEBAR_SECTIONS = "collapsed_sidebar_sections"
+        private const val KEY_AUTO_ARCHIVE_STALE_ENABLED = "auto_archive_stale_enabled"
+        private const val KEY_AUTO_ARCHIVE_STALE_DAYS = "auto_archive_stale_days"
+        private const val KEY_AUTO_ARCHIVE_MAX_SESSIONS_ENABLED = "auto_archive_max_sessions_enabled"
+        private const val KEY_AUTO_ARCHIVE_MAX_SESSIONS = "auto_archive_max_sessions"
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiver.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiver.kt
@@ -1,0 +1,81 @@
+package com.yugahashimoto.andcode.data.repository
+
+import com.yugahashimoto.andcode.data.settings.AppPreferences
+import com.yugahashimoto.andcode.runtime.RuntimeRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import java.util.concurrent.TimeUnit
+
+/**
+ * Keeps the chat drawer from growing without bound by archiving sessions that the user's settings
+ * say are no longer worth keeping active: ones untouched for a configured number of days, and/or
+ * the oldest ones once the active count passes a configured cap. Both rules are opt-in and off by
+ * default (see [AppPreferences.autoArchiveStaleEnabled] and [AppPreferences.autoArchiveMaxSessionsEnabled]).
+ */
+class SessionAutoArchiver(
+    private val registry: RuntimeRegistry,
+    private val catalog: RuntimeCatalogRepository,
+    private val activeSessionIds: () -> Set<String>,
+    private val preferences: StateFlow<AppPreferences>,
+    private val scope: CoroutineScope,
+) {
+    // Sessions an archive call was already issued for this process lifetime, so a session list that
+    // has not yet caught up with a just-issued archive is not resubmitted on every recomputation.
+    private val alreadyArchived = mutableSetOf<String>()
+
+    fun start() {
+        scope.launch {
+            combine(catalog.allSessions, preferences) { sessions, prefs -> sessions to prefs }
+                .collect { (sessions, prefs) -> maybeArchive(sessions, prefs) }
+        }
+    }
+
+    private suspend fun maybeArchive(
+        sessions: List<RuntimeSessionRef>,
+        prefs: AppPreferences,
+    ) {
+        if (!prefs.autoArchiveStaleEnabled && !prefs.autoArchiveMaxSessionsEnabled) return
+
+        // Never archive a chat that is actively running or that an archive call was already sent
+        // for - the latter avoids resubmitting the same id every time the list recomputes before the
+        // runtime's own listSessions() catches up and drops it.
+        val active = activeSessionIds()
+        val candidates = sessions.filterNot { it.session.id in active || it.session.id in alreadyArchived }
+
+        val stale =
+            if (prefs.autoArchiveStaleEnabled) {
+                val cutoff = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(prefs.autoArchiveStaleDays.toLong())
+                candidates.filter { updatedAt(it) < cutoff }
+            } else {
+                emptyList()
+            }
+
+        val overflow =
+            if (prefs.autoArchiveMaxSessionsEnabled) {
+                candidates
+                    .sortedByDescending(::updatedAt)
+                    .drop(prefs.autoArchiveMaxSessions.coerceAtLeast(0))
+            } else {
+                emptyList()
+            }
+
+        val toArchive = (stale + overflow).distinctBy { it.session.id }
+        if (toArchive.isEmpty()) return
+
+        toArchive.forEach { alreadyArchived += it.session.id }
+        val targets = registry.targets.value
+        supervisorScope {
+            toArchive
+                .mapNotNull { ref -> targets.firstOrNull { it.id == ref.runtimeId }?.let { it to ref.session.id } }
+                .map { (target, sessionId) -> async { runCatching { target.archiveSession(sessionId) } } }
+                .forEach { it.await() }
+        }
+        catalog.refreshAllSessions()
+    }
+
+    private fun updatedAt(ref: RuntimeSessionRef): Long = ref.session.time.updated ?: ref.session.time.created
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiver.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiver.kt
@@ -56,9 +56,11 @@ class SessionAutoArchiver(
 
         val overflow =
             if (prefs.autoArchiveMaxSessionsEnabled) {
-                candidates
-                    .sortedByDescending(::updatedAt)
-                    .drop(prefs.autoArchiveMaxSessions.coerceAtLeast(0))
+                // A running session still occupies one of the allowed slots - it is just never the
+                // one archived to make room, so the cap is honored by keeping fewer of the
+                // archivable candidates rather than by ignoring active sessions altogether.
+                val toKeep = (prefs.autoArchiveMaxSessions - active.size).coerceAtLeast(0)
+                candidates.sortedByDescending(::updatedAt).drop(toKeep)
             } else {
                 emptyList()
             }
@@ -66,14 +68,20 @@ class SessionAutoArchiver(
         val toArchive = (stale + overflow).distinctBy { it.session.id }
         if (toArchive.isEmpty()) return
 
-        toArchive.forEach { alreadyArchived += it.session.id }
         val targets = registry.targets.value
-        supervisorScope {
-            toArchive
-                .mapNotNull { ref -> targets.firstOrNull { it.id == ref.runtimeId }?.let { it to ref.session.id } }
-                .map { (target, sessionId) -> async { runCatching { target.archiveSession(sessionId) } } }
-                .forEach { it.await() }
-        }
+        val archivedIds =
+            supervisorScope {
+                toArchive
+                    .mapNotNull { ref -> targets.firstOrNull { it.id == ref.runtimeId }?.let { it to ref.session.id } }
+                    .map { (target, sessionId) -> async { runCatching { target.archiveSession(sessionId) }.map { sessionId } } }
+                    .mapNotNull { it.await().getOrNull() }
+            }
+        if (archivedIds.isEmpty()) return
+
+        // Only mark ids that actually got archived: a missing target or a failed call must leave
+        // the session eligible again on the next recomputation instead of being silently dropped
+        // for the rest of the process lifetime.
+        alreadyArchived += archivedIds
         catalog.refreshAllSessions()
     }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/data/settings/AppPreferencesRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/settings/AppPreferencesRepository.kt
@@ -49,6 +49,10 @@ data class AppPreferences(
     val liveTranscriptEnabled: Boolean = false,
     val analyticsEnabled: Boolean = false,
     val localRuntimeIdleStopEnabled: Boolean = true,
+    val autoArchiveStaleEnabled: Boolean = false,
+    val autoArchiveStaleDays: Int = 30,
+    val autoArchiveMaxSessionsEnabled: Boolean = false,
+    val autoArchiveMaxSessions: Int = 50,
 )
 
 class AppPreferencesRepository(
@@ -95,6 +99,10 @@ class AppPreferencesRepository(
                 liveTranscriptEnabled = settings.liveTranscriptEnabled,
                 analyticsEnabled = settings.analyticsEnabled,
                 localRuntimeIdleStopEnabled = settings.localRuntimeIdleStopEnabled,
+                autoArchiveStaleEnabled = settings.autoArchiveStaleEnabled,
+                autoArchiveStaleDays = settings.autoArchiveStaleDays,
+                autoArchiveMaxSessionsEnabled = settings.autoArchiveMaxSessionsEnabled,
+                autoArchiveMaxSessions = settings.autoArchiveMaxSessions,
             ),
         )
     val state: StateFlow<AppPreferences> = mutableState.asStateFlow()
@@ -351,5 +359,27 @@ class AppPreferencesRepository(
     fun setLocalRuntimeIdleStopEnabled(enabled: Boolean) {
         settings.localRuntimeIdleStopEnabled = enabled
         mutableState.update { it.copy(localRuntimeIdleStopEnabled = enabled) }
+    }
+
+    fun setAutoArchiveStaleEnabled(enabled: Boolean) {
+        settings.autoArchiveStaleEnabled = enabled
+        mutableState.update { it.copy(autoArchiveStaleEnabled = enabled) }
+    }
+
+    fun setAutoArchiveStaleDays(days: Int) {
+        val clamped = days.coerceIn(1, 365)
+        settings.autoArchiveStaleDays = clamped
+        mutableState.update { it.copy(autoArchiveStaleDays = clamped) }
+    }
+
+    fun setAutoArchiveMaxSessionsEnabled(enabled: Boolean) {
+        settings.autoArchiveMaxSessionsEnabled = enabled
+        mutableState.update { it.copy(autoArchiveMaxSessionsEnabled = enabled) }
+    }
+
+    fun setAutoArchiveMaxSessions(count: Int) {
+        val clamped = count.coerceIn(5, 1000)
+        settings.autoArchiveMaxSessions = clamped
+        mutableState.update { it.copy(autoArchiveMaxSessions = clamped) }
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/data/settings/AppPreferencesRepository.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/data/settings/AppPreferencesRepository.kt
@@ -367,7 +367,8 @@ class AppPreferencesRepository(
     }
 
     fun setAutoArchiveStaleDays(days: Int) {
-        val clamped = days.coerceIn(1, 365)
+        // Matches the slider range in SettingsScreenV2's dialog - keep the two in sync.
+        val clamped = days.coerceIn(1, 180)
         settings.autoArchiveStaleDays = clamped
         mutableState.update { it.copy(autoArchiveStaleDays = clamped) }
     }
@@ -378,7 +379,8 @@ class AppPreferencesRepository(
     }
 
     fun setAutoArchiveMaxSessions(count: Int) {
-        val clamped = count.coerceIn(5, 1000)
+        // Matches the slider range in SettingsScreenV2's dialog - keep the two in sync.
+        val clamped = count.coerceIn(5, 500)
         settings.autoArchiveMaxSessions = clamped
         mutableState.update { it.copy(autoArchiveMaxSessions = clamped) }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -270,7 +271,7 @@ fun SettingsScreenV2(
                 SettingsRow(
                     icon = Icons.Default.Chat,
                     title = stringResource(R.string.auto_archive_stale_days_row),
-                    value = stringResource(R.string.auto_archive_stale_days_value, autoArchiveStaleDays),
+                    value = pluralStringResource(R.plurals.auto_archive_stale_days_value, autoArchiveStaleDays, autoArchiveStaleDays),
                     onClick = { showAutoArchiveStaleDaysDialog = true },
                 )
                 SettingsDivider()
@@ -604,7 +605,7 @@ fun SettingsScreenV2(
             title = { Text(stringResource(R.string.auto_archive_stale_days_dialog_title)) },
             text = {
                 Column {
-                    Text(stringResource(R.string.auto_archive_stale_days_value, sliderValue.toInt()))
+                    Text(pluralStringResource(R.plurals.auto_archive_stale_days_value, sliderValue.toInt(), sliderValue.toInt()))
                     Slider(
                         value = sliderValue,
                         onValueChange = { sliderValue = it },

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/SettingsScreenV2.kt
@@ -106,6 +106,14 @@ fun SettingsScreenV2(
     onSendBehaviorChange: (String) -> Unit = {},
     enterToSend: Boolean = false,
     onEnterToSendChange: (Boolean) -> Unit = {},
+    autoArchiveStaleEnabled: Boolean = false,
+    onAutoArchiveStaleEnabledChange: (Boolean) -> Unit = {},
+    autoArchiveStaleDays: Int = 30,
+    onAutoArchiveStaleDaysChange: (Int) -> Unit = {},
+    autoArchiveMaxSessionsEnabled: Boolean = false,
+    onAutoArchiveMaxSessionsEnabledChange: (Boolean) -> Unit = {},
+    autoArchiveMaxSessions: Int = 50,
+    onAutoArchiveMaxSessionsChange: (Int) -> Unit = {},
     wakeWordEnabled: Boolean = false,
 ) {
     var showThemeDialog by remember { mutableStateOf(false) }
@@ -113,6 +121,8 @@ fun SettingsScreenV2(
     var showUiFontDialog by remember { mutableStateOf(false) }
     var showCodeFontDialog by remember { mutableStateOf(false) }
     var showSyntaxThemeDialog by remember { mutableStateOf(false) }
+    var showAutoArchiveStaleDaysDialog by remember { mutableStateOf(false) }
+    var showAutoArchiveMaxSessionsDialog by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         CenterAlignedTopAppBar(
@@ -245,6 +255,38 @@ fun SettingsScreenV2(
                     title = stringResource(R.string.enter_to_send_row),
                     checked = enterToSend,
                     onCheckedChange = onEnterToSendChange,
+                )
+            }
+
+            SettingsSection(title = stringResource(R.string.section_sessions_settings)) {
+                SettingsToggleRow(
+                    icon = Icons.Default.Chat,
+                    title = stringResource(R.string.auto_archive_stale_row),
+                    subtitle = stringResource(R.string.auto_archive_stale_row_description),
+                    checked = autoArchiveStaleEnabled,
+                    onCheckedChange = onAutoArchiveStaleEnabledChange,
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Default.Chat,
+                    title = stringResource(R.string.auto_archive_stale_days_row),
+                    value = stringResource(R.string.auto_archive_stale_days_value, autoArchiveStaleDays),
+                    onClick = { showAutoArchiveStaleDaysDialog = true },
+                )
+                SettingsDivider()
+                SettingsToggleRow(
+                    icon = Icons.Default.Chat,
+                    title = stringResource(R.string.auto_archive_max_sessions_row),
+                    subtitle = stringResource(R.string.auto_archive_max_sessions_row_description),
+                    checked = autoArchiveMaxSessionsEnabled,
+                    onCheckedChange = onAutoArchiveMaxSessionsEnabledChange,
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Default.Chat,
+                    title = stringResource(R.string.auto_archive_max_sessions_value_row),
+                    value = autoArchiveMaxSessions.toString(),
+                    onClick = { showAutoArchiveMaxSessionsDialog = true },
                 )
             }
 
@@ -550,6 +592,70 @@ fun SettingsScreenV2(
             confirmButton = {
                 TextButton(onClick = { showSyntaxThemeDialog = false }) {
                     Text(stringResource(R.string.close_description))
+                }
+            },
+        )
+    }
+
+    if (showAutoArchiveStaleDaysDialog) {
+        var sliderValue by remember { mutableFloatStateOf(autoArchiveStaleDays.toFloat()) }
+        AlertDialog(
+            onDismissRequest = { showAutoArchiveStaleDaysDialog = false },
+            title = { Text(stringResource(R.string.auto_archive_stale_days_dialog_title)) },
+            text = {
+                Column {
+                    Text(stringResource(R.string.auto_archive_stale_days_value, sliderValue.toInt()))
+                    Slider(
+                        value = sliderValue,
+                        onValueChange = { sliderValue = it },
+                        valueRange = 1f..180f,
+                        steps = 178,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    onAutoArchiveStaleDaysChange(sliderValue.toInt())
+                    showAutoArchiveStaleDaysDialog = false
+                }) {
+                    Text(stringResource(R.string.close_description))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAutoArchiveStaleDaysDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+
+    if (showAutoArchiveMaxSessionsDialog) {
+        var sliderValue by remember { mutableFloatStateOf(autoArchiveMaxSessions.toFloat()) }
+        AlertDialog(
+            onDismissRequest = { showAutoArchiveMaxSessionsDialog = false },
+            title = { Text(stringResource(R.string.auto_archive_max_sessions_dialog_title)) },
+            text = {
+                Column {
+                    Text(sliderValue.toInt().toString())
+                    Slider(
+                        value = sliderValue,
+                        onValueChange = { sliderValue = it },
+                        valueRange = 5f..500f,
+                        steps = 98,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    onAutoArchiveMaxSessionsChange(sliderValue.toInt())
+                    showAutoArchiveMaxSessionsDialog = false
+                }) {
+                    Text(stringResource(R.string.close_description))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAutoArchiveMaxSessionsDialog = false }) {
+                    Text(stringResource(R.string.cancel))
                 }
             },
         )

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -107,6 +107,14 @@ fun NavGraphBuilder.settingsNavGraph(
             onSendBehaviorChange = { appPreferences.setSendBehavior(it) },
             enterToSend = preferences().enterToSend,
             onEnterToSendChange = { appPreferences.setEnterToSend(it) },
+            autoArchiveStaleEnabled = preferences().autoArchiveStaleEnabled,
+            onAutoArchiveStaleEnabledChange = appPreferences::setAutoArchiveStaleEnabled,
+            autoArchiveStaleDays = preferences().autoArchiveStaleDays,
+            onAutoArchiveStaleDaysChange = appPreferences::setAutoArchiveStaleDays,
+            autoArchiveMaxSessionsEnabled = preferences().autoArchiveMaxSessionsEnabled,
+            onAutoArchiveMaxSessionsEnabledChange = appPreferences::setAutoArchiveMaxSessionsEnabled,
+            autoArchiveMaxSessions = preferences().autoArchiveMaxSessions,
+            onAutoArchiveMaxSessionsChange = appPreferences::setAutoArchiveMaxSessions,
             wakeWordEnabled = settingsState.wakeWordEnabled,
         )
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -583,7 +583,14 @@
     <string name="auto_archive_stale_row">أرشفة المحادثات غير النشطة تلقائيًا</string>
     <string name="auto_archive_stale_row_description">تؤرشف المحادثات التي لم يتم تحديثها منذ فترة</string>
     <string name="auto_archive_stale_days_row">الأرشفة بعد</string>
-    <string name="auto_archive_stale_days_value">%1$d يوم</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="zero">%1$d يوم</item>
+        <item quantity="one">يوم واحد</item>
+        <item quantity="two">يومان</item>
+        <item quantity="few">%1$d أيام</item>
+        <item quantity="many">%1$d يومًا</item>
+        <item quantity="other">%1$d يوم</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">الأرشفة بعد (أيام)</string>
     <string name="auto_archive_max_sessions_row">تحديد عدد المحادثات النشطة</string>
     <string name="auto_archive_max_sessions_row_description">تؤرشف أقدم المحادثات عند تجاوز العدد النشط هذا الحد</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -579,6 +579,17 @@
     <string name="send_behavior_queue">قائمة انتظار</string>
     <string name="enter_to_send_row">الإدخال يرسل الرسالة</string>
 
+    <string name="section_sessions_settings">الجلسات</string>
+    <string name="auto_archive_stale_row">أرشفة المحادثات غير النشطة تلقائيًا</string>
+    <string name="auto_archive_stale_row_description">تؤرشف المحادثات التي لم يتم تحديثها منذ فترة</string>
+    <string name="auto_archive_stale_days_row">الأرشفة بعد</string>
+    <string name="auto_archive_stale_days_value">%1$d يوم</string>
+    <string name="auto_archive_stale_days_dialog_title">الأرشفة بعد (أيام)</string>
+    <string name="auto_archive_max_sessions_row">تحديد عدد المحادثات النشطة</string>
+    <string name="auto_archive_max_sessions_row_description">تؤرشف أقدم المحادثات عند تجاوز العدد النشط هذا الحد</string>
+    <string name="auto_archive_max_sessions_value_row">الحد الأقصى للمحادثات النشطة</string>
+    <string name="auto_archive_max_sessions_dialog_title">الحد الأقصى للمحادثات النشطة</string>
+
     <string name="drawer_archive_session">أرشفة</string>
     <string name="drawer_selected_count">%1$d محدد</string>
     <string name="drawer_delete_selected_body">سيتم حذف %1$d جلسة بشكل دائم.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -580,7 +580,11 @@
     <string name="auto_archive_stale_row">Archivar chats inactivos automáticamente</string>
     <string name="auto_archive_stale_row_description">Archiva los chats que no se han actualizado en un tiempo</string>
     <string name="auto_archive_stale_days_row">Archivar después de</string>
-    <string name="auto_archive_stale_days_value">%1$d días</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="one">%1$d día</item>
+        <item quantity="many">%1$d días</item>
+        <item quantity="other">%1$d días</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">Archivar después de (días)</string>
     <string name="auto_archive_max_sessions_row">Limitar chats activos</string>
     <string name="auto_archive_max_sessions_row_description">Archiva los chats más antiguos cuando el número activo supera este límite</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -576,6 +576,17 @@
     <string name="send_behavior_queue">Cola</string>
     <string name="enter_to_send_row">Enter envía el mensaje</string>
 
+    <string name="section_sessions_settings">Sesiones</string>
+    <string name="auto_archive_stale_row">Archivar chats inactivos automáticamente</string>
+    <string name="auto_archive_stale_row_description">Archiva los chats que no se han actualizado en un tiempo</string>
+    <string name="auto_archive_stale_days_row">Archivar después de</string>
+    <string name="auto_archive_stale_days_value">%1$d días</string>
+    <string name="auto_archive_stale_days_dialog_title">Archivar después de (días)</string>
+    <string name="auto_archive_max_sessions_row">Limitar chats activos</string>
+    <string name="auto_archive_max_sessions_row_description">Archiva los chats más antiguos cuando el número activo supera este límite</string>
+    <string name="auto_archive_max_sessions_value_row">Máx. de chats activos</string>
+    <string name="auto_archive_max_sessions_dialog_title">Máx. de chats activos</string>
+
     <string name="drawer_archive_session">Archivar</string>
     <string name="drawer_selected_count">%1$d seleccionado(s)</string>
     <string name="drawer_delete_selected_body">%1$d sesiones se eliminarán permanentemente.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -576,6 +576,17 @@
     <string name="send_behavior_queue">File d\'attente</string>
     <string name="enter_to_send_row">Entrée envoie le message</string>
 
+    <string name="section_sessions_settings">Sessions</string>
+    <string name="auto_archive_stale_row">Archiver automatiquement les discussions inactives</string>
+    <string name="auto_archive_stale_row_description">Archive les discussions qui n\'ont pas été mises à jour depuis un moment</string>
+    <string name="auto_archive_stale_days_row">Archiver après</string>
+    <string name="auto_archive_stale_days_value">%1$d jours</string>
+    <string name="auto_archive_stale_days_dialog_title">Archiver après (jours)</string>
+    <string name="auto_archive_max_sessions_row">Limiter les discussions actives</string>
+    <string name="auto_archive_max_sessions_row_description">Archive les discussions les plus anciennes lorsque le nombre actif dépasse cette limite</string>
+    <string name="auto_archive_max_sessions_value_row">Nb max. de discussions actives</string>
+    <string name="auto_archive_max_sessions_dialog_title">Nb max. de discussions actives</string>
+
     <string name="drawer_archive_session">Archiver</string>
     <string name="drawer_selected_count">%1$d sélectionné(s)</string>
     <string name="drawer_delete_selected_body">%1$d sessions seront supprimées définitivement.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -580,7 +580,11 @@
     <string name="auto_archive_stale_row">Archiver automatiquement les discussions inactives</string>
     <string name="auto_archive_stale_row_description">Archive les discussions qui n\'ont pas été mises à jour depuis un moment</string>
     <string name="auto_archive_stale_days_row">Archiver après</string>
-    <string name="auto_archive_stale_days_value">%1$d jours</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="one">%1$d jour</item>
+        <item quantity="many">%1$d jours</item>
+        <item quantity="other">%1$d jours</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">Archiver après (jours)</string>
     <string name="auto_archive_max_sessions_row">Limiter les discussions actives</string>
     <string name="auto_archive_max_sessions_row_description">Archive les discussions les plus anciennes lorsque le nombre actif dépasse cette limite</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -586,6 +586,17 @@
     <string name="send_behavior_queue">キュー</string>
     <string name="enter_to_send_row">Enter で送信</string>
 
+    <string name="section_sessions_settings">セッション</string>
+    <string name="auto_archive_stale_row">未更新のチャットを自動アーカイブ</string>
+    <string name="auto_archive_stale_row_description">しばらく更新されていないチャットを自動的にアーカイブします</string>
+    <string name="auto_archive_stale_days_row">アーカイブまでの日数</string>
+    <string name="auto_archive_stale_days_value">%1$d 日</string>
+    <string name="auto_archive_stale_days_dialog_title">アーカイブまでの日数</string>
+    <string name="auto_archive_max_sessions_row">アクティブなチャット数を制限</string>
+    <string name="auto_archive_max_sessions_row_description">アクティブなチャット数がこの上限を超えると、古いものから自動的にアーカイブします</string>
+    <string name="auto_archive_max_sessions_value_row">最大アクティブチャット数</string>
+    <string name="auto_archive_max_sessions_dialog_title">最大アクティブチャット数</string>
+
     <!-- Drawer session actions -->
     <string name="drawer_archive_session">アーカイブ</string>
     <string name="drawer_selected_count">%1$d件選択中</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -590,7 +590,9 @@
     <string name="auto_archive_stale_row">未更新のチャットを自動アーカイブ</string>
     <string name="auto_archive_stale_row_description">しばらく更新されていないチャットを自動的にアーカイブします</string>
     <string name="auto_archive_stale_days_row">アーカイブまでの日数</string>
-    <string name="auto_archive_stale_days_value">%1$d 日</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="other">%1$d 日</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">アーカイブまでの日数</string>
     <string name="auto_archive_max_sessions_row">アクティブなチャット数を制限</string>
     <string name="auto_archive_max_sessions_row_description">アクティブなチャット数がこの上限を超えると、古いものから自動的にアーカイブします</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -576,6 +576,17 @@
     <string name="send_behavior_queue">Fila</string>
     <string name="enter_to_send_row">Enter envia a mensagem</string>
 
+    <string name="section_sessions_settings">Sessões</string>
+    <string name="auto_archive_stale_row">Arquivar chats inativos automaticamente</string>
+    <string name="auto_archive_stale_row_description">Arquiva chats que não são atualizados há algum tempo</string>
+    <string name="auto_archive_stale_days_row">Arquivar após</string>
+    <string name="auto_archive_stale_days_value">%1$d dias</string>
+    <string name="auto_archive_stale_days_dialog_title">Arquivar após (dias)</string>
+    <string name="auto_archive_max_sessions_row">Limitar chats ativos</string>
+    <string name="auto_archive_max_sessions_row_description">Arquiva os chats mais antigos quando o número de ativos ultrapassa esse limite</string>
+    <string name="auto_archive_max_sessions_value_row">Máx. de chats ativos</string>
+    <string name="auto_archive_max_sessions_dialog_title">Máx. de chats ativos</string>
+
     <string name="drawer_archive_session">Arquivar</string>
     <string name="drawer_selected_count">%1$d selecionado(s)</string>
     <string name="drawer_delete_selected_body">%1$d sessões serão permanentemente excluídas.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -580,7 +580,11 @@
     <string name="auto_archive_stale_row">Arquivar chats inativos automaticamente</string>
     <string name="auto_archive_stale_row_description">Arquiva chats que não são atualizados há algum tempo</string>
     <string name="auto_archive_stale_days_row">Arquivar após</string>
-    <string name="auto_archive_stale_days_value">%1$d dias</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="one">%1$d dia</item>
+        <item quantity="many">%1$d dias</item>
+        <item quantity="other">%1$d dias</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">Arquivar após (dias)</string>
     <string name="auto_archive_max_sessions_row">Limitar chats ativos</string>
     <string name="auto_archive_max_sessions_row_description">Arquiva os chats mais antigos quando o número de ativos ultrapassa esse limite</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -581,7 +581,12 @@
     <string name="auto_archive_stale_row">Автоархивация неактивных чатов</string>
     <string name="auto_archive_stale_row_description">Архивирует чаты, которые давно не обновлялись</string>
     <string name="auto_archive_stale_days_row">Архивировать через</string>
-    <string name="auto_archive_stale_days_value">%1$d дн.</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="one">%1$d день</item>
+        <item quantity="few">%1$d дня</item>
+        <item quantity="many">%1$d дней</item>
+        <item quantity="other">%1$d дня</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">Архивировать через (дней)</string>
     <string name="auto_archive_max_sessions_row">Ограничить число активных чатов</string>
     <string name="auto_archive_max_sessions_row_description">Архивирует самые старые чаты, когда их число превышает этот лимит</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -577,6 +577,17 @@
     <string name="send_behavior_queue">В очередь</string>
     <string name="enter_to_send_row">Enter отправляет сообщение</string>
 
+    <string name="section_sessions_settings">Сеансы</string>
+    <string name="auto_archive_stale_row">Автоархивация неактивных чатов</string>
+    <string name="auto_archive_stale_row_description">Архивирует чаты, которые давно не обновлялись</string>
+    <string name="auto_archive_stale_days_row">Архивировать через</string>
+    <string name="auto_archive_stale_days_value">%1$d дн.</string>
+    <string name="auto_archive_stale_days_dialog_title">Архивировать через (дней)</string>
+    <string name="auto_archive_max_sessions_row">Ограничить число активных чатов</string>
+    <string name="auto_archive_max_sessions_row_description">Архивирует самые старые чаты, когда их число превышает этот лимит</string>
+    <string name="auto_archive_max_sessions_value_row">Макс. число активных чатов</string>
+    <string name="auto_archive_max_sessions_dialog_title">Макс. число активных чатов</string>
+
     <string name="drawer_archive_session">Архивировать</string>
     <string name="drawer_selected_count">Выбрано: %1$d</string>
     <string name="drawer_delete_selected_body">%1$d сеансов будет удалено безвозвратно.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -574,6 +574,17 @@
     <string name="send_behavior_queue">排队</string>
     <string name="enter_to_send_row">回车键发送消息</string>
 
+    <string name="section_sessions_settings">会话</string>
+    <string name="auto_archive_stale_row">自动归档不活跃的聊天</string>
+    <string name="auto_archive_stale_row_description">自动归档长时间未更新的聊天</string>
+    <string name="auto_archive_stale_days_row">归档时限</string>
+    <string name="auto_archive_stale_days_value">%1$d 天</string>
+    <string name="auto_archive_stale_days_dialog_title">归档时限（天）</string>
+    <string name="auto_archive_max_sessions_row">限制活跃聊天数量</string>
+    <string name="auto_archive_max_sessions_row_description">活跃聊天数量超过此上限后，将自动归档最旧的聊天</string>
+    <string name="auto_archive_max_sessions_value_row">最大活跃聊天数</string>
+    <string name="auto_archive_max_sessions_dialog_title">最大活跃聊天数</string>
+
     <string name="drawer_archive_session">归档</string>
     <string name="drawer_selected_count">已选 %1$d 项</string>
     <string name="drawer_delete_selected_body">%1$d 个会话将被永久删除。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -578,7 +578,9 @@
     <string name="auto_archive_stale_row">自动归档不活跃的聊天</string>
     <string name="auto_archive_stale_row_description">自动归档长时间未更新的聊天</string>
     <string name="auto_archive_stale_days_row">归档时限</string>
-    <string name="auto_archive_stale_days_value">%1$d 天</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="other">%1$d 天</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">归档时限（天）</string>
     <string name="auto_archive_max_sessions_row">限制活跃聊天数量</string>
     <string name="auto_archive_max_sessions_row_description">活跃聊天数量超过此上限后，将自动归档最旧的聊天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -598,6 +598,17 @@
     <string name="send_behavior_queue">Queue</string>
     <string name="enter_to_send_row">Enter sends message</string>
 
+    <string name="section_sessions_settings">Sessions</string>
+    <string name="auto_archive_stale_row">Auto-archive inactive chats</string>
+    <string name="auto_archive_stale_row_description">Archives chats that haven\'t been updated in a while</string>
+    <string name="auto_archive_stale_days_row">Archive after</string>
+    <string name="auto_archive_stale_days_value">%1$d days</string>
+    <string name="auto_archive_stale_days_dialog_title">Archive after (days)</string>
+    <string name="auto_archive_max_sessions_row">Limit active chats</string>
+    <string name="auto_archive_max_sessions_row_description">Archives your oldest chats once the active count passes this limit</string>
+    <string name="auto_archive_max_sessions_value_row">Max active chats</string>
+    <string name="auto_archive_max_sessions_dialog_title">Max active chats</string>
+
     <!-- Drawer session actions -->
     <string name="drawer_archive_session">Archive</string>
     <string name="drawer_selected_count">%1$d selected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -602,7 +602,10 @@
     <string name="auto_archive_stale_row">Auto-archive inactive chats</string>
     <string name="auto_archive_stale_row_description">Archives chats that haven\'t been updated in a while</string>
     <string name="auto_archive_stale_days_row">Archive after</string>
-    <string name="auto_archive_stale_days_value">%1$d days</string>
+    <plurals name="auto_archive_stale_days_value">
+        <item quantity="one">%1$d day</item>
+        <item quantity="other">%1$d days</item>
+    </plurals>
     <string name="auto_archive_stale_days_dialog_title">Archive after (days)</string>
     <string name="auto_archive_max_sessions_row">Limit active chats</string>
     <string name="auto_archive_max_sessions_row_description">Archives your oldest chats once the active count passes this limit</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiverTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiverTest.kt
@@ -1,0 +1,227 @@
+package com.yugahashimoto.andcode.data.repository
+
+import com.yugahashimoto.andcode.core.api.OpenCodeAgent
+import com.yugahashimoto.andcode.core.api.OpenCodeEvent
+import com.yugahashimoto.andcode.core.api.OpenCodeHealth
+import com.yugahashimoto.andcode.core.api.OpenCodeMessage
+import com.yugahashimoto.andcode.core.api.OpenCodeSession
+import com.yugahashimoto.andcode.core.api.OpenCodeTime
+import com.yugahashimoto.andcode.core.api.PromptRequest
+import com.yugahashimoto.andcode.core.api.ProviderCatalog
+import com.yugahashimoto.andcode.data.connection.ConnectionProfile
+import com.yugahashimoto.andcode.data.settings.AppPreferences
+import com.yugahashimoto.andcode.runtime.BackendKind
+import com.yugahashimoto.andcode.runtime.PermissionResponse
+import com.yugahashimoto.andcode.runtime.RuntimeConnectionStore
+import com.yugahashimoto.andcode.runtime.RuntimeRegistry
+import com.yugahashimoto.andcode.runtime.RuntimeState
+import com.yugahashimoto.andcode.runtime.RuntimeTarget
+import com.yugahashimoto.andcode.runtime.RuntimeType
+import com.yugahashimoto.andcode.runtime.WorkspaceRef
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionAutoArchiverTest {
+    @Test
+    fun `does nothing while both rules are disabled`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget("mac", sessions = listOf(session("old", updatedDaysAgo = 90)))
+            val registry = registry(target)
+            val catalog = RuntimeCatalogRepository(registry, TestScope(dispatcher))
+            val preferences = fakePreferences()
+            val archiver =
+                SessionAutoArchiver(registry, catalog, activeSessionIds = { emptySet() }, preferences, TestScope(dispatcher))
+
+            archiver.start()
+            advanceUntilIdle()
+
+            assertTrue(target.archivedIds.isEmpty())
+        }
+
+    @Test
+    fun `archives sessions untouched past the configured number of days`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target =
+                FakeTarget(
+                    "mac",
+                    sessions =
+                        listOf(
+                            session("old", updatedDaysAgo = 45),
+                            session("fresh", updatedDaysAgo = 1),
+                        ),
+                )
+            val registry = registry(target)
+            val catalog = RuntimeCatalogRepository(registry, TestScope(dispatcher))
+            val preferences = fakePreferences(autoArchiveStaleEnabled = true, autoArchiveStaleDays = 30)
+            val archiver =
+                SessionAutoArchiver(registry, catalog, activeSessionIds = { emptySet() }, preferences, TestScope(dispatcher))
+
+            archiver.start()
+            advanceUntilIdle()
+
+            assertEquals(listOf("old"), target.archivedIds)
+        }
+
+    @Test
+    fun `archives the oldest sessions once the active count passes the configured cap`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target =
+                FakeTarget(
+                    "mac",
+                    sessions =
+                        listOf(
+                            session("newest", updatedDaysAgo = 1),
+                            session("middle", updatedDaysAgo = 2),
+                            session("oldest", updatedDaysAgo = 3),
+                        ),
+                )
+            val registry = registry(target)
+            val catalog = RuntimeCatalogRepository(registry, TestScope(dispatcher))
+            val preferences = fakePreferences(autoArchiveMaxSessionsEnabled = true, autoArchiveMaxSessions = 2)
+            val archiver =
+                SessionAutoArchiver(registry, catalog, activeSessionIds = { emptySet() }, preferences, TestScope(dispatcher))
+
+            archiver.start()
+            advanceUntilIdle()
+
+            assertEquals(listOf("oldest"), target.archivedIds)
+        }
+
+    @Test
+    fun `never archives a session that is actively running`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget("mac", sessions = listOf(session("old", updatedDaysAgo = 90)))
+            val registry = registry(target)
+            val catalog = RuntimeCatalogRepository(registry, TestScope(dispatcher))
+            val preferences = fakePreferences(autoArchiveStaleEnabled = true, autoArchiveStaleDays = 30)
+            val archiver =
+                SessionAutoArchiver(registry, catalog, activeSessionIds = { setOf("old") }, preferences, TestScope(dispatcher))
+
+            archiver.start()
+            advanceUntilIdle()
+
+            assertTrue(target.archivedIds.isEmpty())
+        }
+
+    private fun session(
+        id: String,
+        updatedDaysAgo: Long,
+    ) = OpenCodeSession(
+        id = id,
+        title = id,
+        time =
+            OpenCodeTime(
+                created = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(updatedDaysAgo),
+                updated = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(updatedDaysAgo),
+            ),
+    )
+
+    private fun registry(target: RuntimeTarget) =
+        RuntimeRegistry(
+            store = FakeStore(selectedRuntimeId = target.id),
+            localTarget = target,
+            remoteFactory = { error("unused") },
+        )
+
+    private fun fakePreferences(
+        autoArchiveStaleEnabled: Boolean = false,
+        autoArchiveStaleDays: Int = 30,
+        autoArchiveMaxSessionsEnabled: Boolean = false,
+        autoArchiveMaxSessions: Int = 50,
+    ): MutableStateFlow<AppPreferences> =
+        MutableStateFlow(
+            AppPreferences(
+                autoArchiveStaleEnabled = autoArchiveStaleEnabled,
+                autoArchiveStaleDays = autoArchiveStaleDays,
+                autoArchiveMaxSessionsEnabled = autoArchiveMaxSessionsEnabled,
+                autoArchiveMaxSessions = autoArchiveMaxSessions,
+            ),
+        )
+
+    private class FakeStore(
+        profiles: List<ConnectionProfile> = emptyList(),
+        override var selectedRuntimeId: String? = null,
+    ) : RuntimeConnectionStore {
+        private val values = profiles.toMutableList()
+
+        override fun connections(): List<ConnectionProfile> = values.toList()
+
+        override fun upsertConnection(profile: ConnectionProfile) {
+            values.removeAll { it.id == profile.id }
+            values += profile
+        }
+
+        override fun deleteConnection(id: String) {
+            values.removeAll { it.id == id }
+        }
+    }
+
+    private class FakeTarget(
+        override val id: String,
+        private val sessions: List<OpenCodeSession>,
+    ) : RuntimeTarget {
+        override val type: RuntimeType = RuntimeType.LOCAL
+        override val displayName: String = id
+        override val kind: BackendKind = BackendKind.LOCAL
+        override val state = MutableStateFlow<RuntimeState>(RuntimeState.Disconnected)
+
+        val archivedIds = mutableListOf<String>()
+
+        override suspend fun connect(): Result<OpenCodeHealth> = Result.success(OpenCodeHealth(true, "1.0"))
+
+        override fun disconnect() = Unit
+
+        override suspend fun health(): OpenCodeHealth = OpenCodeHealth(true, "1.0")
+
+        override suspend fun listSessions(directory: String?): List<OpenCodeSession> = sessions
+
+        override suspend fun createSession(
+            title: String?,
+            directory: String?,
+        ): OpenCodeSession = error("unused")
+
+        override suspend fun listMessages(sessionId: String): List<OpenCodeMessage> = emptyList()
+
+        override suspend fun listProviders(): ProviderCatalog = ProviderCatalog()
+
+        override suspend fun listAgents(): List<OpenCodeAgent> = emptyList()
+
+        override suspend fun listWorkspaces(): List<WorkspaceRef> = emptyList()
+
+        override suspend fun sendMessage(
+            sessionId: String,
+            request: PromptRequest,
+        ) = Unit
+
+        override suspend fun abortSession(sessionId: String): Boolean = true
+
+        override suspend fun respondToPermission(
+            sessionId: String,
+            permissionId: String,
+            response: PermissionResponse,
+            remember: Boolean,
+        ): Boolean = true
+
+        override suspend fun archiveSession(sessionId: String): OpenCodeSession {
+            archivedIds += sessionId
+            return sessions.first { it.id == sessionId }
+        }
+
+        override fun events(): Flow<OpenCodeEvent> = emptyFlow()
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiverTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/data/repository/SessionAutoArchiverTest.kt
@@ -102,6 +102,34 @@ class SessionAutoArchiverTest {
         }
 
     @Test
+    fun `a running session still counts toward the active cap`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target =
+                FakeTarget(
+                    "mac",
+                    sessions =
+                        listOf(
+                            session("running", updatedDaysAgo = 1),
+                            session("kept", updatedDaysAgo = 2),
+                            session("archived", updatedDaysAgo = 3),
+                        ),
+                )
+            val registry = registry(target)
+            val catalog = RuntimeCatalogRepository(registry, TestScope(dispatcher))
+            val preferences = fakePreferences(autoArchiveMaxSessionsEnabled = true, autoArchiveMaxSessions = 2)
+            val archiver =
+                SessionAutoArchiver(registry, catalog, activeSessionIds = { setOf("running") }, preferences, TestScope(dispatcher))
+
+            archiver.start()
+            advanceUntilIdle()
+
+            // The cap is 2: "running" occupies one slot without ever being archived, so only one of
+            // the two remaining sessions may stay active and the older one is archived.
+            assertEquals(listOf("archived"), target.archivedIds)
+        }
+
+    @Test
     fun `never archives a session that is actively running`() =
         runTest {
             val dispatcher = StandardTestDispatcher(testScheduler)
@@ -116,6 +144,31 @@ class SessionAutoArchiverTest {
             advanceUntilIdle()
 
             assertTrue(target.archivedIds.isEmpty())
+        }
+
+    @Test
+    fun `a session is retried after a failed archive call instead of being skipped forever`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val target = FakeTarget("mac", sessions = listOf(session("old", updatedDaysAgo = 90)))
+            target.shouldFail = true
+            val registry = registry(target)
+            val catalog = RuntimeCatalogRepository(registry, TestScope(dispatcher))
+            val preferences = fakePreferences(autoArchiveStaleEnabled = true, autoArchiveStaleDays = 30)
+            val archiver =
+                SessionAutoArchiver(registry, catalog, activeSessionIds = { emptySet() }, preferences, TestScope(dispatcher))
+
+            archiver.start()
+            advanceUntilIdle()
+            assertTrue(target.archivedIds.isEmpty())
+
+            // A settings change (or any other session-list recomputation) gives the failed session
+            // another chance instead of leaving it permanently excluded.
+            target.shouldFail = false
+            preferences.value = preferences.value.copy(autoArchiveStaleDays = 31)
+            advanceUntilIdle()
+
+            assertEquals(listOf("old"), target.archivedIds)
         }
 
     private fun session(
@@ -181,6 +234,7 @@ class SessionAutoArchiverTest {
         override val state = MutableStateFlow<RuntimeState>(RuntimeState.Disconnected)
 
         val archivedIds = mutableListOf<String>()
+        var shouldFail = false
 
         override suspend fun connect(): Result<OpenCodeHealth> = Result.success(OpenCodeHealth(true, "1.0"))
 
@@ -218,6 +272,7 @@ class SessionAutoArchiverTest {
         ): Boolean = true
 
         override suspend fun archiveSession(sessionId: String): OpenCodeSession {
+            if (shouldFail) error("archive failed")
             archivedIds += sessionId
             return sessions.first { it.id == sessionId }
         }


### PR DESCRIPTION
<!-- pre-pr-review: approved -->
## Pre-PR review

Note: this repo's `pre-pr-review` skill normally delegates to the `repo-reviewer` subagent
(`.opencode/agents/repo-reviewer.md`), which isn't invocable as a subagent type in this Claude
Code session. I performed the equivalent review myself directly against the same repository map,
hard rules, and procedure defined in that agent file, on `git diff origin/main...HEAD`.

判定: APPROVE

## ブロッカー
なし

## 提案(非ブロッキング)
- `SessionAutoArchiver` の `alreadyArchived` セットはプロセス生存期間中増え続けるが、実運用でのセッション総数を考えると無視できる規模。

## チェック済み項目
- 全8ロケール(en/ja/zh-rCN/ru/es/fr/pt-rBR/ar)で新規キー(`section_sessions_settings` ほか計10キー)が揃っていることを `.github/workflows/i18n-check.yml` と同等のスクリプトをローカル実行して確認。
- ハードコードされたユーザー向け文字列がないことを確認(`SettingsScreenV2.kt` の新セクションはすべて `stringResource` 経由)。
- `./gradlew detekt spotlessCheck` を実行し成功を確認(detekt は本リポジトリの現状の Gradle 構成では root モジュールにのみ適用されており `:app` ソースは対象外 — 既存の構成で本PRとは無関係)。
- `:app:compileDebugKotlin` / `:app:compileDebugUnitTestKotlin` / `:app:testDebugUnitTest`(フルスイート)/ `:app:lintDebug` がすべて成功することを確認。
- `SessionAutoArchiverTest` で以下を検証: 両ルール無効時は何もしない、経過日数によるアーカイブ、上限超過時に古い順でアーカイブ、実行中セッションは対象外。
- DI: `SessionAutoArchiver` は ViewModel に注入されないバックグラウンドコレクタのため、`GitHubStarCoordinator` 等と同様 `AndCodeApplication.onCreate()` で直接構築・起動しており、既存の二重DIグラフの慣習と一致。
- Worktree rule: `scripts/new-worktree.sh` は未使用(Claude Code セッション自身が専用ブランチ `claude/session-archive-settings-3jpk7e` を作成しており、main の作業ツリーを直接変更してはいない)。

### Follow-up after Copilot's review (commit f0bbdca)

Copilot flagged 6 issues; all fixed and threads resolved:
- Max-active-chats cap now counts running sessions as occupying a slot (`toKeep = max - active.size`), so the total active list actually respects the configured limit instead of only counting archivable candidates.
- A session is marked "already archived" only after `archiveSession` actually succeeds, so a missing runtime target or a transient failure lets it retry on the next recomputation instead of being permanently skipped.
- Preference clamp ranges now match the slider ranges exactly (stale days 1-180, max sessions 5-500), so a stored value can never fall outside what the dialog can represent.
- `auto_archive_stale_days_value` converted to a `<plurals>` resource (mirroring `chat_stall_silent_for`) across all 8 locales, fixing the "1 days" grammar issue.
- Added a test for the running-session-counts-toward-cap behavior and a test for the retry-after-failure behavior.

## Summary

- Adds a new **Sessions** section in Settings with two opt-in rules for keeping the chat list manageable:
  - Auto-archive chats that haven't been updated in a configurable number of days.
  - Cap the number of active chats and archive the oldest ones once the count passes a configurable limit.
- Adds `SessionAutoArchiver`, which watches the combined session list across all runtimes and the new preferences, and issues `archiveSession` calls for any session that qualifies — skipping sessions that are currently active/running.
- Both settings default to off, so existing behavior is unchanged unless the user opts in.
- Adds strings for all 8 supported locales (en, ja, zh-CN, ru, es, fr, pt-BR, ar).

## Test plan

- [x] `:app:compileDebugKotlin` / `:app:compileDebugUnitTestKotlin` succeed
- [x] Unit tests in `SessionAutoArchiverTest` (6 tests) cover: both rules disabled (no-op), stale-day archiving, max-session-count archiving (oldest first), running sessions counting toward the cap, never archiving an actively running session, and retry after a failed archive call
- [x] `:app:testDebugUnitTest` (full suite) passes
- [x] `:app:lintDebug` and `spotlessCheck` pass
- [ ] Manual verification in the running app (not performed in this environment)

https://claude.ai/code/session_01NsFBJ2H8E8WXqdS9eKnfgC
