### PR TITLE
feat(fdroid): add a Firebase-free build flavor for official F-Droid submission

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -61,7 +61,7 @@ jobs:
           key: and-code-runtime-${{ runner.os }}-${{ hashFiles('runtime_tools/termux_assets.lock.json', 'runtime_tools/termux_assets.py', 'scripts/prepare_android_runtime_*.py') }}
 
       - name: Lint
-        run: ./gradlew :app:lintDebug
+        run: ./gradlew :app:lintGithubDebug
 
   test-and-build:
     runs-on: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
         # must not be implied by this compile-only job.
         env:
           GITHUB_CLIENT_ID: ${{ vars.AND_CODE_GITHUB_CLIENT_ID }}
-        run: ./gradlew :app:testDebugUnitTest :app:assembleDebug :app:assembleDebugAndroidTest
+        run: ./gradlew :app:testGithubDebugUnitTest :app:assembleGithubDebug :app:assembleGithubDebugAndroidTest
 
       # assembleRelease runs R8 with minification and resource shrinking, which is the single
       # most expensive task in this workflow. The published artifact is built by release.yml,
@@ -128,13 +128,13 @@ jobs:
         if: github.event_name == 'push'
         env:
           GITHUB_CLIENT_ID: ${{ vars.AND_CODE_GITHUB_CLIENT_ID }}
-        run: ./gradlew :app:assembleRelease
+        run: ./gradlew :app:assembleGithubRelease
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
           name: and-code-debug
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: app/build/outputs/apk/github/debug/app-github-debug.apk
           if-no-files-found: error
 
       - name: Upload unsigned release APK
@@ -142,5 +142,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: and-code-release-unsigned
-          path: app/build/outputs/apk/release/app-release-unsigned.apk
+          path: app/build/outputs/apk/github/release/app-github-release-unsigned.apk
           if-no-files-found: error

--- a/.github/workflows/pr-apk-build.yml
+++ b/.github/workflows/pr-apk-build.yml
@@ -25,14 +25,14 @@ jobs:
       - run: yes | sdkmanager --licenses >/dev/null || true
       - run: sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
       # See release.yml for why this is AND_CODE_-prefixed rather than GITHUB_CLIENT_ID directly.
-      - run: ./gradlew :app:testDebugUnitTest :app:assembleDebug
+      - run: ./gradlew :app:testGithubDebugUnitTest :app:assembleGithubDebug
         env:
           GITHUB_CLIENT_ID: ${{ vars.AND_CODE_GITHUB_CLIENT_ID }}
       - id: upload-apk
         uses: actions/upload-artifact@v4
         with:
           name: and-code-debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: app/build/outputs/apk/github/debug/app-github-debug.apk
           if-no-files-found: error
           retention-days: 14
       - name: Comment or update APK link on PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
             echo "AND_CODE_GITHUB_CLIENT_ID repo variable is not set - the published APK would have no GitHub sign-in" >&2
             exit 1
           fi
-           ./gradlew detekt spotlessCheck :app:lintDebug :app:testDebugUnitTest assembleDebug assembleRelease
+           ./gradlew detekt spotlessCheck :app:lintGithubDebug :app:testGithubDebugUnitTest assembleGithubDebug assembleGithubRelease
 
       - name: Resolve tag
         id: tag
@@ -97,14 +97,14 @@ jobs:
               --title "$TAG" \
               --generate-notes
           fi
-           cp app/build/outputs/apk/debug/app-debug.apk "and-code-$TAG-debug.apk"
+           cp app/build/outputs/apk/github/debug/app-github-debug.apk "and-code-$TAG-debug.apk"
            ASSETS=("and-code-$TAG-debug.apk")
-           if [ -f app/build/outputs/apk/release/app-release.apk ]; then
-             cp app/build/outputs/apk/release/app-release.apk "and-code-$TAG-release.apk"
+           if [ -f app/build/outputs/apk/github/release/app-github-release.apk ]; then
+             cp app/build/outputs/apk/github/release/app-github-release.apk "and-code-$TAG-release.apk"
              ASSETS+=("and-code-$TAG-release.apk")
              gh release delete-asset "$TAG" "and-code-$TAG-release-unsigned.apk" -y || true
            else
