### PR TITLE
fix(api): archive OpenCode sessions through time.archived, filter them from lists

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClient.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClient.kt
@@ -58,7 +58,13 @@ class OpenCodeApiClient(
 
     suspend fun health(): OpenCodeHealth = get("global/health")
 
-    suspend fun sessions(directory: String? = null): List<OpenCodeSession> = getList("session", query("directory" to directory))
+    /**
+     * Active (non-archived) sessions. The server keeps archived sessions in `GET /session`
+     * forever — its only archive marker is `time.archived` on each entry — so the filter lives
+     * here; every chat list the app shows is fed from this one method.
+     */
+    suspend fun sessions(directory: String? = null): List<OpenCodeSession> =
+        getList<OpenCodeSession>("session", query("directory" to directory)).filter { it.time.archived == null }
 
     suspend fun session(sessionId: String): OpenCodeSession = get("session/${encodePath(sessionId)}")
 
@@ -324,11 +330,20 @@ class OpenCodeApiClient(
             query("directory" to directory),
         )
 
+    /**
+     * Archives a session: `PATCH /session/{id}` takes `{"time": {"archived": <epoch ms>}}` per
+     * the server's own schema. A bare `{"archive": true}` used to be sent here — the server
+     * silently ignores that unknown key, so the call returned 200, archived nothing, and the
+     * auto-archive settings never moved a single OpenCode chat out of the drawer.
+     */
     suspend fun archiveSession(
         sessionId: String,
         directory: String? = null,
     ): OpenCodeSession {
-        val body = buildJsonObject { put("archive", true) }
+        val body =
+            buildJsonObject {
+                put("time", buildJsonObject { put("archived", System.currentTimeMillis()) })
+            }
         return patch(
             "session/${encodePath(sessionId)}",
             body,

--- a/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/api/OpenCodeApiModels.kt
@@ -16,6 +16,12 @@ data class OpenCodeTime(
     val created: Long = 0L,
     val updated: Long? = null,
     val completed: Long? = null,
+    /**
+     * Epoch ms when the session was archived, or null while it is active. The server's
+     * `GET /session` keeps returning archived sessions, so this field is what tells them apart —
+     * the app hides them everywhere a chat list is shown.
+     */
+    val archived: Long? = null,
 )
 
 @Serializable

--- a/app/src/test/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClientTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/core/api/OpenCodeApiClientTest.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -68,6 +69,40 @@ class OpenCodeApiClientTest {
             val createRequest = server.takeRequest()
             assertEquals("/session?directory=%2Frepo%20with%20space", createRequest.path)
             assertEquals("New", Json.parseToJsonElement(createRequest.body.readUtf8()).jsonObject["title"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `session list hides archived sessions`() =
+        runBlocking {
+            server.enqueue(
+                MockResponse().setBody(
+                    """[{"id":"s1","title":"Active","time":{"created":1,"updated":2}},""" +
+                        """{"id":"s2","title":"Archived","time":{"created":3,"updated":4,"archived":5}}]""",
+                ),
+            )
+            val client = client()
+
+            val sessions = client.sessions()
+
+            assertEquals(listOf("s1"), sessions.map { it.id })
+        }
+
+    @Test
+    fun `archiving marks time archived instead of the ignored archive flag`() =
+        runBlocking {
+            server.enqueue(MockResponse().setBody("""{"id":"s1","title":"Old","time":{"created":1,"updated":2,"archived":9}}"""))
+            val client = client()
+
+            val archived = client.archiveSession("s1")
+
+            assertEquals(9L, archived.time.archived)
+            val request = server.takeRequest()
+            assertEquals("/session/s1", request.path)
+            assertEquals("PATCH", request.method)
+            val body = Json.parseToJsonElement(request.body.readUtf8()).jsonObject
+            val archivedAt = body["time"]!!.jsonObject["archived"]!!.jsonPrimitive.long
+            assertTrue("archived timestamp should be now-ish", archivedAt > 0)
+            assertTrue("the bare archive flag the server ignores must be gone", body["archive"] == null)
         }
 
     @Test


### PR DESCRIPTION
<!-- pre-pr-review: approved -->
## Pre-PR review

判定： APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- `app/src/main/java/com/yugahashimoto/andcode/runtime/OpenCodeBackend.kt:52` — `session()` のデフォルト実装は `listSessions().firstOrNull { ... }` で解決するため、アーカイブが実際に機能するようになった今、将来このデフォルトに依存するバックエンドはアーカイブ済みセッションを解決できなくなる。現行の全バックエンド（`RemoteOpenCodeBackend` / `LocalOpenCodeBackend` はいずれもフィルタ無しの直接エンドポイントに override 済み）では問題ないが、デフォルト実装にその旨のコメントかフォールバックを足しておくと安全。
- `app/src/main/java/com/yugahashimoto/andcode/runtime/remote/RemoteRuntimeTarget.kt:80-85` — `listWorkspaces()` は `listSessions()`（アーカイブ済みを除外）と `listProjects()` のマージ。`listProjects()` が失敗した古いサーバーでは「チャットが全てアーカイブ済みのワークスペース」がピッカーから消える。Antigravity 側は明示的にアーカイブ済みを含めてワークスペースを維持している（`AntigravityRuntime.kt:364`）ので、同じ保証が OpenCode でも要るならマージ対象への含め戻しを検討。

## チェック済み項目
- **diff 全 hunks 精読**（3ファイル、+58/−2。`origin/main...HEAD` は単一コミット `fc1b36a`）
- **PATCH body の正しさ**： `{"time": {"archived": <ms>}}` を `kotlinx.serialization.json.put`（Number オーバーロード）で構築。`archive` キーが残っていないことを新テストが検証
- **クライアント側フィルタ**： `sessions()` に `time.archived == null` フィルタ。呼び出し元を全数確認 — `RemoteOpenCodeBackend.listSessions` → `RuntimeCatalogRepository`（ドロワー、`SessionAutoArchiver`、ウィジェット/スケジュール経由の集約）の全リストがこの経路で、`RemoteRuntimeTarget`/`LocalRuntimeTarget` も同経由
- **アーカイブ済みセッションの再解決**： `RemoteOpenCodeBackend.session()` / `LocalOpenCodeBackend.delegate().session()` はフィルタ無しの `GET /session/{id}` を叩くため、ディープリンクや `ChatViewModel` の復元がアーカイブ済みでも機能することを確認
- **`OpenCodeTime` へのフィールド追加**： 末尾追加 + デフォルト値で、既存の位置引数コンストラクト（8 箇所）と全テストフィクスチャに影響なし。`defaultJson` の `ignoreUnknownKeys`/`encodeDefaults` により旧サーバー応答との後方互換も維持
- **自動アーカイバとの整合**： `SessionAutoArchiver` は `alreadyArchived` ガード + `refreshAllSessions()` 前提だが、実際にアーカイブが効けばリストから落ちるため二重送信は発生しない
- **i18n**: ユーザー可視文字列の追加なし。**シークレット**: なし

## Problem

The auto-archive settings never moved a single OpenCode chat out of the drawer. Verified against
a live opencode 1.18.21 server (the kind this app runs on-device), two server facts made the old
call a silent no-op:

1. `PATCH /session/{id}` takes `{"time": {"archived": <epoch ms>}}` per its own OpenAPI schema.
   The bare `{"archive": true}` the client sent is an unknown key the server ignores — the call
   returned 200 and archived nothing.
2. `GET /session` keeps returning archived sessions forever, so even a correctly archived chat
   must be filtered client-side.

## Fix

- `archiveSession` stamps `time.archived` with the current epoch ms, exactly per the schema.
- `OpenCodeTime` gains an `archived: Long?` field (backwards compatible).
- `sessions()` hides sessions carrying the marker; every chat list the app shows (drawer,
  auto-archiver, workspace pickers) is fed from this one method, while `session(id)` still
  resolves archived chats for deep links.

## Verification

- Against the live server: `PATCH` with `time.archived` sets the marker; `GET /session` still
  returns it, confirming the client-side filter is required.
- `detekt spotlessCheck :app:testDebugUnitTest` — all PASS (includes 2 new MockWebServer tests:
  archived sessions hidden from lists; PATCH body shape with no `archive` flag).
- repo-reviewer pre-PR review: APPROVE (report above).
