### PR TITLE
fix(antigravity): unblock tool calls; fix(theme): make the light theme readable

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
@@ -58,7 +58,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.R
-import com.yugahashimoto.andcode.ui.theme.AndCodeSuccess
+import com.yugahashimoto.andcode.ui.theme.LocalThemeColors
 
 /**
  * One collapsed line standing in for a whole run of reasoning/tool calls.
@@ -379,7 +379,7 @@ fun ToolStatusChip(status: ToolStatus) {
         when (status) {
             ToolStatus.PENDING -> stringResource(R.string.tool_status_pending) to MaterialTheme.colorScheme.onSurfaceVariant
             ToolStatus.RUNNING -> stringResource(R.string.tool_status_running) to MaterialTheme.colorScheme.primary
-            ToolStatus.COMPLETED -> stringResource(R.string.tool_status_completed) to AndCodeSuccess
+            ToolStatus.COMPLETED -> stringResource(R.string.tool_status_completed) to LocalThemeColors.current.success
             ToolStatus.ERROR -> stringResource(R.string.tool_status_error) to MaterialTheme.colorScheme.error
             ToolStatus.UNKNOWN -> stringResource(R.string.tool_status_pending) to MaterialTheme.colorScheme.onSurfaceVariant
         }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -67,7 +67,7 @@ import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
-import com.yugahashimoto.andcode.ui.theme.AndCodeWarning
+import com.yugahashimoto.andcode.ui.theme.LocalThemeColors
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -220,8 +220,9 @@ fun PermissionCard(
     permission: PermissionRequest,
     onPermission: (String, PermissionResponse, Boolean) -> Unit,
 ) {
+    val warningColor = LocalThemeColors.current.warning
     Card(
-        colors = CardDefaults.cardColors(containerColor = AndCodeWarning.copy(alpha = 0.10f)),
+        colors = CardDefaults.cardColors(containerColor = warningColor.copy(alpha = 0.10f)),
         shape = RoundedCornerShape(18.dp),
     ) {
         Column(
@@ -229,7 +230,7 @@ fun PermissionCard(
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Security, contentDescription = stringResource(R.string.cd_permission), tint = AndCodeWarning)
+                Icon(Icons.Default.Security, contentDescription = stringResource(R.string.cd_permission), tint = warningColor)
                 Spacer(Modifier.padding(horizontal = 5.dp))
                 Text(stringResource(R.string.permission_required), fontWeight = FontWeight.SemiBold)
             }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/CodeViewerScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/CodeViewerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -52,9 +53,15 @@ import com.yugahashimoto.andcode.ui.theme.SyntaxTheme
 import com.yugahashimoto.andcode.ui.theme.syntaxThemeFor
 import kotlinx.coroutines.launch
 
+// The code surface stays dark in every app theme: the syntax palettes are all dark-oriented and
+// an editor that flips to white would need a full light palette set. Everything drawn on it must
+// therefore carry an explicit dark-surface color - unstyled text falls back to onSurface, which
+// is near-black in the light theme and vanished against this background.
 private val CodeBackground = Color(0xFF282C34)
+private val CodeForeground = Color(0xFFDCDFE4)
 private val LineNumberColor = Color(0xFF6B7280)
 private val MatchHighlight = Color(0x99FFD54F)
+private val MatchHighlightForeground = Color(0xFF1A1A1A)
 
 private val TOKEN_REGEX =
     Regex(
@@ -162,6 +169,16 @@ fun CodeViewerScreen(
                             modifier = Modifier.weight(1f),
                             singleLine = true,
                             label = { Text(stringResource(R.string.search_label)) },
+                            colors =
+                                OutlinedTextFieldDefaults.colors(
+                                    focusedTextColor = CodeForeground,
+                                    unfocusedTextColor = CodeForeground,
+                                    cursorColor = CodeForeground,
+                                    focusedLabelColor = LineNumberColor,
+                                    unfocusedLabelColor = LineNumberColor,
+                                    focusedBorderColor = LineNumberColor,
+                                    unfocusedBorderColor = LineNumberColor,
+                                ),
                         )
                         IconButton(
                             onClick = {
@@ -219,6 +236,7 @@ fun CodeViewerScreen(
                         items(lines.size) { index ->
                             Text(
                                 text = highlightLine(lines[index], theme, searchQuery),
+                                color = CodeForeground,
                                 fontSize = 12.sp,
                                 lineHeight = 18.sp,
                                 fontFamily = FontFamily.Monospace,
@@ -256,7 +274,11 @@ private fun highlightLine(
         if (searchQuery.isNotEmpty()) {
             var idx = line.indexOf(searchQuery)
             while (idx >= 0) {
-                addStyle(SpanStyle(background = MatchHighlight), idx, idx + searchQuery.length)
+                addStyle(
+                    SpanStyle(background = MatchHighlight, color = MatchHighlightForeground),
+                    idx,
+                    idx + searchQuery.length,
+                )
                 idx = line.indexOf(searchQuery, idx + searchQuery.length)
             }
         }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/CodeViewerScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/CodeViewerScreen.kt
@@ -189,7 +189,11 @@ fun CodeViewerScreen(
                                 }
                             },
                         ) {
-                            Icon(Icons.Default.KeyboardArrowDown, contentDescription = stringResource(R.string.cd_next_match))
+                            Icon(
+                                Icons.Default.KeyboardArrowDown,
+                                contentDescription = stringResource(R.string.cd_next_match),
+                                tint = CodeForeground,
+                            )
                         }
                     }
                     if (searchQuery.isNotEmpty()) {

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityGuestSettings.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityGuestSettings.kt
@@ -18,6 +18,14 @@ import java.io.File
 object AntigravityGuestSettings {
     private const val RELATIVE_PATH = "root/.gemini/antigravity-cli/settings.json"
 
+    /**
+     * The one-shot `--print` bridge has no channel to answer per-tool review prompts, so
+     * `request-review` makes agy treat every tool call - `read_file`, `list_dir`, shell - as
+     * denied by the user. The session's `--mode` flag is what scopes what the agent may do;
+     * this setting only has to stop the unanswerable prompts.
+     */
+    const val TOOL_PERMISSION = "always-proceed"
+
     private val json = Json { prettyPrint = true }
 
     val content: String =