-             cp app/build/outputs/apk/release/app-release-unsigned.apk "and-code-$TAG-release-unsigned.apk"
+             cp app/build/outputs/apk/github/release/app-github-release-unsigned.apk "and-code-$TAG-release-unsigned.apk"
              ASSETS+=("and-code-$TAG-release-unsigned.apk")
           fi
           gh release upload "$TAG" --clobber "${ASSETS[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing!
 2. Create a feature branch: `git checkout -b feat/your-feature`
 3. Install the commit-msg hook: `ln -sf ../../scripts/commit-msg-hook.sh .git/hooks/commit-msg`
 4. Make your changes
-5. Run checks: `./gradlew testDebugUnitTest lintDebug assembleDebug`
+5. Run checks: `./gradlew testGithubDebugUnitTest lintGithubDebug assembleGithubDebug`
 6. Commit with a clear message following [Conventional Commits](https://www.conventionalcommits.org/)
 7. Push and open a Pull Request against `main`
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -214,20 +214,20 @@ npx qrcode "opencode://connect?name=Mac%20mini&url=http%3A%2F%2F192.168.1.10%3A4
 必要環境: JDK 17、Android SDK、Python 3、ネットワーク接続（初回のみ）
 
 ```bash
-./gradlew detekt spotlessCheck :app:lintDebug :app:testDebugUnitTest :app:assembleDebug :app:assembleRelease
+./gradlew detekt spotlessCheck :app:lintGithubDebug :app:testGithubDebugUnitTest :app:assembleGithubDebug :app:assembleGithubRelease
 ```
 
 出力されるAPK:
 
 ```text
-app/build/outputs/apk/debug/app-debug.apk
-app/build/outputs/apk/release/app-release-unsigned.apk
+app/build/outputs/apk/github/debug/app-github-debug.apk
+app/build/outputs/apk/github/release/app-github-release-unsigned.apk
 ```
 
 端末へのインストール:
 
 ```bash
-adb install -r app/build/outputs/apk/debug/app-debug.apk
+adb install -r app/build/outputs/apk/github/debug/app-github-debug.apk
 ```
 
 ## ドキュメント

--- a/README.md
+++ b/README.md
@@ -214,20 +214,20 @@ Restart the desktop app, then discover it from the Android app via **LAN search*
 Requirements: JDK 17, Android SDK, Python 3, network access (first build only)
 
 ```bash
-./gradlew detekt spotlessCheck :app:lintDebug :app:testDebugUnitTest :app:assembleDebug :app:assembleRelease
+./gradlew detekt spotlessCheck :app:lintGithubDebug :app:testGithubDebugUnitTest :app:assembleGithubDebug :app:assembleGithubRelease
 ```
 
 Output APKs:
 
 ```text
-app/build/outputs/apk/debug/app-debug.apk
-app/build/outputs/apk/release/app-release-unsigned.apk
+app/build/outputs/apk/github/debug/app-github-debug.apk
+app/build/outputs/apk/github/release/app-github-release-unsigned.apk
 ```
 
 Install to device:
 
 ```bash
-adb install -r app/build/outputs/apk/debug/app-debug.apk
+adb install -r app/build/outputs/apk/github/debug/app-github-debug.apk
 ```
 
 ## Documentation

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,8 +8,20 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.devtools.ksp")
     id("androidx.baselineprofile")
-    id("com.google.gms.google-services")
-    id("com.google.firebase.crashlytics")
+    id("com.google.gms.google-services") apply false
+    id("com.google.firebase.crashlytics") apply false
+}
+
+// The fdroid flavor's dependencies already exclude Firebase (see the "githubImplementation"
+// entries below), but the google-services/crashlytics Gradle plugins process google-services.json
+// project-wide regardless of flavor, so they must be skipped outright rather than merely left off
+// a flavor's classpath. F-Droid's own build server builds with -Pandcode.fdroidBuild=true (see the
+// `gradleprops` field this project's future fdroiddata metadata will declare) to produce a build
+// with no Firebase/Google Play services code at all.
+val isFdroidBuild = providers.gradleProperty("andcode.fdroidBuild").orNull.toBoolean()
+if (!isFdroidBuild) {
+    apply(plugin = "com.google.gms.google-services")
+    apply(plugin = "com.google.firebase.crashlytics")
 }
 
 val repoRoot = rootProject.projectDir
@@ -113,6 +125,21 @@ android {
         }
     }
 
