### PR TITLE
fix(runtime): add network retry hint to package install failures

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstaller.kt
@@ -329,7 +329,7 @@ object ClaudeCodeInstaller {
         if (!process.waitFor(timeoutMinutes, TimeUnit.MINUTES)) {
             process.destroyForcibly()
             process.waitFor(5, TimeUnit.SECONDS)
-            error("Claude Code package operation timed out after $timeoutMinutes minutes")
+            error("Claude Code package operation timed out after $timeoutMinutes minutes. $PACKAGE_INSTALL_RETRY_HINT")
         }
         return process.exitValue()
     }
@@ -378,6 +378,11 @@ object ClaudeCodeInstaller {
             append(exitCode)
             append("): ")
             append(primary)
+            // On its own line right after the primary error: the errors block and the log head and
+            // tail that follow run to thousands of characters, and a hint buried under them is
+            // never read (issue #290).
+            append('\n')
+            append(PACKAGE_INSTALL_RETRY_HINT)
             if (errors.isNotBlank()) {
                 append('\n')
                 append(errors)

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/DebianRootfsInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/DebianRootfsInstaller.kt
@@ -166,10 +166,13 @@ class DebianRootfsInstaller(
         val completed = process.waitFor(10, java.util.concurrent.TimeUnit.MINUTES)
         if (!completed) {
             process.destroyForcibly()
-            error("Debian development tool installation timed out")
+            error("Debian development tool installation timed out. $PACKAGE_INSTALL_RETRY_HINT")
         }
         require(process.exitValue() == 0) {
-            "Unable to install Debian development tools: ${installLog.readText().takeLast(4000)}"
+            // Same shape as LocalRuntimeInstaller: hint before the log tail, which is the only part
+            // long enough to push it out of view.
+            "Unable to install Debian development tools. $PACKAGE_INSTALL_RETRY_HINT\n\n" +
+                "Last log lines:\n${installLog.readText().takeLast(4000)}"
         }
         installGitHubCli(rootfs, suite, prootTmp)
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
@@ -406,10 +406,13 @@ class LocalRuntimeInstaller(
         val completed = process.waitFor(15, java.util.concurrent.TimeUnit.MINUTES)
         if (!completed) {
             process.destroyForcibly()
-            error("Development tool installation timed out")
+            error("Development tool installation timed out. $PACKAGE_INSTALL_RETRY_HINT")
         }
         require(process.exitValue() == 0) {
-            "Unable to install Git and development tools: ${installLog.readText().takeLast(4000)}"
+            // The hint sits between the headline and the raw log, or a 4000-character tail scrolls
+            // it off the screen the error is read on.
+            "Unable to install Git and development tools. $PACKAGE_INSTALL_RETRY_HINT\n\n" +
+                "Last log lines:\n${installLog.readText().takeLast(4000)}"
         }
     }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/PackageInstallRetryHint.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/PackageInstallRetryHint.kt
@@ -1,0 +1,12 @@
+package com.yugahashimoto.andcode.runtime.local
+
+/**
+ * Appended to package-installation failures, where the log alone cannot say whose fault it was.
+ *
+ * A user on a slow or flaky connection reads `1 error; 1435.7 MiB in 257 packages` as a broken
+ * build, deletes the app and moves on, when retrying on a stable network very often succeeds
+ * (issue #290). The installers share one wording so the advice reads the same whichever agent's
+ * card showed the failure.
+ */
+internal const val PACKAGE_INSTALL_RETRY_HINT =
+    "This is often just a network timeout - retrying the installation on a stable connection usually succeeds."

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
@@ -83,6 +83,21 @@ class ClaudeCodeInstallerTest {
     }
 
     @Test
+    fun `failureMessage carries the network retry hint before the log dump`() {
+        // Issue #290: the raw apk summary reads like a broken build when it is usually just a
+        // timed-out download, and a hint buried under the log tail is never read.
+        val log =
+            File.createTempFile("claude-install-hint", ".log").apply {
+                deleteOnExit()
+                writeText("1 error; 1435.7 MiB in 257 packages\n")
+            }
+        val message = ClaudeCodeInstaller.failureMessage("installation", 1, log)
+        val lines = message.lineSequence().toList()
+        assertTrue(lines[1].contains(PACKAGE_INSTALL_RETRY_HINT))
+        assertTrue(lines.indexOfFirst { it.contains("--- log tail ---") } > 1)
+    }
+
+    @Test
     fun `assembled scripts abort on the first failure and end with the package work`() {
         listOf(ClaudeCodeInstaller.INSTALL_SCRIPT, ClaudeCodeInstaller.UPDATE_SCRIPT).forEach { script ->
             assertEquals("set -e", script.lineSequence().first())

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeInstallerTest.kt
@@ -93,8 +93,11 @@ class ClaudeCodeInstallerTest {
             }
         val message = ClaudeCodeInstaller.failureMessage("installation", 1, log)
         val lines = message.lineSequence().toList()
-        assertTrue(lines[1].contains(PACKAGE_INSTALL_RETRY_HINT))
-        assertTrue(lines.indexOfFirst { it.contains("--- log tail ---") } > 1)
+        assertTrue(lines.indexOfFirst { it.contains(PACKAGE_INSTALL_RETRY_HINT) } > 0)
+        assertTrue(
+            lines.indexOfFirst { it.contains(PACKAGE_INSTALL_RETRY_HINT) } <
+                lines.indexOfFirst { it.contains("--- log tail ---") },
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #290.

A failed package install (apk/apt) on a slow or flaky connection reads like a broken build — the reporter saw `Unable to install Git and development tools ... 1 error; 1435.7 MiB in 257 packages` at ~27 KB/s, gave up, and only later discovered a retry on stable Wi-Fi just works. This adds the hint the issue asked for: **"This is often just a network timeout - retrying the installation on a stable connection usually succeeds."**

- New shared `PACKAGE_INSTALL_RETRY_HINT` constant so the advice reads the same wherever an install fails.
- Applied to every fatal package-install path: the shared Alpine tool install (timeout + non-zero exit), the Debian tool install (same), and Claude Code package operations (`failureMessage` + timeout).
- The hint sits on its own line **before** the log dump (which runs to thousands of characters) so it is actually read.
- No resource changes: runtime-layer exception messages stay English, matching the existing convention for diagnostics that embed raw logs.

## Test plan

- New test: `failureMessage carries the network retry hint before the log dump` asserts the hint appears before the `--- log tail ---` marker; existing `failureMessage` tests still pass unchanged.
- `./gradlew detekt spotlessCheck :app:testGithubDebugUnitTest` all pass locally.

<!-- pre-pr-review: approved -->
## Pre-PR review

判定： APPROVE

### ブロッカー
- なし

### 提案（非ブロッキング）
- `app/src/test/.../ClaudeCodeInstallerTest.kt:97` — `lines.indexOfFirst { it.contains("--- log tail ---") } > 1` は単独では順序保証が弱く（ヒントがログ末尾以降にあっても成立する）、順序の実保証は実質 `lines[1]` 側のアサーションが担っています。`assertTrue(lines.indexOfFirst { it.contains(PACKAGE_INSTALL_RETRY_HINT) } < lines.indexOfFirst { it.contains("--- log tail ---") })` のように「ヒント行 < ログマーカー行」を直接書くと、テスト名の意図がコードにそのまま反映されます。現状でも仕様は検証できているのでマージ可です。 → **適用済み**（e1d46b8）。
- `DebianRootfsInstaller.kt:234` — `installGitHubCli` の `apt-get install gh` 失敗は non-fatal ログのみでヒント対象外ですが、issue #290 のスコープ（パッケージインストール失敗時のユーザー離脱防止）を広げるなら将来対象にできます。今回は fatal パスのみの対応で一貫しており問題ありません。 → 将来課題として記録。

### チェック済み項目
- **スコープとブランチ規約**: `git diff origin/main...fix/bootstrap-error-retry-hint` を全文読了（5ファイル、+43/−5）。origin/main (6551a03) 直上の単一コミットで、スクリプト由来のワークツリー（`.worktree/fix/bootstrap-error-retry-hint`）で管理されていることを確認。作業ツリーはクリーン。
- **テストの実値検証**: `failureMessage` の実装を精読し、`primary` が `lineSequence().firstOrNull()` により常に単一行であること（→ ヒント行が必ず2行目になる）を確認。テスト用ログでの `extractApkErrors` → サマリ行が primary に落ちる経路も追跡し、アサーションと log tail マーカー位置が実値で成立することを確認。既存2つの `failureMessage` テストは1行目のみ検証しており、追記された2行目以降の影響を受けないことも確認。
- **メッセージ変更の影響範囲**: 旧文言（`Unable to install ...:` / 各タイムアウト文）をテスト・実装がパースしている箇所を grep で全数確認し、依存なし。`ChatErrorPresentation.classifyChatError` が "timeout"/"timed out" を部分一致で分類するため、ヒント文言の "network timeout" が誤分類しないか調査 → `classifyChatError` はチャット送信系の `state.error` のみに入力され、チャット機能はインストーラを呼ばないため影響なし。
- **静的解析**: 変更行はすべて detekt `maxLineLength: 140` 以内。トップレベル `const val` のアンダースコア命名は `Routes.kt` 等の CI 通過済み定数と同一形状。`internal` 可視性は同モジュールのユニットテストから到達可能。
- **i18n**: リソース変更なし。ランタイム層の例外メッセージを英語のままとするのは同ファイル群の既存規約（診断・ログ系は英語）に一致。
- **その他**: シークレット無し、不要なリファクタ無し、`error()`/`require()` の例外型変更なし。

問題の把握（issue #290 の意図）、ヒント配置の設計（ログダンプ前への独立行配置）、KDoc の説明品質、いずれも良好です。このまま PR を作成して問題ありません。