@@ -28,7 +36,7 @@ object AntigravityGuestSettings {
                     "altScreenMode" to JsonPrimitive("never"),
                     "notifications" to JsonPrimitive(false),
                     "enableTelemetry" to JsonPrimitive(false),
-                    "toolPermission" to JsonPrimitive("request-review"),
+                    "toolPermission" to JsonPrimitive(TOOL_PERMISSION),
                     "trustedWorkspaces" to JsonArray(listOf(JsonPrimitive("/workspace"))),
                 ),
             ),
@@ -48,5 +56,14 @@ object AntigravityGuestSettings {
         }
     }
 
-    private fun isValid(raw: String): Boolean = runCatching { Json.parseToJsonElement(raw) is JsonObject }.getOrDefault(false)
+    /**
+     * Valid means usable by the current build, not merely parseable: installs provisioned before
+     * the tool-permission fix still carry a parseable `request-review` file that denies every tool
+     * call, so the value itself has to be checked for [repair] to ever heal them.
+     */
+    private fun isValid(raw: String): Boolean =
+        runCatching {
+            val parsed = Json.parseToJsonElement(raw)
+            parsed is JsonObject && parsed["toolPermission"]?.let { it is JsonPrimitive && it.content == TOOL_PERMISSION } == true
+        }.getOrDefault(false)
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/components/AndCodeComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/components/AndCodeComponents.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.R
-import com.yugahashimoto.andcode.ui.theme.AndCodeSuccess
+import com.yugahashimoto.andcode.ui.theme.LocalThemeColors
 
 @Composable
 fun OpenCodeBrand(modifier: Modifier = Modifier) {
@@ -83,7 +83,7 @@ fun StatusChip(
     active: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val color = if (active) AndCodeSuccess else MaterialTheme.colorScheme.onSurfaceVariant
+    val color = if (active) LocalThemeColors.current.success else MaterialTheme.colorScheme.onSurfaceVariant
     Surface(
         modifier = modifier,
         color = color.copy(alpha = 0.14f),

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/theme/Color.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/theme/Color.kt
@@ -211,15 +211,3 @@ val GhosttyTheme =
         statusIdle = Color(0xFF6B7385),
         statusUnread = Color(0xFF4C8DF6),
     )
-
-val AndCodeBackground get() = DarkTheme.surface0
-val AndCodeSurface get() = DarkTheme.surface1
-val AndCodeSurfaceVariant get() = DarkTheme.surface2
-val AndCodePrimary get() = DarkTheme.accent
-val AndCodeSecondary get() = DarkTheme.secondary
-val AndCodeSuccess get() = DarkTheme.success
-val AndCodeWarning get() = DarkTheme.warning
-val AndCodeError get() = DarkTheme.destructive
-val AndCodeTextPrimary get() = DarkTheme.foreground
-val AndCodeTextSecondary get() = DarkTheme.foregroundMuted
-val AndCodeOutline get() = DarkTheme.border

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/theme/Theme.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/theme/Theme.kt
@@ -69,10 +69,25 @@ private fun buildColorScheme(
         onPrimaryContainer = tc.accent,
         secondaryContainer = tc.secondary.copy(alpha = 0.14f),
         onSecondaryContainer = tc.secondary,
+        // The palettes have no dedicated third hue; leaving these undefined let the Material
+        // baseline purple leak through components like the queued chip in every theme.
+        tertiary = tc.secondary,
+        onTertiary = tc.surface0,
+        tertiaryContainer = tc.secondary.copy(alpha = 0.14f),
+        onTertiaryContainer = tc.secondary,
         errorContainer = tc.destructive.copy(alpha = 0.14f),
         onErrorContainer = tc.destructive,
+        surfaceContainerLowest = tc.surface0,
+        surfaceContainerLow = tc.surface1,
+        surfaceContainer = tc.surface1,
+        surfaceContainerHigh = tc.surface2,
+        surfaceContainerHighest = tc.surface3,
+        surfaceBright = tc.surface2,
+        surfaceDim = tc.surface0,
+        outlineVariant = tc.border,
         inverseSurface = tc.surface4,
         inverseOnSurface = tc.foreground,
+        inversePrimary = tc.accentBright,
         scrim = tc.surface0.copy(alpha = 0.6f),
     )
 } else {
@@ -94,10 +109,25 @@ private fun buildColorScheme(
         onPrimaryContainer = tc.accent,
         secondaryContainer = tc.secondary.copy(alpha = 0.14f),
         onSecondaryContainer = tc.secondary,
+        tertiary = tc.secondary,
+        onTertiary = tc.surface0,
+        tertiaryContainer = tc.secondary.copy(alpha = 0.14f),
+        onTertiaryContainer = tc.secondary,
         errorContainer = tc.destructive.copy(alpha = 0.14f),
         onErrorContainer = tc.destructive,
-        inverseSurface = tc.surface4,
-        inverseOnSurface = tc.foreground,
+        surfaceContainerLowest = tc.surface0,
+        surfaceContainerLow = tc.surface1,
+        surfaceContainer = tc.surface1,
+        surfaceContainerHigh = tc.surface2,
+        surfaceContainerHighest = tc.surface3,
+        surfaceBright = tc.surface1,
+        surfaceDim = tc.surface4,
+        outlineVariant = tc.border,
+        // A light theme inverts against its dark foreground, not against another light surface;
+        // tooltips and overlays otherwise rendered as washed-out light gray on light gray.
+        inverseSurface = tc.foreground,
+        inverseOnSurface = tc.surface0,
+        inversePrimary = tc.accent,
         scrim = tc.surface0.copy(alpha = 0.6f),
     )
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/theme/Theme.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/theme/Theme.kt
@@ -115,7 +115,7 @@ private fun buildColorScheme(
         onTertiaryContainer = tc.secondary,
         errorContainer = tc.destructive.copy(alpha = 0.14f),
         onErrorContainer = tc.destructive,
-        surfaceContainerLowest = tc.surface0,
+        surfaceContainerLowest = tc.surface1,
         surfaceContainerLow = tc.surface1,
         surfaceContainer = tc.surface1,
         surfaceContainerHigh = tc.surface2,

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravitySandboxLauncherTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravitySandboxLauncherTest.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
+import java.nio.file.Files
 
 class AntigravitySandboxLauncherTest {
     @Test
@@ -31,6 +33,59 @@ class AntigravitySandboxLauncherTest {
     fun `guest settings are valid json with the alt screen disabled`() {
         val parsed = Json.parseToJsonElement(AntigravityGuestSettings.content).jsonObject
         assertEquals("never", parsed["altScreenMode"]?.jsonPrimitive?.content)
-        assertEquals("request-review", parsed["toolPermission"]?.jsonPrimitive?.content)
+        assertEquals("always-proceed", parsed["toolPermission"]?.jsonPrimitive?.content)
     }
+
+    @Test
+    fun `repair heals a legacy request-review settings file`() {
+        val rootfs = Files.createTempDirectory("antigravity-guest-settings").toFile()
+        try {
+            val settings = File(rootfs, "root/.gemini/antigravity-cli/settings.json")
+            settings.parentFile?.mkdirs()
+            settings.writeText("""{"toolPermission":"request-review"}""")
+
+            val runtime = mockRuntime(rootfs)
+            AntigravityGuestSettings.repair(runtime)
+
+            val healed = Json.parseToJsonElement(settings.readText()).jsonObject
+            assertEquals("always-proceed", healed["toolPermission"]?.jsonPrimitive?.content)
+        } finally {
+            rootfs.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `repair leaves an up to date settings file untouched`() {
+        val rootfs = Files.createTempDirectory("antigravity-guest-settings").toFile()
+        try {
+            val settings = File(rootfs, "root/.gemini/antigravity-cli/settings.json")
+            settings.parentFile?.mkdirs()
+            settings.writeText("""{"toolPermission":"always-proceed","custom":"keep"}""")
+
+            AntigravityGuestSettings.repair(mockRuntime(rootfs))
+
+            val healed = Json.parseToJsonElement(settings.readText()).jsonObject
+            assertEquals("always-proceed", healed["toolPermission"]?.jsonPrimitive?.content)
+            assertEquals("keep", healed["custom"]?.jsonPrimitive?.content)
+        } finally {
+            rootfs.deleteRecursively()
+        }
+    }
+
+    private fun mockRuntime(rootfs: File): LocalRuntimeInstaller.InstalledRuntime =
+        LocalRuntimeInstaller.InstalledRuntime(
+            metadata = LocalRuntimeMetadata(version = "test", port = 0, installedAt = 0),
+            commandSuite =
+                EmbeddedCommandSuite.Paths(
+                    home = rootfs,
+                    tmp = rootfs,
+                    nativeLibraryDirectory = rootfs,
+                    proot = rootfs,
+                    loader = rootfs,
+                    loader32 = rootfs,
+                ),
+            rootfs = rootfs,
+            openCode = null,
+            antigravityRootfs = rootfs,
+        )
 }


### PR DESCRIPTION
## Summary

Two user-reported fixes:

### #278 — Antigravity can't use shell at all
The guest `settings.json` pinned `toolPermission: "request-review"`, but the one-shot `agy --print` bridge has no channel to answer per-tool review prompts, so agy treated **every** tool call (`read_file`, `list_dir`, shell) as denied by the user. Now the guest settings provision `always-proceed` and the session's `--mode` flag (plan / accept-edits / full access) remains what scopes what the agent may do. `repair()` validates the value itself, so installs provisioned by older builds are healed on the next send or sign-in.

### #279 — Light theme looks poor
- `buildColorScheme()` now defines the `tertiary*`, `surfaceContainer*`, `outlineVariant`, and `inverse*` roles whose undefined values let the Material baseline purple leak into the queued chip, voice overlay, context meter, and menus.
- The light scheme's inverse surface is now the dark foreground (true inversion for tooltips), and the surface container tones are ordered light-to-dark as M3 expects.
- Replaced the `DarkTheme`-fixed legacy getters (`AndCodeSuccess`/`AndCodeWarning`, now deleted) with theme-aware `LocalThemeColors` reads in the completed-tool chip, permission card, and status chip.
- The code viewer intentionally keeps a dark editor surface (all syntax palettes are dark-oriented), but every element drawn on it now carries explicit dark-surface colors: code text, line numbers, search field, next-match icon, and match highlight, which previously rendered near-black-on-dark in the light theme.

## Test plan
- `./gradlew detekt spotlessCheck :app:lintDebug` — pass
- `./gradlew :app:testDebugUnitTest` — 974 tests, 0 failures (incl. 2 new `repair` tests: legacy `request-review` file heals, up-to-date file untouched)

Follow-up candidate (non-blocking, pre-existing): the light branch's `scrim` is near-white where M3 expects a dark scrim behind modal bottom sheets.

<!-- pre-pr-review: approved -->
## Pre-PR review

判定： APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- Theme.kt:131 — ライト分岐の `scrim = tc.surface0.copy(alpha = 0.6f)` はほぼ白（FAFAFA 60%）で、M3の規定（暗いスクライム）と逆です。`ModalBottomSheet` を6ファイルで使用しており、ライトテーマ時に暗くなるべきディムが白いベールになります。本ブランチより前から存在する行（今回は未変更）なので対応義務はありませんが、このPRの「ライトテーマのM3ロール漏出修正」と同種の課題なので、フォローアップ候補として挙げておきます。
- 前回指摘の origin/main 取り込みについて確認済み: 向こう側の2コミット（f06825c, 8465999）が触るのは `.github/workflows/fdroid-repository.yml` のみで、本ブランチの8ファイルと重複なし。コンフリクトなしでマージできます。

## チェック済み項目
- 前回ブロッカーの修正を確認: CodeViewerScreen.kt:195 の「次の一致」IconButton に `tint = CodeForeground` 追加済み。前回提案の `surfaceContainerLowest = tc.surface1`（Theme.kt:118）も適用済みで、LightTheme のトーン順序（FFFFFF→E8E8E8）と整合。
- レガシーゲッター廃止: ワークツリー全体を grep し、`AndCodeBackground`/`AndCodeSuccess` 等の残存参照ゼロを確認（`LocalThemeColors.current.success/warning` への移行は AssistantActivityRow / ChatMessageComponents / AndCodeComponents の3箇所で完結）。`LocalThemeColors` は `AndCodeTheme` で provide され、デフォルト `DarkTheme` フォールバック付きで安全。
- Theme.kt の新規ロール: `ThemeColors` インターフェースと全6パレットに `surface3`/`surface4`/`accentBright` が存在することを確認。`tertiary` 系は実際に AndCodeApp:1359（queued チップ）等で消費されており、紫漏出修正は実効あり。ダーク/ライト両分岐で surfaceContainer 系の明度順序が単調であることを確認。
- issue #278: `isValid` が `toolPermission == "always-proceed"` を検証するよう強化され、`repair()`（サインイン時 AntigravityAuthCoordinator:111、毎送信時 AntigravityRuntime:168 で呼び出し）がレガシーの `request-review` ファイルを修復するフローを確認。`--mode` cliArgs（AntigravityRuntime:202, AntigravityPermissionMode）がセッション権限の実スコープであることから、`always-proceed` が過剰な権限を与えないというコメントの主張も裏付け済み。
- テスト: `mockRuntime` のコンストラクタ引数が `InstalledRuntime` / `LocalRuntimeMetadata` / `EmbeddedCommandSuite.Paths` の実シグネチャと完全一致することを照合。レガシー修復・最新ファイル無変更の両パスをカバー。
- コードビューア: 固定ダーク面上の全要素（本文・検索フィールドの文字/カーソル/ラベル/ボーダー・一致ハイライトの前景・一致カウンター・行番号）に明示色が付与されていることを通読で確認。ローディング/エラー状態と TopAppBar はテーマ側サーフェス上に残り、問題なし。ハイライト前景 `0xFF1A1A1A` は半透明黄背景上で両テーマ可読。
- i18n: リソース変更なし。使用中のキー（`cd_next_match` 等4件）が全8ロケールに存在することを確認。ハードコードされたユーザー可視テキストなし。
- 整合性: ktlint の max-line-length は .editorconfig で無効化されており AntigravityGuestSettings.kt:67 の長行は問題なし。ローカルゲート（detekt/spotlessCheck/testDebugUnitTest 974件）通過の報告とコード上の確認が矛盾しないことまで検証。

前回指摘がすべて適切に反映されており、CI・動作・規約のいずれにも懸念が残らないため承認します。上記の非ブロッキング1件（ライトスクライム）はフォローアップissue化を推奨します。

Fixes #278, fixes #279