### PR TITLE
Clear a stale reasoning-effort variant when the model changes

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -706,10 +706,17 @@ class ChatViewModel(
     ) {
         this.contextLimit = contextLimit
         _uiState.update {
+            val modelChanged = providerId != it.selectedProviderId || modelId != it.selectedModelId
             it.copy(
                 selectedProviderId = providerId,
                 selectedModelId = modelId,
                 selectedAgentId = agentId,
+                // A reasoning-effort variant belongs to the model that offered it, not to the chat
+                // session, so carrying it across a model switch can silently apply an effort the new
+                // model never listed - AntigravityModels.cliArgs in particular reads a leftover
+                // variant straight off whatever provider set it last, for any model whose id has no
+                // effort baked in.
+                selectedVariant = if (modelChanged) null else it.selectedVariant,
             )
         }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -39,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.OpenCodeModel
@@ -369,7 +371,30 @@ private fun ModelRow(
             )
         }
         Column(modifier = Modifier.weight(1f)) {
-            Text(model.name, style = MaterialTheme.typography.bodyMedium, maxLines = 1)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    model.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                // A model that carries reasoning-effort variants (Claude Code's `--effort`, or any
+                // OpenCode model configured with variants) controls that depth from the composer's
+                // thinking chip, not from this sheet - flagging it here is the only hint a user
+                // browsing models gets that the level exists at all before they pick this model.
+                if (model.variants.isNotEmpty()) {
+                    Icon(
+                        imageVector = Icons.Default.Psychology,
+                        contentDescription = stringResource(R.string.cd_thinking),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+            }
             Text(
                 model.id,
                 style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
@@ -382,10 +382,13 @@ private fun ModelRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f, fill = false),
                 )
-                // A model that carries reasoning-effort variants (Claude Code's `--effort`, or any
-                // OpenCode model configured with variants) controls that depth from the composer's
-                // thinking chip, not from this sheet - flagging it here is the only hint a user
-                // browsing models gets that the level exists at all before they pick this model.
+                // Flags a model whose `variants` map is non-empty - today that's every Claude Code
+                // alias (ClaudeModels.kt hardcodes low/medium/high/xhigh/max) and, in principle, any
+                // OpenCode model whose server has reasoning variants configured. The actual control
+                // lives in the composer's thinking chip, which appears under the exact same
+                // condition, so this icon is a secondary hint for models the chip already surfaces -
+                // it does nothing for models with no variants (e.g. Antigravity, or OpenCode's
+                // models.dev catalog, which as of this writing declares variants for no model).
                 if (model.variants.isNotEmpty()) {
                     Icon(
                         imageVector = Icons.Default.Psychology,

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ModelAndRuntimePickerSheet.kt
@@ -382,13 +382,10 @@ private fun ModelRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f, fill = false),
                 )
-                // Flags a model whose `variants` map is non-empty - today that's every Claude Code
-                // alias (ClaudeModels.kt hardcodes low/medium/high/xhigh/max) and, in principle, any
-                // OpenCode model whose server has reasoning variants configured. The actual control
-                // lives in the composer's thinking chip, which appears under the exact same
-                // condition, so this icon is a secondary hint for models the chip already surfaces -
-                // it does nothing for models with no variants (e.g. Antigravity, or OpenCode's
-                // models.dev catalog, which as of this writing declares variants for no model).
+                // Flags a model whose `variants` map is non-empty, i.e. one that exposes
+                // reasoning-effort variants. The actual control lives in the composer's thinking
+                // chip, which appears under the exact same condition, so this icon is just a
+                // secondary hint for models the chip already surfaces.
                 if (model.variants.isNotEmpty()) {
                     Icon(
                         imageVector = Icons.Default.Psychology,

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -1144,6 +1144,37 @@ class ChatViewModelTest {
             assertNull(viewModel.uiState.value.parentSession)
         }
 
+    @Test
+    fun `switching model clears a reasoning-effort variant the new model may not offer`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+
+            viewModel.selectConfiguration("claude-code", "sonnet", agentId = null)
+            viewModel.selectVariant("high")
+            assertEquals("high", viewModel.uiState.value.selectedVariant)
+
+            viewModel.selectConfiguration("antigravity", "gemini-3.6-flash", agentId = null)
+
+            assertNull(viewModel.uiState.value.selectedVariant)
+        }
+
+    @Test
+    fun `reselecting the same model keeps its chosen reasoning-effort variant`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+
+            viewModel.selectConfiguration("claude-code", "sonnet", agentId = null)
+            viewModel.selectVariant("high")
+
+            viewModel.selectConfiguration("claude-code", "sonnet", agentId = "build")
+
+            assertEquals("high", viewModel.uiState.value.selectedVariant)
+        }
+
     private fun sessionAssistantMessage(
         sessionId: String,
         messageId: String,


### PR DESCRIPTION
## Summary

- **Fix a real bug**: `ChatViewModel.selectConfiguration()` never cleared `selectedVariant` when the provider/model changed. Since `AntigravityModels.cliArgs` falls back to whatever `variant` string it's handed when a model's id has no effort baked in, switching from e.g. Claude Code with effort `"max"` selected to a bare Antigravity model could silently launch with an effort value left over from an unrelated provider (or, for values Antigravity doesn't recognize, silently drop `--effort` on a model that requires it, breaking the launch). `selectedVariant` is now reset whenever the provider or model id actually changes, and preserved when only the agent changes.
- **Small discoverability hint**: added a 14dp brain icon next to a model's name in `ModelAndRuntimePickerSheet` when `model.variants.isNotEmpty()`, flagging that the model has reasoning-effort levels.

## What this does NOT fix

This PR does **not** resolve #270. The issue's likely reporter has no thinking/reasoning control to find in the first place, and this PR doesn't change that:

- The composer's `ThinkingChip` is already shown under the exact same condition as the new picker icon (`model.variants.isNotEmpty()`), and it's a labelled chip, not a bare icon — so the new icon only appears for models that already show the chip. It adds nothing for the users who see no control at all.
- **Claude Code**: AndCode itself synthesises `variants = low/medium/high/xhigh/max` in `ClaudeModels.kt`, so the chip (and now the icon) already exists there. This is the only runtime where the control exists today.
- **Antigravity**: effort is baked into the model slug by design (separate picker entries like `gemini-3.6-flash-high`), so `variants` is empty and neither the chip nor the icon appears.
- **OpenCode (local on-device runtime and remote)**: the model catalog comes from models.dev. Checking every model in `https://models.dev/api.json` shows zero models declare `variants`. So for OpenCode users — the app's default/flagship runtime, and the most likely #270 reporter — the thinking chip never appears out of the box, and the new icon never appears either. It would only show up for a remote OpenCode server someone has hand-configured with reasoning variants, which is not the out-of-the-box experience.

Giving OpenCode models a reasoning-effort control (surfacing something equivalent to `variants` from the default models.dev catalog, or another mechanism) is follow-up work that needs its own PR and design discussion — not attempted here.

Relates to #270

## Test plan

- Added two `ChatViewModelTest` cases: switching provider/model clears a previously chosen `selectedVariant`; switching only the agent (same provider/model) preserves it.
- `./gradlew spotlessKotlinCheck` passes.
- Could not run `./gradlew :app:compileDebugKotlin` or the unit test suite in this sandbox — no Android SDK is installed here (`ANDROID_HOME`/`local.properties` unset, no cached SDK found). CI should run the real compile/test before merge.