+    flavorDimensions += "distribution"
+    productFlavors {
+        // Distributed via GitHub Releases (and the self-hosted F-Droid repo built from those
+        // release APKs). Includes Firebase Analytics/Crashlytics.
+        create("github") {
+            dimension = "distribution"
+        }
+        // Built from source by F-Droid's own build server for the official F-Droid catalog.
+        // Firebase is excluded entirely; see the isFdroidBuild guard above and the
+        // "githubImplementation" dependencies below.
+        create("fdroid") {
+            dimension = "distribution"
+        }
+    }
+
     if (hasReleaseSigning) {
         signingConfigs {
             create("release") {
@@ -197,13 +224,14 @@ dependencies {
     // Core Android
     implementation("androidx.core:core-ktx:1.15.0")
 
-    // Firebase
+    // Firebase (github flavor only - the fdroid flavor ships with no Firebase/Google Play
+    // services code so it can be built from source by F-Droid's own build server).
     // 34.17.0 pulls Play Services Measurement compiled with Kotlin 2.2 metadata, while this
     // project is currently on Kotlin 2.0/KSP 2.0. Keep the Firebase stack on the compatible
     // 33.6 line until the Android build toolchain is upgraded together.
-    implementation(platform("com.google.firebase:firebase-bom:33.6.0"))
-    implementation("com.google.firebase:firebase-analytics")
-    implementation("com.google.firebase:firebase-crashlytics")
+    "githubImplementation"(platform("com.google.firebase:firebase-bom:33.6.0"))
+    "githubImplementation"("com.google.firebase:firebase-analytics")
+    "githubImplementation"("com.google.firebase:firebase-crashlytics")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-process:2.8.7")

--- a/app/src/fdroid/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporter.kt
+++ b/app/src/fdroid/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporter.kt
@@ -1,0 +1,25 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+import android.content.Context
+
+/**
+ * No-op stand-in for the `github` flavor's Firebase Analytics reporter.
+ *
+ * The F-Droid build excludes Firebase entirely (F-Droid's build server only compiles from source
+ * and does not accept proprietary Google Play services), so this flavor collects no usage
+ * analytics at all rather than sending them anywhere else.
+ */
+object AnalyticsReporter {
+    fun install(
+        context: Context,
+        enabled: Boolean = false,
+    ) = Unit
+
+    fun setEnabled(enabled: Boolean) = Unit
+
+    fun recordRuntimeSessionCompleted() = Unit
+
+    fun recordRuntimeSessionError() = Unit
+
+    fun recordRuntimeSessionStalled(reason: StallReason) = Unit
+}

--- a/app/src/fdroid/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporter.kt
+++ b/app/src/fdroid/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporter.kt
@@ -1,0 +1,20 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+/**
+ * No-op stand-in for the `github` flavor's Firebase Crashlytics reporter.
+ *
+ * The F-Droid build excludes Firebase entirely (F-Droid's build server only compiles from source
+ * and does not accept proprietary Google Play services), so this flavor reports crashes nowhere;
+ * they are only visible through the device's own logs.
+ */
+object CrashReporter {
+    fun install() = Unit
+
+    fun log(message: String) = Unit
+
+    fun recordException(
+        error: Throwable,
+        message: String? = null,
+        customKeys: Map<String, String> = emptyMap(),
+    ) = Unit
+}

--- a/app/src/github/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporter.kt
+++ b/app/src/github/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsReporter.kt
@@ -4,25 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 
-internal data class AnalyticsEvent(
-    val name: String,
-    val parameters: Map<String, String> = emptyMap(),
-)
-
-internal object AnalyticsEvents {
-    fun runtimeSessionCompleted(): AnalyticsEvent = AnalyticsEvent("runtime_session_completed")
-
-    fun runtimeSessionError(): AnalyticsEvent = AnalyticsEvent("runtime_session_error")
-
-    /**
-     * Records why a wedged run went quiet, so the common causes can be told apart. Only the reasons
-     * that leave a run stuck get here: a stall that turns out to be a finished or failed turn is
-     * settled as one, and counts as a completion or an error instead.
-     */
-    fun runtimeSessionStalled(reason: StallReason): AnalyticsEvent =
-        AnalyticsEvent("runtime_session_stalled", mapOf("reason" to reason.name))
-}
-
 /** Reports anonymous product-usage events while Firebase Analytics supplies automatic metrics. */
 object AnalyticsReporter {
     @Volatile

--- a/app/src/github/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporter.kt
+++ b/app/src/github/java/com/yugahashimoto/andcode/core/diagnostics/CrashReporter.kt
@@ -2,7 +2,6 @@ package com.yugahashimoto.andcode.core.diagnostics
 
 import android.os.Build
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import com.yugahashimoto.andcode.core.security.SecretRedaction
 
 /**
  * Best-effort bridge for non-fatal diagnostics.
@@ -12,10 +11,6 @@ import com.yugahashimoto.andcode.core.security.SecretRedaction
  * sanitization needed before sending messages and keys off-device.
  */
 object CrashReporter {
-    private const val MAX_LOG_CHARS = 1_000
-    private const val MAX_KEY_CHARS = 40
-    private const val MAX_VALUE_CHARS = 100
-
     @Volatile
     private var crashlytics: FirebaseCrashlytics? = null
 
@@ -59,13 +54,5 @@ object CrashReporter {
             }
             client.recordException(error)
         }
-    }
-
-    internal object CrashReportSanitizer {
-        fun message(value: String): String = SecretRedaction.redact(value.replace(Regex("\\s+"), " ").trim()).take(MAX_LOG_CHARS)
-
-        fun key(value: String): String = value.replace(Regex("[^A-Za-z0-9_]"), "_").take(MAX_KEY_CHARS).ifBlank { "key" }
-
-        fun value(value: String): String = message(value).take(MAX_VALUE_CHARS)
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsEvent.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/AnalyticsEvent.kt
@@ -1,0 +1,20 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+internal data class AnalyticsEvent(
+    val name: String,
+    val parameters: Map<String, String> = emptyMap(),
+)
+
+internal object AnalyticsEvents {
+    fun runtimeSessionCompleted(): AnalyticsEvent = AnalyticsEvent("runtime_session_completed")
+
+    fun runtimeSessionError(): AnalyticsEvent = AnalyticsEvent("runtime_session_error")
+
+    /**
+     * Records why a wedged run went quiet, so the common causes can be told apart. Only the reasons
+     * that leave a run stuck get here: a stall that turns out to be a finished or failed turn is
+     * settled as one, and counts as a completion or an error instead.
+     */
+    fun runtimeSessionStalled(reason: StallReason): AnalyticsEvent =
+        AnalyticsEvent("runtime_session_stalled", mapOf("reason" to reason.name))
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/CrashReportSanitizer.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/diagnostics/CrashReportSanitizer.kt
@@ -1,0 +1,15 @@
+package com.yugahashimoto.andcode.core.diagnostics
+
+import com.yugahashimoto.andcode.core.security.SecretRedaction
+
+internal object CrashReportSanitizer {
+    private const val MAX_LOG_CHARS = 1_000
+    private const val MAX_KEY_CHARS = 40
+    private const val MAX_VALUE_CHARS = 100
+
+    fun message(value: String): String = SecretRedaction.redact(value.replace(Regex("\\s+"), " ").trim()).take(MAX_LOG_CHARS)
+
+    fun key(value: String): String = value.replace(Regex("[^A-Za-z0-9_]"), "_").take(MAX_KEY_CHARS).ifBlank { "key" }
+
+    fun value(value: String): String = message(value).take(MAX_VALUE_CHARS)
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/core/diagnostics/CrashReportSanitizerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/core/diagnostics/CrashReportSanitizerTest.kt
@@ -3,20 +3,20 @@ package com.yugahashimoto.andcode.core.diagnostics
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class CrashReporterTest {
+class CrashReportSanitizerTest {
     @Test
     fun `sanitizer collapses whitespace and caps log size`() {
         val input = "  first\n\tsecond  " + "x".repeat(1_100)
 
-        val sanitized = CrashReporter.CrashReportSanitizer.message(input)
+        val sanitized = CrashReportSanitizer.message(input)
 
         assertEquals(("first second " + "x".repeat(1_100)).take(1_000), sanitized)
     }
 
     @Test
     fun `sanitizer makes custom keys safe and caps values`() {
-        assertEquals("runtime_error_code", CrashReporter.CrashReportSanitizer.key("runtime.error-code"))
-        assertEquals("value", CrashReporter.CrashReportSanitizer.value(" value "))
-        assertEquals(100, CrashReporter.CrashReportSanitizer.value("x".repeat(200)).length)
+        assertEquals("runtime_error_code", CrashReportSanitizer.key("runtime.error-code"))
+        assertEquals("value", CrashReportSanitizer.value(" value "))
+        assertEquals(100, CrashReportSanitizer.value("x".repeat(200)).length)
     }
 }

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -13,6 +13,9 @@ android {
         targetSdk = 35
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // :app now has a "distribution" flavor dimension (github/fdroid); baseline profiles are
+        // only generated against the github flavor.
+        missingDimensionStrategy("distribution", "github")
     }
 
     buildTypes {

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -27,15 +27,15 @@ ANDROID_CODE_KEY_PASSWORD=...
 3. Optional: wire `signingConfigs` in `app/build.gradle.kts` reading those properties, then:
 
 ```bash
-./gradlew assembleRelease
+./gradlew assembleGithubRelease
 # or
-./gradlew bundleRelease
+./gradlew bundleGithubRelease
 ```
 
 4. Verify:
 
 ```bash
-apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk
+apksigner verify --print-certs app/build/outputs/apk/github/release/app-github-release.apk
 ```
 
 ## Versioning
@@ -46,7 +46,7 @@ apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk
 
 ## Pre-release checklist
 
-- [ ] `./gradlew testDebugUnitTest lintDebug assembleRelease`
+- [ ] `./gradlew testGithubDebugUnitTest lintGithubDebug assembleGithubRelease`
 - [ ] Manual smoke: local install, chat, permission approve/reject, remote connect
 - [ ] `THIRD_PARTY_NOTICES.md` still accurate
 - [ ] No secrets in git history
@@ -91,3 +91,67 @@ https://yuga-hashimoto.github.io/and-code/fdroid/repo/
 ```
 
 The workflow retains the latest 100 non-draft, non-prerelease GitHub releases.
+
+## Official F-Droid catalog (build-from-source)
+
+The self-hosted repository above only republishes the GitHub-signed APK; it does
+not put AndCode in the official F-Droid catalog (browsable by category, e.g.
+"AI Chat"). That requires F-Droid's own build server to compile the app from
+source, which does not accept Firebase/Google Play services.
+
+The `app` module has a `distribution` flavor dimension for this:
+
+- `github` — current behavior, includes Firebase Analytics/Crashlytics.
+- `fdroid` — no Firebase code at all (`app/src/fdroid/.../diagnostics/`
+  provides no-op `AnalyticsReporter`/`CrashReporter` in place of
+  `app/src/github/.../diagnostics/`, which keeps the Firebase-backed ones).
+
+Build it locally with:
+
+```bash
+./gradlew -Pandcode.fdroidBuild=true :app:assembleFdroidRelease
+```
+
+The `-Pandcode.fdroidBuild=true` property additionally skips applying the
+`com.google.gms.google-services` / `com.google.firebase.crashlytics` Gradle
+plugins outright (they process `google-services.json` project-wide regardless
+of flavor, so leaving them applied would still embed inert Google project
+identifiers in the fdroid build).
+
+Submitting to the official catalog means opening a merge request against
+[fdroiddata](https://gitlab.com/fdroid/fdroiddata) with metadata resembling:
+
+```yaml
+Categories:
+  - AI Chat
+License: MIT
+SourceCode: https://github.com/yuga-hashimoto/and-code
+IssueTracker: https://github.com/yuga-hashimoto/and-code/issues
+Changelog: https://github.com/yuga-hashimoto/and-code/releases
+
+Builds:
+  - versionName: "1.2.16"
+    versionCode: 55
+    commit: v1.2.16
+    subdir: app
+    gradle:
+      - fdroid
+    gradleprops:
+      - andcode.fdroidBuild=true
+    # google-services/firebase-crashlytics still appear (apply false) in
+    # app/build.gradle.kts for the github flavor; allowlist those known-safe
+    # lines rather than have the scanner flag them.
+    scanignore:
+      - app/build.gradle.kts
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+CurrentVersion: "1.2.16"
+CurrentVersionCode: 55
+```
+
+This has not been submitted yet — it needs a real F-Droid build server dry run
+(`fdroid build --test`) to confirm the recipe actually compiles before opening
+the merge request, and a decision on whether any remaining dependency (e.g.
+the Vosk speech model, downloaded on first use rather than bundled) needs an
+`AntiFeature` tag.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -125,6 +125,8 @@ Submitting to the official catalog means opening a merge request against
 Categories:
   - AI Chat
 License: MIT
+RepoType: git
+Repo: https://github.com/yuga-hashimoto/and-code
 SourceCode: https://github.com/yuga-hashimoto/and-code
 IssueTracker: https://github.com/yuga-hashimoto/and-code/issues
 Changelog: https://github.com/yuga-hashimoto/and-code/releases
@@ -138,10 +140,11 @@ Builds:
       - fdroid
     gradleprops:
       - andcode.fdroidBuild=true
-    # google-services/firebase-crashlytics still appear (apply false) in
-    # app/build.gradle.kts for the github flavor; allowlist those known-safe
-    # lines rather than have the scanner flag them.
+    # google-services/firebase-crashlytics still appear (apply false) in both
+    # build.gradle.kts files; allowlist those known-safe lines rather than
+    # have the scanner flag them.
     scanignore:
+      - build.gradle.kts
       - app/build.gradle.kts
 
 AutoUpdateMode: Version
@@ -150,8 +153,23 @@ CurrentVersion: "1.2.16"
 CurrentVersionCode: 55
 ```
 
-This has not been submitted yet — it needs a real F-Droid build server dry run
-(`fdroid build --test`) to confirm the recipe actually compiles before opening
-the merge request, and a decision on whether any remaining dependency (e.g.
-the Vosk speech model, downloaded on first use rather than bundled) needs an
-`AntiFeature` tag.
+This recipe was dry-run locally with `fdroid build --test` (pip-installed
+`fdroidserver`, no Docker/buildserver VM available) against this repo's actual
+`fdroid` flavor and confirmed to work end-to-end: clone at a pinned commit,
+`clean`, source scan, and `assembleFdroidRelease` all succeeded, producing an
+APK whose embedded versionName/versionCode matched the metadata. Both
+`Repo`/`RepoType` and the two-line `scanignore` above were only discovered as
+necessary through that dry run (without them, the build never even reaches the
+Gradle step). It has not been submitted as a merge request yet — remaining
+before that:
+
+- decide whether any remaining dependency (e.g. the Vosk speech model,
+  downloaded on first use from alphacephei.com rather than bundled — the
+  models themselves are Apache-2.0, so this is likely not an `AntiFeature`,
+  but F-Droid reviewers may still ask about it) needs an `AntiFeature` tag
+- decide how to describe the GitHub OAuth sign-in dependency, since GitHub
+  itself is a non-free network service (used for optional sign-in, not core
+  functionality, so likely not `NonFreeNet`, but again a reviewer question)
+- a real dry run against F-Droid's actual buildserver (`fdroid build --test
+  --server`), which needs the Debian/Docker buildserver image this sandbox
+  does not have


### PR DESCRIPTION
## Summary

- Splits `:app` into `github` (current behavior, Firebase Analytics/Crashlytics) and `fdroid` (no Firebase/Google Play services code at all) product flavors.
- This is a prerequisite for listing on the **official F-Droid catalog** (issue #267 asks specifically for the "AI Chat" category there). The existing self-hosted repository (`.github/workflows/fdroid-repository.yml`, added in #281/#282) only republishes GitHub-signed APKs and is explicitly documented as *not* an official F-Droid submission.
- `-Pandcode.fdroidBuild=true` additionally skips applying the `com.google.gms.google-services` / `com.google.firebase.crashlytics` Gradle plugins entirely, since they process `google-services.json` project-wide regardless of flavor.
- Extracted `AnalyticsEvent`/`CrashReportSanitizer` (pure, no Firebase dependency) into shared files so only the thin Firebase-calling wrapper differs per flavor.
- Updated the 3 CI workflows and README/CONTRIBUTING for the new flavor-scoped Gradle task names (`assembleGithubRelease` etc.) and APK output paths.
- Documented the planned fdroiddata `Build:` metadata (gradle flavor, gradleprops, scanignore) in `docs/RELEASE.md` for the eventual official submission.

## Verified locally (JDK 17 + Android SDK, no CI needed to confirm this)

- `:app:compileGithubDebugKotlin` / `:app:compileFdroidDebugKotlin` — both succeed
- `:app:testGithubDebugUnitTest` / `:app:testFdroidDebugUnitTest` — same pass/fail set on both flavors (2 pre-existing, environment-related `AntigravityInstallerTest` failures unrelated to this change — a disk-space check failing in this sandbox)
- `:app:assembleGithubDebug` / `:app:assembleFdroidDebug` and the `Release` R8-minified variants of both — all succeed
- Confirmed via `unzip -l` that the `fdroid` flavor APK contains **zero** `firebase`/`com/google/android/gms` classes, while the `github` flavor APK still does
- `:benchmark:tasks` configures cleanly against the new `distribution` flavor dimension (added `missingDimensionStrategy`)

## Test plan

- [ ] CI (android.yml) passes on this PR
- [ ] `release.yml` still produces `and-code-<tag>-release.apk` correctly on the next tagged release
- [ ] Follow-up: dry-run the drafted fdroiddata `Build:` recipe with `fdroid build --test`
- [ ] Follow-up: decide on any F-Droid `AntiFeature` tags (e.g. the Vosk speech model download) before submitting the fdroiddata merge request