### PR TITLE
fix: limit F-Droid repository to AndCode APKs

### DIFF
--- a/.github/workflows/fdroid-repository.yml
+++ b/.github/workflows/fdroid-repository.yml
@@ -53,7 +53,7 @@ jobs:
             fi
             for attempt in $(seq 1 "$attempts"); do
               has_apk="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" \
-                --json assets --jq '[.assets[].name] | any(endswith("-release.apk"))')"
+                --json assets --jq '[.assets[].name] | any(startswith("and-code-") and endswith("-release.apk"))')"
               if [ "$has_apk" = true ]; then
                 ready=true
                 break
@@ -68,7 +68,7 @@ jobs:
             fi
             gh release download "$tag" \
               --repo "$GITHUB_REPOSITORY" \
-              --pattern '*-release.apk' \
+              --pattern 'and-code-*-release.apk' \
               --dir fdroid/repo \
               --clobber
           done < <(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 \


### PR DESCRIPTION
## Summary

Limit the self-hosted F-Droid repository workflow to `and-code-*-release.apk` so unrelated release APKs are not indexed as separate applications.

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
なし

## 提案（非ブロッキング）
- なし

## チェック済み項目
- `origin/main...fix-fdroid-apk-filter` の全差分を確認
- Release WorkflowのAPK命名規則とフィルター条件の整合性を確認
- F-Droidの待機判定・ダウンロード判定が同じ条件になっていることを確認
- `git diff --check` が成功することを確認
- 作業ツリーがクリーンであることを確認