### PR TITLE
fix(runtime): make session archiving work for Claude Code and Antigravity chats

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
@@ -37,6 +37,8 @@ data class AntigravitySessionRecord(
      * [AntigravityTarget] a session is still unnamed and its first prompt should name it.
      */
     val title: String? = null,
+    /** Hidden from the drawer without deleting the transcript, like the OpenCode server's archive. */
+    val archived: Boolean = false,
 )
 
 class AntigravityRuntime(
@@ -350,10 +352,27 @@ class AntigravityRuntime(
         }
     }
 
+    /** The drawer's list: every chat that is not archived, optionally narrowed to one workspace. */
     fun listSessions(directory: String?): List<AntigravitySessionRecord> =
         records.values.filter {
-            directory == null || it.workspace == directory
+            !it.archived && (directory == null || it.workspace == directory)
         }
+
+    /** A record by id whether archived or not, so reopening an archived chat still resolves. */
+    fun findSession(sessionId: String): AntigravitySessionRecord? = records[sessionId]
+
+    /** Every chat's workspace, archived ones included: the picker must keep offering folders whose chats were all archived. */
+    fun workspacePaths(): List<String> = records.values.map { it.workspace }.distinct()
+
+    /** Marks a session archived; see [AntigravitySessionRecord.archived]. */
+    fun archive(sessionId: String): AntigravitySessionRecord? {
+        val record = records[sessionId] ?: return null
+        if (record.archived) return record
+        val archived = record.copy(archived = true)
+        records[sessionId] = archived
+        persist()
+        return archived
+    }
 
     fun listMessages(sessionId: String): List<OpenCodeMessage> = messages[sessionId].orEmpty().toList()
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityTarget.kt
@@ -106,7 +106,7 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
         title: String,
     ): OpenCodeSession {
         runtime.setSessionTitle(sessionId, title)
-        val record = runtime.listSessions(null).firstOrNull { it.appSessionId == sessionId } ?: error("Antigravity session not found")
+        val record = runtime.findSession(sessionId) ?: error("Antigravity session not found")
         return OpenCodeSession(
             record.appSessionId,
             directory = record.workspace,
@@ -118,7 +118,7 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
     /** Same as [ClaudeCodeTarget.listMessages]: names the model for chats held before it was stored. */
     override suspend fun listMessages(sessionId: String): List<OpenCodeMessage> {
         val messages = runtime.listMessages(sessionId)
-        val model = runtime.listSessions(null).firstOrNull { it.appSessionId == sessionId }?.model ?: return messages
+        val model = runtime.findSession(sessionId)?.model ?: return messages
         val reference = OpenCodeModelReference(AntigravityModels.PROVIDER_ID, model)
         return messages.map { message ->
             if (message.info.role == "assistant" && message.info.model == null) {
@@ -147,7 +147,7 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
         sessionId: String,
         request: PromptRequest,
     ) {
-        val record = runtime.listSessions(null).firstOrNull { it.appSessionId == sessionId } ?: error("Antigravity session not found")
+        val record = runtime.findSession(sessionId) ?: error("Antigravity session not found")
         // The CLI does not name its conversations, so every chat would sit in the drawer as
         // "Antigravity" - the same gap ClaudeCodeTarget fills, filled the same way. The prompt stands
         // in at once so the drawer is never left showing the tool's name.
@@ -213,6 +213,23 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
         return runtime.remove(sessionId)
     }
 
+    /**
+     * Hides the chat from the drawer while keeping its transcript - the same semantics the
+     * OpenCode server's archive endpoint gives. The CLI has no archive of its own, so the flag
+     * lives on the session record; without this override the auto-archive settings (and the
+     * drawer's archive action) hit the backend's "unsupported" for every Antigravity chat and
+     * silently did nothing, so stale and over-cap chats piled up forever.
+     */
+    override suspend fun archiveSession(sessionId: String): OpenCodeSession {
+        val record = runtime.archive(sessionId) ?: error("Antigravity session not found")
+        return OpenCodeSession(
+            record.appSessionId,
+            directory = record.workspace,
+            title = record.title ?: DEFAULT_TITLE,
+            time = OpenCodeTime(record.createdAt, record.updatedAt),
+        )
+    }
+
     override suspend fun respondToPermission(
         sessionId: String,
         permissionId: String,
@@ -255,8 +272,8 @@ class AntigravityTarget(internal val runtime: AntigravityRuntime) : RuntimeTarge
     ): List<OpenCodeSearchMatch> = withContext(kotlinx.coroutines.Dispatchers.IO) { files.search(directory, pattern) }
 
     override suspend fun listWorkspaces(): List<WorkspaceRef> =
-        runtime.listSessions(null).map {
-            WorkspaceRef(it.workspace, it.workspace.substringAfterLast('/').ifBlank { it.workspace }, it.workspace)
+        runtime.workspacePaths().map {
+            WorkspaceRef(it, it.substringAfterLast('/').ifBlank { it }, it)
         }.distinctBy { it.id }
 
     private companion object {

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTarget.kt
@@ -52,6 +52,8 @@ private data class ClaudeSessionRecord(
     @SerialName("permissionMode") val permissionMode: String = ClaudePermissionMode.DEFAULT.cliValue,
     @SerialName("model") val model: String = ClaudeModels.DEFAULT_MODEL,
     @SerialName("effort") val effort: String? = null,
+    /** Hidden from the drawer without deleting the transcript, like the OpenCode server's archive. */
+    @SerialName("archived") val archived: Boolean = false,
 )
 
 /** Exposes the Android-local Claude Code agent as a selectable runtime. */
@@ -203,6 +205,7 @@ class ClaudeCodeTarget(
 
     override suspend fun listSessions(directory: String?): List<OpenCodeSession> =
         records.values
+            .filterNot(ClaudeSessionRecord::archived)
             .map(ClaudeSessionRecord::session)
             .filter { directory == null || it.directory == directory }
 
@@ -313,6 +316,22 @@ class ClaudeCodeTarget(
         }
         withContext(Dispatchers.IO) { runtime.deleteSessionData(sessionId) }
         return removed
+    }
+
+    /**
+     * Hides the chat from the drawer while keeping its transcript on disk - the same semantics the
+     * OpenCode server's archive endpoint gives. Claude Code has no archive concept of its own, so
+     * the flag lives on the session record; without this override the auto-archive settings (and
+     * the drawer's archive action) hit the backend's "unsupported" for every Claude chat and
+     * silently did nothing, so stale and over-cap chats piled up forever.
+     */
+    override suspend fun archiveSession(sessionId: String): OpenCodeSession {
+        val record = records[sessionId] ?: error("Claude Code session not found")
+        if (!record.archived) {
+            records[sessionId] = record.copy(archived = true)
+            persist()
+        }
+        return record.session
     }
 
     /**

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravitySessionArchiveTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravitySessionArchiveTest.kt
@@ -40,6 +40,18 @@ class AntigravitySessionArchiveTest {
         }
     }
 
+    @Test
+    fun `archiving is idempotent`() =
+        runBlocking {
+            val target = target()
+            val session = target.createSession("Archive me twice", "/workspace")
+
+            target.archiveSession(session.id)
+            target.archiveSession(session.id)
+
+            assertEquals(emptyList<String>(), target.listSessions(null).map { it.id })
+        }
+
     /** The flag lives on the persisted record, so the chat stays hidden after an app restart. */
     @Test
     fun `an archive survives a new runtime instance`() {

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravitySessionArchiveTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/AntigravitySessionArchiveTest.kt
@@ -1,0 +1,81 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Archiving an Antigravity chat.
+ *
+ * The CLI has no archive of its own, so the flag lives on the session record. Without
+ * [AntigravityTarget.archiveSession] the call fell through to the backend's "unsupported", which
+ * the auto-archive settings and the drawer's archive action both swallow - chats piled up forever.
+ */
+class AntigravitySessionArchiveTest {
+    @get:Rule val folder = TemporaryFolder()
+
+    private fun target(): AntigravityTarget = AntigravityTarget(AntigravityRuntime(folder.root, { null }))
+
+    @Test
+    fun `an archived chat disappears from the session list but stays resolvable`() =
+        runBlocking {
+            val target = target()
+            val kept = target.createSession("Keep me", "/workspace")
+            val archived = target.createSession("Archive me", "/workspace")
+
+            val result = target.archiveSession(archived.id)
+
+            assertEquals("Archive me", result.title)
+            assertEquals(listOf(kept.id), target.listSessions(null).map { it.id })
+        }
+
+    @Test
+    fun `archiving an unknown session fails loudly`() {
+        assertThrows(IllegalStateException::class.java) {
+            runBlocking { target().archiveSession("no-such-session") }
+        }
+    }
+
+    /** The flag lives on the persisted record, so the chat stays hidden after an app restart. */
+    @Test
+    fun `an archive survives a new runtime instance`() {
+        runBlocking {
+            val target = target()
+            val session = target.createSession("Archive me", "/workspace")
+            target.archiveSession(session.id)
+        }
+        runBlocking {
+            assertEquals(emptyList<String>(), target().listSessions(null).map { it.id })
+        }
+    }
+
+    /** Archived chats must not drag their workspace out of the picker. */
+    @Test
+    fun `the workspace of an archived chat is still offered`() =
+        runBlocking {
+            val target = target()
+            val session = target.createSession("Archive me", "/workspace/note-articles")
+            target.archiveSession(session.id)
+
+            val workspaces = target.listWorkspaces()
+
+            assertTrue(workspaces.any { it.path == "/workspace/note-articles" })
+        }
+
+    /** Renaming an archived chat must not resurrect it in the drawer. */
+    @Test
+    fun `a rename keeps an archived chat archived`() =
+        runBlocking {
+            val target = target()
+            val session = target.createSession(null, "/workspace")
+            target.archiveSession(session.id)
+
+            target.renameSession(session.id, "Fix the login crash")
+
+            assertEquals(emptyList<String>(), target.listSessions(null).map { it.id })
+        }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTargetArchiveTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeTargetArchiveTest.kt
@@ -1,0 +1,85 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Archiving a Claude Code chat.
+ *
+ * Claude Code has no archive of its own, so the flag lives on the session record. Without
+ * [ClaudeCodeTarget.archiveSession] the call fell through to the backend's "unsupported", which the
+ * auto-archive settings and the drawer's archive action both swallow - chats piled up forever.
+ */
+class ClaudeCodeTargetArchiveTest {
+    @get:Rule val folder = TemporaryFolder()
+
+    private fun target(): ClaudeCodeTarget = ClaudeCodeTarget(ClaudeCodeRuntime(folder.root, { null }))
+
+    @Test
+    fun `an archived chat disappears from the session list but stays resolvable`() =
+        runBlocking {
+            val target = target()
+            val kept = target.createSession("Keep me", "/workspace")
+            val archived = target.createSession("Archive me", "/workspace")
+
+            val result = target.archiveSession(archived.id)
+
+            assertEquals("Archive me", result.title)
+            assertEquals(listOf(kept.id), target.listSessions(null).map { it.id })
+            assertEquals(listOf(kept.id), target.listSessions("/workspace").map { it.id })
+        }
+
+    @Test
+    fun `archiving is idempotent`() =
+        runBlocking {
+            val target = target()
+            val session = target.createSession("Archive me twice", "/workspace")
+
+            target.archiveSession(session.id)
+            target.archiveSession(session.id)
+
+            assertEquals(emptyList<String>(), target.listSessions(null).map { it.id })
+        }
+
+    @Test
+    fun `archiving an unknown session fails loudly`() {
+        assertThrows(IllegalStateException::class.java) {
+            runBlocking { target().archiveSession("no-such-session") }
+        }
+    }
+
+    /** The flag lives on the persisted record, so the chat stays hidden after an app restart. */
+    @Test
+    fun `an archive survives a new target instance`() {
+        val id: String
+        runBlocking {
+            val target = target()
+            target.createSession("Archive me", "/workspace")
+            target.createSession("Keep me", "/workspace")
+            id = target.listSessions(null).first { it.title == "Archive me" }.id
+            target.archiveSession(id)
+        }
+        runBlocking {
+            val reloaded = target().listSessions(null)
+            assertEquals(listOf("Keep me"), reloaded.map { it.title })
+        }
+    }
+
+    /** Archived chats must not drag their workspace out of the picker. */
+    @Test
+    fun `the workspace of an archived chat is still offered`() =
+        runBlocking {
+            val target = target()
+            val session = target.createSession("Archive me", "/workspace/note-articles")
+            target.archiveSession(session.id)
+
+            val workspaces = target.listWorkspaces()
+
+            assertTrue(workspaces.any { it.path == "/workspace/note-articles" })
+        }
+}


### PR DESCRIPTION
<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- なし

## チェック済み項目
- 全差分（5ファイル、+227/−6）を hunk 単位で通読し、worktree (/workspace/and-code/.worktree/fix/auto-archive-not-working) 上の実コードで呼び出し経路を検証
- archiveSession の全呼び出し元 (SessionAutoArchiver, AndCodeApp の onArchiveSession/onBatchArchive) と OpenCodeBackend の unsupported デフォルトを確認し、問題診断と修正アプローチが正しいことを確認
- 既存永続化データとの後方互換 (archived デフォルト false + ignoreUnknownKeys) を両レコード型で確認
- アーカイブ済みセッションの再解決経路 (findSession への変更、Claude の records 直参照) と listSessions 消費者 (カタログ、LocalRuntimeTarget、workspace ピッカー) 全件を確認
- アンアーカイブ機能が存在しないことを確認し、OpenCode サーバーとの一方向アーカイブとしてのセマンティクス整合を確認
- テストが既存規約 (TemporaryFolder/runBlocking/assertThrows、コンストラクタ形式) に合致することを確認
- i18n: UI 文字列・リソース変更なし、ハードコードされたユーザー表示テキストなし（エラーメッセージ・コメントは英語で規約どおり）
- DI/Koin・ViewModel への影響なし、シークレットなし、worktree 規約（スクリプト由来ブランチ）を確認
- ローカルゲート (detekt spotlessCheck :app:testDebugUnitTest) の PASS 申告を踏まえ、静的解析で指摘されうる形式面は差分目視で追加確認
- 続報 (3931220): Antigravity 冪等性テスト追加のみの差分であることを確認し、本 HEAD でも APPROVE を維持

## Problem

The "未更新のチャットを自動アーカイブ" / "アクティブなチャット数を制限" session settings did
nothing for Claude Code and Antigravity chats. Both targets lack an `archiveSession` override, so
the call fell through to the backend's `unsupported("session archive")` — and every caller
(`SessionAutoArchiver`, the drawer's single/batch archive) wraps the call in `runCatching` and
swallows the failure. Chats therefore piled up in the drawer forever, no matter what the settings
said.

## Fix

Archive now lives on each target's own session record with the same semantics as the OpenCode
server's archive endpoint: hidden from `listSessions`, transcript kept.

- `ClaudeSessionRecord` / `AntigravitySessionRecord` gain an `archived` flag (default `false`,
  backward compatible with existing persisted JSON).
- `ClaudeCodeTarget.archiveSession` / `AntigravityTarget.archiveSession` set the flag and persist.
- `AntigravityRuntime.findSession` replaces record lookups that went through the active-session
  list, so archived chats still resolve for rename/messages/send.
- `AntigravityRuntime.workspacePaths` keeps folders whose chats were all archived in the workspace
  picker.
- Tests for both targets: hiding from the list, persistence across instances, idempotency,
  loud failure on unknown ids, archived-only workspaces staying offered, rename keeping archives.

## Verification

- `detekt spotlessCheck :app:testDebugUnitTest` — all PASS (982 unit tests, 0 failures)
- repo-reviewer pre-PR review: APPROVE (report above)
