### PR TITLE
fix(runtime): make full development tools optional and resumable

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/AndCodeApplication.kt
@@ -344,6 +344,7 @@ class AndCodeApplication : Application() {
                 statusProvider = localRuntimeManager::status,
                 processMetricsProvider = launcher::metrics,
                 commandExecutor = commandRunner::run,
+                fullDevelopmentToolsInstalledProvider = localRuntimeManager::fullDevelopmentToolsInstalled,
                 messages = runtimeMessages,
             )
         localRuntimeController = LocalRuntimeServiceController(this)

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
@@ -75,7 +75,13 @@ import com.yugahashimoto.andcode.runtime.local.ClaudePermissionMode
 import com.yugahashimoto.andcode.ui.theme.AndCodeTheme
 import kotlinx.coroutines.delay
 
-private const val TOTAL_STEPS = 4
+private const val TOTAL_STEPS = 5
+
+internal fun shouldStartRuntimeInstall(
+    installComplete: Boolean,
+    installFullDevelopmentTools: Boolean,
+    fullDevelopmentToolsInstalled: Boolean = false,
+): Boolean = !installComplete || (installFullDevelopmentTools && !fullDevelopmentToolsInstalled)
 
 /**
  * Guided setup: choose agents, install them, sign in, then connect GitHub.
@@ -89,7 +95,9 @@ fun AndroidSetupScreen(
     runtimeStatus: LocalRuntimeStatus,
     claude: ClaudeCodeUiState,
     antigravity: AntigravityControllerState = AntigravityControllerState(),
-    onStartSetup: (Set<LocalAgent>) -> Unit,
+    fullDevelopmentToolsInstalled: Boolean = false,
+    fullDevelopmentToolsInstallFailed: Boolean = false,
+    onStartSetup: (Set<LocalAgent>, Boolean) -> Unit,
     onSelectClaudePermissionMode: (ClaudePermissionMode) -> Unit,
     onBeginClaudeSignIn: () -> Unit,
     onSubmitClaudeSignInCode: (String) -> Unit,
@@ -140,8 +148,7 @@ fun AndroidSetupScreen(
     val antigravitySelected = LocalAgent.ANTIGRAVITY in selectedAgents
     val openCodeReady = runtimeStatus is LocalRuntimeStatus.Ready || runtimeStatus is LocalRuntimeStatus.Stopped
     val antigravityReady = antigravitySelected && antigravity.installed && !antigravity.busy
-    val installComplete = (!openCodeSelected || openCodeReady) && (!claudeSelected || claude.installed) && (!antigravitySelected || antigravityReady)
-
+    val claudeReady = claude.installed && claude.install !is ClaudeInstallStatus.Installing && claude.install !is ClaudeInstallStatus.Failed
     // Only what is selected *and* actually on the device: an agent whose binary is missing has no
     // sign-in to offer, and Claude Code's card would shell out to /usr/bin/claude and fail there.
     // OpenCode, Claude Code, Antigravity - the same order the picker lists them in, so the guide
@@ -156,6 +163,36 @@ fun AndroidSetupScreen(
     val signInAgent = signInAgents.getOrNull(signInIndex.coerceAtMost(signInAgents.lastIndex.coerceAtLeast(0)))
 
     var currentStep by rememberSaveable { mutableIntStateOf(1) }
+    var installFullDevelopmentTools by rememberSaveable { mutableStateOf(false) }
+    var fullToolsInstallPending by rememberSaveable { mutableStateOf(false) }
+    var fullToolsInstallObserved by rememberSaveable { mutableStateOf(false) }
+    val packageInstallRunning =
+        runtimeStatus is LocalRuntimeStatus.Installing ||
+            claude.install is ClaudeInstallStatus.Installing ||
+            antigravity.busy
+    val fullToolsReady = !installFullDevelopmentTools || fullDevelopmentToolsInstalled
+    val agentsInstallComplete =
+        (!openCodeSelected || openCodeReady) &&
+            (!claudeSelected || claudeReady) &&
+            (!antigravitySelected || antigravityReady) &&
+            fullToolsReady
+    val installComplete = agentsInstallComplete && !fullToolsInstallPending
+
+    LaunchedEffect(packageInstallRunning, fullToolsInstallPending, agentsInstallComplete, fullDevelopmentToolsInstallFailed) {
+        if (!fullToolsInstallPending) return@LaunchedEffect
+        if (fullDevelopmentToolsInstallFailed) {
+            fullToolsInstallPending = false
+            fullToolsInstallObserved = false
+            currentStep = 3
+        } else {
+            if (packageInstallRunning) fullToolsInstallObserved = true
+            if (fullToolsInstallObserved && !packageInstallRunning && agentsInstallComplete) {
+                fullToolsInstallPending = false
+                fullToolsInstallObserved = false
+                currentStep = 3
+            }
+        }
+    }
 
     // One install provisions every selected agent, so the guide no longer chains a second and third
     // install off this screen once the first finishes. It used to, and that made the outcome depend
@@ -167,10 +204,6 @@ fun AndroidSetupScreen(
         if (!openCodeReady) return@LaunchedEffect
         if (claudeSelected) onRefreshClaudeState()
         if (antigravitySelected) onRefreshAntigravityState()
-    }
-
-    LaunchedEffect(installComplete) {
-        if (installComplete && currentStep == 2) currentStep = 3
     }
 
     LaunchedEffect(openCodeReady, openCodeSelected, settingsState.availableProviders, settingsState.providerAuthMethods) {
@@ -189,15 +222,38 @@ fun AndroidSetupScreen(
                     enabled = selectedAgents.isNotEmpty(),
                     onClick = {
                         currentStep = 2
-                        if (!installComplete) onStartSetup(selectedAgents)
                     },
                 )
             2 ->
+                SetupPrimaryAction(stringResource(R.string.setup_next_action), !fullToolsInstallPending) {
+                    if (
+                        shouldStartRuntimeInstall(
+                            agentsInstallComplete,
+                            installFullDevelopmentTools,
+                            fullDevelopmentToolsInstalled,
+                        )
+                    ) {
+                        if (installFullDevelopmentTools) fullToolsInstallPending = true
+                        onStartSetup(selectedAgents, installFullDevelopmentTools)
+                        if (!installFullDevelopmentTools) currentStep = 3
+                    } else {
+                        currentStep = 3
+                    }
+                }
+            3 ->
                 if (installComplete) {
-                    SetupPrimaryAction(stringResource(R.string.setup_next_action), true) { currentStep = 3 }
-                } else if (runtimeStatus is LocalRuntimeStatus.Broken || claude.install is ClaudeInstallStatus.Failed || antigravity.error != null) {
+                    SetupPrimaryAction(stringResource(R.string.setup_next_action), true) { currentStep = 4 }
+                } else if (
+                    runtimeStatus is LocalRuntimeStatus.Broken ||
+                    claude.install is ClaudeInstallStatus.Failed ||
+                    antigravity.error != null ||
+                    fullDevelopmentToolsInstallFailed
+                ) {
                     SetupPrimaryAction(stringResource(R.string.claude_retry_install_button), true) {
-                        onStartSetup(if (antigravity.error != null) setOf(LocalAgent.ANTIGRAVITY) else selectedAgents)
+                        onStartSetup(
+                            if (antigravity.error != null) setOf(LocalAgent.ANTIGRAVITY) else selectedAgents,
+                            installFullDevelopmentTools,
+                        )
                     }
                 } else {
                     null
@@ -205,9 +261,9 @@ fun AndroidSetupScreen(
             // "Next" walks the sign-in tabs before it leaves the step, so signing in to three
             // agents is three taps of one button rather than a hunt for the chip the user has not
             // visited yet.
-            3 ->
+            4 ->
                 SetupPrimaryAction(stringResource(R.string.setup_next_action), true) {
-                    if (signInIndex < signInAgents.lastIndex) signInIndex++ else currentStep = 4
+                    if (signInIndex < signInAgents.lastIndex) signInIndex++ else currentStep = 5
                 }
             else -> SetupPrimaryAction(stringResource(R.string.setup_complete_button), true, onFinish)
         }
@@ -246,7 +302,7 @@ fun AndroidSetupScreen(
             SetupBottomBar(
                 currentStep = currentStep,
                 primaryAction = primaryAction,
-                onSkip = if (currentStep >= 3) onFinish else null,
+                onSkip = if (currentStep >= 4) onFinish else null,
                 onBackStep = { currentStep -= 1 },
             )
         },
@@ -271,6 +327,12 @@ fun AndroidSetupScreen(
                         },
                     )
                 2 ->
+                    DevelopmentToolsStep(
+                        installFullDevelopmentTools = installFullDevelopmentTools,
+                        installPending = fullToolsInstallPending,
+                        onInstallFullDevelopmentToolsChanged = { installFullDevelopmentTools = it },
+                    )
+                3 ->
                     RuntimeDownloadStep(
                         runtimeStatus = runtimeStatus,
                         claude = claude,
@@ -279,7 +341,7 @@ fun AndroidSetupScreen(
                         claudeSelected = claudeSelected,
                         antigravitySelected = antigravitySelected,
                     )
-                3 ->
+                4 ->
                     SignInStep(
                         agents = signInAgents,
                         current = signInAgent,
@@ -542,6 +604,74 @@ private fun AgentOption(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun DevelopmentToolsStep(
+    installFullDevelopmentTools: Boolean,
+    installPending: Boolean,
+    onInstallFullDevelopmentToolsChanged: (Boolean) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        StepHeader(
+            title = stringResource(R.string.setup_step_development_tools),
+            description = stringResource(R.string.setup_development_tools_description),
+        )
+        SetupPanel {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Checkbox(checked = true, onCheckedChange = null, enabled = false)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.required_tools_title), fontWeight = FontWeight.SemiBold)
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        stringResource(R.string.setup_required_tools_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Checkbox(
+                    checked = installFullDevelopmentTools,
+                    onCheckedChange = onInstallFullDevelopmentToolsChanged,
+                    enabled = !installPending,
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        stringResource(R.string.setup_install_full_development_tools),
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        stringResource(R.string.setup_install_full_development_tools_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+        Text(
+            stringResource(R.string.setup_development_tools_settings_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (installPending) {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            Text(
+                stringResource(R.string.install_step_installing_dev_tools),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
@@ -1110,7 +1240,7 @@ private fun AndroidSetupScreenPreview() {
         AndroidSetupScreen(
             runtimeStatus = LocalRuntimeStatus.Installing(0.68f, "Downloading runtime"),
             claude = ClaudeCodeUiState(),
-            onStartSetup = {},
+            onStartSetup = { _, _ -> },
             onBeginClaudeSignIn = {},
             onSubmitClaudeSignInCode = {},
             onCancelClaudeSignIn = {},
@@ -1143,7 +1273,7 @@ private fun AndroidSetupProviderStepPreview() {
         AndroidSetupScreen(
             runtimeStatus = LocalRuntimeStatus.Ready("1.0.0", 4097),
             claude = ClaudeCodeUiState(installed = true, version = "2.1.212"),
-            onStartSetup = {},
+            onStartSetup = { _, _ -> },
             onBeginClaudeSignIn = {},
             onSubmitClaudeSignInCode = {},
             onCancelClaudeSignIn = {},

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/LocalRuntimeManagementScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/LocalRuntimeManagementScreen.kt
@@ -64,6 +64,7 @@ fun LocalRuntimeManagementScreen(
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onRepair: () -> Unit,
+    onInstallFullDevelopmentTools: () -> Unit,
     onRequestDelete: () -> Unit,
     onDismissDelete: () -> Unit,
     onConfirmDelete: () -> Unit,
@@ -117,6 +118,13 @@ fun LocalRuntimeManagementScreen(
             state.diagnostics?.let { diagnostics ->
                 RuntimeSummaryCard(diagnostics)
                 RuntimeStorageCard(diagnostics)
+                if (state.runtimeEnvironmentInstalled) {
+                    DevelopmentToolsCard(
+                        installed = state.fullDevelopmentToolsInstalled,
+                        busy = busy,
+                        onInstall = onInstallFullDevelopmentTools,
+                    )
+                }
                 RuntimeToolsCard(diagnostics)
                 AdbSetupCard(
                     adbState = state.adbState,
@@ -168,6 +176,51 @@ fun LocalRuntimeManagementScreen(
             onDismiss = onDismissAdbPairDialog,
             onPair = onAdbPair,
         )
+    }
+}
+
+@Composable
+private fun DevelopmentToolsCard(
+    installed: Boolean,
+    busy: Boolean,
+    onInstall: () -> Unit,
+) {
+    SectionCard {
+        Text(
+            stringResource(R.string.full_development_tools_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            stringResource(R.string.full_development_tools_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(10.dp))
+        if (installed) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    Icons.Default.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(stringResource(R.string.full_development_tools_installed))
+            }
+        } else {
+            Button(
+                onClick = onInstall,
+                enabled = !busy,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Default.Build, contentDescription = null)
+                Spacer(Modifier.padding(horizontal = 4.dp))
+                Text(stringResource(R.string.install_full_development_tools_button))
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/LocalRuntimeManagementViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/LocalRuntimeManagementViewModel.kt
@@ -21,6 +21,8 @@ data class LocalRuntimeManagementUiState(
     val lastOperation: LocalRuntimeOperationResult? = null,
     val isLoading: Boolean = true,
     val isDeleting: Boolean = false,
+    val runtimeEnvironmentInstalled: Boolean = false,
+    val fullDevelopmentToolsInstalled: Boolean = false,
     val showDeleteConfirmation: Boolean = false,
     val deleteCompleted: Boolean = false,
     val error: String? = null,
@@ -35,6 +37,9 @@ class LocalRuntimeManagementViewModel(
     lastOperationState: StateFlow<LocalRuntimeOperationResult?>,
     private val diagnosticsProvider: suspend () -> LocalRuntimeDiagnostics,
     private val repairAction: () -> Unit,
+    private val installFullDevelopmentToolsAction: () -> Unit = {},
+    private val runtimeEnvironmentInstalledProvider: () -> Boolean = { false },
+    private val fullDevelopmentToolsInstalledProvider: () -> Boolean = { false },
     private val deleteAction: () -> Unit,
     private val getString: (Int) -> String,
     private val deleteTimeoutMillis: Long = 30_000L,
@@ -120,6 +125,8 @@ class LocalRuntimeManagementViewModel(
                         it.copy(
                             diagnostics = diagnostics,
                             runtimeStatus = diagnostics.status,
+                            runtimeEnvironmentInstalled = runtimeEnvironmentInstalledProvider(),
+                            fullDevelopmentToolsInstalled = fullDevelopmentToolsInstalledProvider(),
                             isLoading = false,
                             error = null,
                         )
@@ -141,6 +148,13 @@ class LocalRuntimeManagementViewModel(
 
     fun repair() {
         dispatchAction(getString(R.string.runtime_repair_start_failed), repairAction)
+    }
+
+    fun installFullDevelopmentTools() {
+        dispatchAction(
+            getString(R.string.runtime_full_development_tools_start_failed),
+            installFullDevelopmentToolsAction,
+        )
     }
 
     fun requestDelete() {
@@ -239,6 +253,18 @@ class LocalRuntimeManagementViewModel(
             mutableState.update {
                 it.copy(
                     diagnostics = diagnostics ?: it.diagnostics,
+                    runtimeEnvironmentInstalled =
+                        if (diagnostics == null) {
+                            it.runtimeEnvironmentInstalled
+                        } else {
+                            runtimeEnvironmentInstalledProvider()
+                        },
+                    fullDevelopmentToolsInstalled =
+                        if (diagnostics == null) {
+                            it.fullDevelopmentToolsInstalled
+                        } else {
+                            fullDevelopmentToolsInstalledProvider()
+                        },
                     error = if (diagnostics == null) it.error else null,
                 )
             }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceViewModel.kt
@@ -334,7 +334,10 @@ class WorkspaceViewModel(
     }
 
     /** [agents] is the setup guide's selection; every other caller means OpenCode alone. */
-    fun setupLocalRuntime(agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE)) = localRuntimeController.installAndStart(agents)
+    fun setupLocalRuntime(
+        agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE),
+        installFullDevelopmentTools: Boolean = false,
+    ) = localRuntimeController.installAndStart(agents, installFullDevelopmentTools)
 
     fun startLocalRuntime() = localRuntimeController.start()
 
@@ -344,7 +347,7 @@ class WorkspaceViewModel(
 
     fun reinstallLocalRuntime() = localRuntimeController.reinstall()
 
-    fun installClaudeCode() = claudeCode?.install() ?: Unit
+    fun installClaudeCode(installFullDevelopmentTools: Boolean = false) = claudeCode?.install(installFullDevelopmentTools) ?: Unit
 
     fun updateClaudeCode() = claudeCode?.update() ?: Unit
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityController.kt
@@ -139,13 +139,16 @@ class AntigravityController(
      * is not among it. Two installs would race each other for the same staging directory, so the
      * guide has exactly one entry point per run and this is it whenever Antigravity is selected.
      */
-    fun install(agents: Set<LocalAgent> = setOf(LocalAgent.ANTIGRAVITY)) {
+    fun install(
+        agents: Set<LocalAgent> = setOf(LocalAgent.ANTIGRAVITY),
+        installFullDevelopmentTools: Boolean = false,
+    ) {
         if (mutableState.value.install is AntigravityInstallStatus.Installing) return
         mutableState.value = mutableState.value.copy(install = AntigravityInstallStatus.Installing(0f, ""))
         scope.launch {
             runtimeWork.withLease(INSTALL_LEASE_TAG) {
                 runCatching {
-                    installer.install(agents + LocalAgent.ANTIGRAVITY) { progress, step, _ ->
+                    installer.install(agents + LocalAgent.ANTIGRAVITY, installFullDevelopmentTools) { progress, step, _ ->
                         mutableState.value = mutableState.value.copy(install = AntigravityInstallStatus.Installing(progress, step))
                     }
                 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeController.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/ClaudeCodeController.kt
@@ -117,7 +117,7 @@ class ClaudeCodeController(
      * Safe to call when only OpenCode is installed: the sandbox is shared, so this adds a package
      * rather than reinstalling everything.
      */
-    fun install() {
+    fun install(installFullDevelopmentTools: Boolean = false) {
         if (installJob?.isActive == true) return
         installJob =
             scope.launch(Dispatchers.IO) {
@@ -125,7 +125,13 @@ class ClaudeCodeController(
                     runCatching {
                         if (installer.installedRuntime() == null) {
                             report(ClaudeInstallStatus.Installing(R.string.claude_step_preparing_runtime))
-                            installer.install(agents = setOf(LocalAgent.CLAUDE_CODE)) { _, _, _ -> }
+                            installer.install(
+                                agents = setOf(LocalAgent.CLAUDE_CODE),
+                                installFullDevelopmentTools = installFullDevelopmentTools,
+                            ) { _, _, _ -> }
+                        } else if (installFullDevelopmentTools) {
+                            report(ClaudeInstallStatus.Installing(R.string.install_step_installing_dev_tools))
+                            installer.installFullDevelopmentTools()
                         }
                         report(ClaudeInstallStatus.Installing(R.string.claude_step_adding_repository))
                         target.install { step ->

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/DebianRootfsInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/DebianRootfsInstaller.kt
@@ -18,11 +18,11 @@ class DebianRootfsInstaller(
 ) {
     suspend fun installInto(
         destination: File,
+        installFullDevelopmentTools: Boolean = false,
         onProgress: (Float) -> Unit = {},
     ): File =
         withContext(Dispatchers.IO) {
             val asset = DebianRootfsManifest.assetFor(abi)
-            val token = accessToken()
             val archive = File(runtimeDirectory, "cache/debian-bookworm-slim-$abi.tar.gz").apply { parentFile?.mkdirs() }
             if (archive.length() != asset.sizeBytes || runCatching { RuntimeArchive.verifySha256(archive, asset.sha256) }.isFailure) {
                 downloader.download(
@@ -30,7 +30,7 @@ class DebianRootfsInstaller(
                     destination = archive,
                     expectedSha256 = asset.sha256,
                     expectedSizeBytes = asset.sizeBytes,
-                    headers = mapOf("Authorization" to "Bearer $token"),
+                    headers = mapOf("Authorization" to "Bearer ${accessToken()}"),
                     onProgress = { onProgress((it ?: 0f) * 0.75f) },
                 )
             } else {
@@ -42,11 +42,18 @@ class DebianRootfsInstaller(
                 configure(extracted)
                 ensureGlibcLoader(extracted)
                 installPtyUtility(extracted)
-                installDevelopmentTools(extracted)
+                resetAlternatives(extracted)
+                installPackages(
+                    extracted,
+                    if (installFullDevelopmentTools) {
+                        REQUIRED_RUNTIME_PACKAGES + OPTIONAL_DEVELOPMENT_PACKAGES
+                    } else {
+                        REQUIRED_RUNTIME_PACKAGES
+                    },
+                )
                 destination.deleteRecursively()
                 require(extracted.renameTo(destination)) { "Unable to activate Debian Antigravity rootfs" }
                 onProgress(1f)
-                archive.delete()
                 destination
             } finally {
                 extracted.deleteRecursively()
@@ -91,7 +98,6 @@ class DebianRootfsInstaller(
         }
         packageFile.inputStream().use { RuntimeArchive.extractDebianPackage(it, rootfs) }
         require(File(rootfs, "usr/bin/script").isFile) { "Debian PTY utility was not installed" }
-        packageFile.delete()
     }
 
     /**
@@ -109,10 +115,26 @@ class DebianRootfsInstaller(
         }
     }
 
-    private fun installDevelopmentTools(rootfs: File) {
+    /** Adds the optional toolchain to an already active Antigravity rootfs. */
+    fun installFullDevelopmentTools(rootfs: File) {
+        // Older runtimes predate the required adb/Python support packages. Installing the union
+        // makes this migration safe as well as adding the optional toolchain.
+        installPackages(rootfs, REQUIRED_RUNTIME_PACKAGES + OPTIONAL_DEVELOPMENT_PACKAGES)
+    }
+
+    private fun installPackages(
+        rootfs: File,
+        packages: List<String>,
+    ) {
         val suite = commandSuite ?: return
         val prootTmp = File(runtimeDirectory, "proot-tmp").apply { mkdirs() }
-        resetAlternatives(rootfs)
+        val aptCache = File(runtimeDirectory, "cache/apt/archives").apply { mkdirs() }
+        File(aptCache, "partial").mkdirs()
+        File(rootfs, "var/cache/apt/archives").mkdirs()
+        // Docker's slim image otherwise deletes these archives after every apt operation.
+        val dockerClean = File(rootfs, "etc/apt/apt.conf.d/docker-clean")
+        require(!dockerClean.exists() || dockerClean.delete()) { "Unable to enable the Debian package cache" }
+        File(rootfs, "etc/apt/apt.conf.d/keep-downloads").writeText("APT::Keep-Downloaded-Packages \"true\";\n")
         File(rootfs, "etc/apt/sources.list").apply {
             parentFile?.mkdirs()
             writeText(
@@ -135,6 +157,8 @@ class DebianRootfsInstaller(
                 "/proc",
                 "-b",
                 "/sys",
+                "-b",
+                "${aptCache.absolutePath}:/var/cache/apt/archives",
                 "-w",
                 "/root",
                 // Debian 12 has a merged /usr: this is the real interpreter, and `/bin/sh` only
@@ -145,9 +169,8 @@ class DebianRootfsInstaller(
                 GUEST_ENV +
                     "apt-get update -qq && " +
                     "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends " +
-                    "git curl wget jq tree file less nano openssh-client ripgrep ca-certificates " +
-                    "python3 python3-pil && " +
-                    "apt-get clean && rm -rf /var/lib/apt/lists/*",
+                    "${packages.filterNot { it == "gh" }.joinToString(" ")} && " +
+                    "rm -rf /var/lib/apt/lists/*",
             )
         val installLog =
             File(runtimeDirectory, "logs/debian-tool-install.log").apply {
@@ -171,16 +194,17 @@ class DebianRootfsInstaller(
         require(process.exitValue() == 0) {
             // Same shape as LocalRuntimeInstaller: hint before the log tail, which is the only part
             // long enough to push it out of view.
-            "Unable to install Debian development tools. $PACKAGE_INSTALL_RETRY_HINT\n\n" +
+            "Unable to install Debian runtime packages. $PACKAGE_INSTALL_RETRY_HINT\n\n" +
                 "Last log lines:\n${installLog.readText().takeLast(4000)}"
         }
-        installGitHubCli(rootfs, suite, prootTmp)
+        if ("gh" in packages) installGitHubCli(rootfs, suite, prootTmp, aptCache)
     }
 
     private fun installGitHubCli(
         rootfs: File,
         suite: EmbeddedCommandSuite.Paths,
         prootTmp: File,
+        aptCache: File,
     ) {
         val arch = if (abi == "arm64-v8a") "arm64" else "amd64"
         val command =
@@ -197,9 +221,10 @@ class DebianRootfsInstaller(
                 "/proc",
                 "-b",
                 "/sys",
+                "-b",
+                "${aptCache.absolutePath}:/var/cache/apt/archives",
                 "-w",
                 "/root",
-                // See installDevelopmentTools: the real interpreter lives under the merged /usr.
                 "/usr/bin/sh",
                 "-c",
                 GUEST_ENV +
@@ -209,7 +234,7 @@ class DebianRootfsInstaller(
                     "https://cli.github.com/packages stable main\" > /etc/apt/sources.list.d/github-cli.list && " +
                     "apt-get update -qq && " +
                     "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends gh && " +
-                    "apt-get clean && rm -rf /var/lib/apt/lists/*",
+                    "rm -rf /var/lib/apt/lists/*",
             )
         val installLog =
             File(runtimeDirectory, "logs/debian-gh-install.log").apply {
@@ -228,10 +253,10 @@ class DebianRootfsInstaller(
         val completed = process.waitFor(5, java.util.concurrent.TimeUnit.MINUTES)
         if (!completed) {
             process.destroyForcibly()
-            return
+            error("GitHub CLI installation timed out")
         }
-        if (process.exitValue() != 0) {
-            android.util.Log.w("DebianRootfsInstaller", "gh install failed (non-fatal): ${installLog.readText().takeLast(500)}")
+        require(process.exitValue() == 0) {
+            "Unable to install GitHub CLI: ${installLog.readText().takeLast(4000)}"
         }
     }
 
@@ -251,7 +276,48 @@ class DebianRootfsInstaller(
         }
     }
 
-    private companion object {
+    internal companion object {
+        val REQUIRED_RUNTIME_PACKAGES =
+            listOf(
+                "git",
+                "curl",
+                "wget",
+                "jq",
+                "openssh-client",
+                "ripgrep",
+                "ca-certificates",
+                "adb",
+                "python3",
+                "python3-pil",
+            )
+
+        val OPTIONAL_DEVELOPMENT_PACKAGES =
+            listOf(
+                "tree",
+                "file",
+                "less",
+                "nano",
+                "vim",
+                "gh",
+                "openjdk-17-jdk-headless",
+                "gradle",
+                "python3-pip",
+                "nodejs",
+                "npm",
+                "make",
+                "cmake",
+                "gcc",
+                "g++",
+                "libc6-dev",
+                "pkg-config",
+                "patch",
+                "zip",
+                "unzip",
+                "sqlite3",
+                "golang-go",
+                "util-linux",
+            )
+
         /**
          * Guest-side environment for every `proot ... /usr/bin/sh -c` run here.
          *

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeDiagnostics.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeDiagnostics.kt
@@ -56,6 +56,7 @@ class LocalRuntimeDiagnosticsCollector(
     },
     private val processMetricsProvider: () -> LocalRuntimeProcessMetrics?,
     private val commandExecutor: (LocalRuntimeToolDefinition) -> LocalRuntimeCommandResult,
+    private val fullDevelopmentToolsInstalledProvider: () -> Boolean = { false },
     private val nowMillis: () -> Long = System::currentTimeMillis,
     private val maxLogCharacters: Int = 12_000,
     private val messages: LocalRuntimeMessages = LocalRuntimeMessages,
@@ -69,9 +70,12 @@ class LocalRuntimeDiagnosticsCollector(
         val installed =
             status !is LocalRuntimeStatus.NotInstalled &&
                 status !is LocalRuntimeStatus.UnsupportedAbi
+        val definitions =
+            REQUIRED_TOOLS +
+                OPTIONAL_TOOLS.takeIf { fullDevelopmentToolsInstalledProvider() }.orEmpty()
         val tools =
             if (installed) {
-                REQUIRED_TOOLS.map { definition ->
+                definitions.map { definition ->
                     runCatching { commandExecutor(definition) }
                         .fold(
                             onSuccess = { result ->
@@ -102,7 +106,7 @@ class LocalRuntimeDiagnosticsCollector(
                         )
                 }
             } else {
-                REQUIRED_TOOLS.map { definition ->
+                definitions.map { definition ->
                     LocalRuntimeToolCheck(
                         id = definition.id,
                         label = displayLabel(definition),
@@ -179,9 +183,13 @@ class LocalRuntimeDiagnosticsCollector(
                     "test -s /etc/ssl/certs/ca-certificates.crt && echo installed",
                 ),
                 LocalRuntimeToolDefinition("adb", "ADB", "adb version | head -n 1"),
+                LocalRuntimeToolDefinition("python3", "Python", "python3 --version"),
+            )
+
+        val OPTIONAL_TOOLS =
+            listOf(
                 LocalRuntimeToolDefinition("java", "Java", "java -version 2>&1 | head -n 1"),
                 LocalRuntimeToolDefinition("gradle", "Gradle", "gradle --version 2>&1 | head -n 1"),
-                LocalRuntimeToolDefinition("python3", "Python", "python3 --version"),
                 LocalRuntimeToolDefinition("node", "Node.js", "node --version"),
                 LocalRuntimeToolDefinition("npm", "npm", "npm --version"),
                 LocalRuntimeToolDefinition("go", "Go", "go version"),

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeInstaller.kt
@@ -48,6 +48,7 @@ class LocalRuntimeInstaller(
      */
     suspend fun install(
         agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE),
+        installFullDevelopmentTools: Boolean = false,
         /**
          * Progress, the step to show, and which agent that step belongs to - null for the shared
          * Alpine environment every agent runs in. One install provisions the whole selection, so
@@ -63,13 +64,18 @@ class LocalRuntimeInstaller(
             val onAntigravity: (Float?, String) -> Unit = { progress, step -> onProgress(progress, step, LocalAgent.ANTIGRAVITY) }
             runtimeDirectory.mkdirs()
             onShared(0.02f, context.getString(R.string.install_step_preparing_command_env))
+            val existingMetadata = installedMetadata()
             val requestedAgents =
                 agents + (
-                    installedMetadata()?.let {
+                    existingMetadata?.let {
                             existing ->
                         LocalAgent.entries.filter(existing::has)
                     } ?: emptyList()
                 )
+            // Runtimes created before this option existed already contain the full toolchain, and
+            // adding another agent must not silently remove it by rebuilding a smaller rootfs.
+            val includeFullDevelopmentTools =
+                installFullDevelopmentTools || existingMetadata?.fullDevelopmentToolsInstalled == true
             require(requestedAgents.isNotEmpty()) { "At least one agent must be selected" }
             val commandSuite = EmbeddedCommandSuite(context, runtimeDirectory, abi).ensureInstalled()
             val manifest = manifestReader.read()
@@ -128,6 +134,7 @@ class LocalRuntimeInstaller(
                         onAntigravity(0.90f, context.getString(R.string.install_step_preparing_antigravity_rootfs))
                         DebianRootfsInstaller(runtimeDirectory, abi, downloader, httpClient, commandSuite).installInto(
                             File(staging, "antigravity-rootfs"),
+                            installFullDevelopmentTools = includeFullDevelopmentTools,
                         ) { progress ->
                             onAntigravity(0.90f + progress * 0.03f, context.getString(R.string.install_step_preparing_antigravity_rootfs))
                         }
@@ -149,8 +156,26 @@ class LocalRuntimeInstaller(
                 // agent whenever another one is added or the runtime is reinstalled.
                 carryOverHomeDirectory(File(active, "rootfs"), rootfs)
                 ensureAndCodeAgentContext(rootfs, context)
-                onShared(0.91f, context.getString(R.string.install_step_installing_dev_tools))
-                installDevelopmentTools(rootfs, commandSuite)
+                onShared(
+                    0.91f,
+                    context.getString(
+                        if (includeFullDevelopmentTools) {
+                            R.string.install_step_installing_dev_tools
+                        } else {
+                            R.string.install_step_installing_runtime_tools
+                        },
+                    ),
+                )
+                installPackages(
+                    rootfs = rootfs,
+                    suite = commandSuite,
+                    packages =
+                        if (includeFullDevelopmentTools) {
+                            REQUIRED_RUNTIME_PACKAGES + OPTIONAL_DEVELOPMENT_PACKAGES
+                        } else {
+                            REQUIRED_RUNTIME_PACKAGES
+                        },
+                )
                 if (LocalAgent.CLAUDE_CODE in requestedAgents) {
                     onClaude(0.93f, context.getString(R.string.install_step_installing_claude_code))
                     ClaudeCodeInstaller.installInto(rootfs, commandSuite, runtimeDirectory)
@@ -176,6 +201,8 @@ class LocalRuntimeInstaller(
                         runtimeVersion = manifest.runtimeVersion,
                         abi = abi,
                         components = requestedAgents.map(LocalAgent::id).toSet(),
+                        fullDevelopmentToolsInstalled = includeFullDevelopmentTools,
+                        fullDebianDevelopmentToolsInstalled = includeFullDevelopmentTools && antigravityRootfs != null,
                     )
                 File(staging, METADATA_FILE).writeText(json.encodeToString(metadata))
                 onShared(0.96f, context.getString(R.string.install_step_activating_runtime))
@@ -266,6 +293,43 @@ class LocalRuntimeInstaller(
             metadataFile.writeText(json.encodeToString(metadata.with(agent)))
         }
     }
+
+    /** Installs the optional toolchain into the active sandbox without rebuilding the runtime. */
+    suspend fun installFullDevelopmentTools(onProgress: (Float?, String, LocalAgent?) -> Unit = { _, _, _ -> }): LocalRuntimeMetadata =
+        withContext(Dispatchers.IO) {
+            accessCoordinator.write {
+                val active = File(runtimeDirectory, "environment")
+                val rootfs = File(active, "rootfs")
+                val metadataFile = File(runtimeDirectory, METADATA_FILE)
+                require(rootfs.isDirectory && metadataFile.isFile) {
+                    "The Linux environment is not installed"
+                }
+                val metadata =
+                    json.decodeFromString<LocalRuntimeMetadata>(metadataFile.readText())
+                if (metadata.hasFullDevelopmentTools()) return@write metadata
+
+                val suite = EmbeddedCommandSuite(context, runtimeDirectory, abi).ensureInstalled()
+                onProgress(null, context.getString(R.string.install_step_installing_dev_tools), null)
+                if (!metadata.fullDevelopmentToolsInstalled) installPackages(rootfs, suite, OPTIONAL_DEVELOPMENT_PACKAGES)
+                if (metadata.has(LocalAgent.ANTIGRAVITY) && !metadata.fullDebianDevelopmentToolsInstalled) {
+                    val antigravityRootfs = File(active, "antigravity-rootfs")
+                    require(antigravityRootfs.isDirectory) { "The Antigravity Linux environment is not installed" }
+                    DebianRootfsInstaller(runtimeDirectory, abi, downloader, httpClient, suite)
+                        .installFullDevelopmentTools(antigravityRootfs)
+                }
+
+                val updated =
+                    metadata.copy(
+                        fullDevelopmentToolsInstalled = true,
+                        fullDebianDevelopmentToolsInstalled = metadata.has(LocalAgent.ANTIGRAVITY),
+                    )
+                val encoded = json.encodeToString(updated)
+                File(active, METADATA_FILE).writeText(encoded)
+                replaceFileAtomically(File(active, METADATA_FILE), metadataFile)
+                onProgress(1f, context.getString(R.string.install_step_done), null)
+                updated
+            }
+        }
 
     fun bundledOpenCodeVersion(): String = manifestReader.read().openCodeVersion
 
@@ -359,11 +423,14 @@ class LocalRuntimeInstaller(
         onProgress(endProgress, label)
     }
 
-    private fun installDevelopmentTools(
+    private fun installPackages(
         rootfs: File,
         suite: EmbeddedCommandSuite.Paths,
+        packages: List<String>,
     ) {
         val prootTmp = File(runtimeDirectory, "proot-tmp").apply { mkdirs() }
+        val apkCache = File(runtimeDirectory, "cache/apk").apply { mkdirs() }
+        File(rootfs, "var/cache/apk").mkdirs()
         val command =
             listOf(
                 suite.proot.absolutePath,
@@ -380,14 +447,15 @@ class LocalRuntimeInstaller(
                 "/sys",
                 "-b",
                 "/system",
+                "-b",
+                "${apkCache.absolutePath}:/var/cache/apk",
                 "-w",
                 "/root",
                 "/bin/sh",
                 "-lc",
-                // `gcompat` and `util-linux` are this branch's additions and must survive main's
-                // wider toolchain list: the official agy binary is glibc-linked, and its sign-in TUI
-                // needs util-linux's `script` to be handed a real PTY.
-                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /sbin/apk add --no-cache bash git curl wget jq tree file less nano vim openssh-client ripgrep ca-certificates libstdc++ github-cli android-tools openjdk17 gradle python3 py3-pillow py3-pip nodejs npm make cmake gcc g++ musl-dev pkgconf patch zip unzip sqlite go gcompat util-linux && /usr/sbin/update-ca-certificates",
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin " +
+                    "/sbin/apk --cache-dir /var/cache/apk add ${packages.joinToString(" ")} && " +
+                    "/usr/sbin/update-ca-certificates",
             )
         val installLog =
             File(runtimeDirectory, "logs/tool-install.log").apply {
@@ -411,7 +479,7 @@ class LocalRuntimeInstaller(
         require(process.exitValue() == 0) {
             // The hint sits between the headline and the raw log, or a 4000-character tail scrolls
             // it off the screen the error is read on.
-            "Unable to install Git and development tools. $PACKAGE_INSTALL_RETRY_HINT\n\n" +
+            "Unable to install runtime packages. $PACKAGE_INSTALL_RETRY_HINT\n\n" +
                 "Last log lines:\n${installLog.readText().takeLast(4000)}"
         }
     }
@@ -607,7 +675,7 @@ class LocalRuntimeInstaller(
         source.copyTo(destination, overwrite = true)
     }
 
-    companion object {
+    internal companion object {
         private const val METADATA_FILE = "metadata.json"
         private const val BROWSER_MCP_NAME = "and-code-browser"
         private const val BROWSER_MCP_BIN = "/usr/local/bin/andcode-browser-mcp.py"
@@ -615,5 +683,51 @@ class LocalRuntimeInstaller(
         private const val SCHEDULE_MCP_NAME = "and-code-schedule"
         private const val SCHEDULE_MCP_BIN = "/usr/local/bin/andcode-schedule-mcp.py"
         private const val SCHEDULE_MCP_TIMEOUT_MILLIS = 120000
+
+        /** Required by OpenCode and AndCode's built-in Git, MCP, and Android-device features. */
+        val REQUIRED_RUNTIME_PACKAGES =
+            listOf(
+                "bash",
+                "git",
+                "curl",
+                "wget",
+                "jq",
+                "openssh-client",
+                "ripgrep",
+                "ca-certificates",
+                "libstdc++",
+                "android-tools",
+                "python3",
+                "py3-pillow",
+            )
+
+        /** Project-specific compilers, language SDKs, editors, and convenience utilities. */
+        val OPTIONAL_DEVELOPMENT_PACKAGES =
+            listOf(
+                "tree",
+                "file",
+                "less",
+                "nano",
+                "vim",
+                "github-cli",
+                "openjdk17",
+                "gradle",
+                "py3-pip",
+                "nodejs",
+                "npm",
+                "make",
+                "cmake",
+                "gcc",
+                "g++",
+                "musl-dev",
+                "pkgconf",
+                "patch",
+                "zip",
+                "unzip",
+                "sqlite",
+                "go",
+                "gcompat",
+                "util-linux",
+            )
     }
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManager.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManager.kt
@@ -32,8 +32,14 @@ data class LocalRuntimeMetadata(
      * the agent they actually contain.
      */
     @SerialName("components") val components: Set<String> = setOf(LocalAgent.OPEN_CODE.id),
+    /** Legacy runtimes installed the complete Alpine toolchain, but not its Debian equivalent. */
+    @SerialName("fullDevelopmentToolsInstalled") val fullDevelopmentToolsInstalled: Boolean = true,
+    @SerialName("fullDebianDevelopmentToolsInstalled") val fullDebianDevelopmentToolsInstalled: Boolean = false,
 ) {
     fun has(agent: LocalAgent): Boolean = agent.id in components
+
+    fun hasFullDevelopmentTools(): Boolean =
+        fullDevelopmentToolsInstalled && (!has(LocalAgent.ANTIGRAVITY) || fullDebianDevelopmentToolsInstalled)
 
     fun with(agent: LocalAgent): LocalRuntimeMetadata = copy(components = components + agent.id)
 
@@ -91,14 +97,17 @@ class LocalRuntimeManager(
 
     fun restartCount(): Int = processLauncher?.restartCount() ?: 0
 
-    suspend fun installAndStart(agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE)): Result<LocalRuntimeStatus.Ready> =
+    suspend fun installAndStart(
+        agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE),
+        installFullDevelopmentTools: Boolean = false,
+    ): Result<LocalRuntimeStatus.Ready> =
         operationMutex.withLock {
             val configuredInstaller =
                 installer
                     ?: return@withLock Result.failure(IllegalStateException("Local runtime installer is not configured"))
             runCatching {
                 val installed =
-                    configuredInstaller.install(agents) { progress, step, agent ->
+                    configuredInstaller.install(agents, installFullDevelopmentTools) { progress, step, agent ->
                         mutableState.value = LocalRuntimeStatus.Installing(progress, step, agent)
                     }
                 mutableState.value = LocalRuntimeStatus.Stopped(installed.metadata.version, installed.metadata.port)
@@ -179,13 +188,22 @@ class LocalRuntimeManager(
     suspend fun reinstall(): Result<LocalRuntimeStatus.Ready> =
         operationMutex.withLock {
             withContext(Dispatchers.IO) { processLauncher?.stop() }
+            val previousMetadata = readMetadata()
             File(runtimeDirectory, METADATA_FILE).delete()
             val configuredInstaller =
                 installer
                     ?: return@withLock Result.failure(IllegalStateException("Local runtime installer is not configured"))
             runCatching {
                 val installed =
-                    configuredInstaller.install { progress, step, agent ->
+                    configuredInstaller.install(
+                        agents =
+                            previousMetadata?.components
+                                ?.mapNotNull(LocalAgent::fromId)
+                                ?.toSet()
+                                ?.takeIf(Set<LocalAgent>::isNotEmpty)
+                                ?: setOf(LocalAgent.OPEN_CODE),
+                        installFullDevelopmentTools = previousMetadata?.fullDevelopmentToolsInstalled == true,
+                    ) { progress, step, agent ->
                         mutableState.value = LocalRuntimeStatus.Installing(progress, step, agent)
                     }
                 startInstalled(installed)
@@ -194,6 +212,63 @@ class LocalRuntimeManager(
                     LocalRuntimeStatus.Broken(
                         error.message ?: messages.reinstallFailed,
                     )
+            }
+        }
+
+    // UI readers must not wait on the installer's write lock during a long package download.
+    fun fullDevelopmentToolsInstalled(): Boolean = readMetadata()?.hasFullDevelopmentTools() == true
+
+    fun runtimeEnvironmentInstalled(): Boolean = readMetadata() != null && File(runtimeDirectory, "environment/rootfs").isDirectory
+
+    suspend fun installFullDevelopmentTools(): Result<Unit> =
+        operationMutex.withLock {
+            val configuredInstaller =
+                installer
+                    ?: return@withLock Result.failure(IllegalStateException("Local runtime installer is not configured"))
+            if (configuredInstaller.installedMetadata()?.hasFullDevelopmentTools() == true) {
+                return@withLock Result.success(Unit)
+            }
+            mutableLastOperation.value = null
+            val wasRunning = status() is LocalRuntimeStatus.Ready
+            try {
+                if (wasRunning) withContext(Dispatchers.IO) { processLauncher?.stop() }
+                configuredInstaller.installFullDevelopmentTools { progress, step, agent ->
+                    mutableState.value = LocalRuntimeStatus.Installing(progress, step, agent)
+                }
+                val installed = configuredInstaller.installedRuntime() ?: error("Local runtime is not installed")
+                if (wasRunning) {
+                    startInstalled(installed)
+                } else {
+                    mutableState.value = LocalRuntimeStatus.Stopped(installed.metadata.version, installed.metadata.port)
+                }
+                mutableLastOperation.value = null
+                Result.success(Unit)
+            } catch (error: Throwable) {
+                // A failed optional-tool download must not turn an otherwise usable runtime into a
+                // broken one. Restore the state it had before the attempt; the persistent APK cache
+                // lets the next retry reuse packages that finished downloading.
+                val restoreError =
+                    withContext(NonCancellable) {
+                        runCatching {
+                            val installed = configuredInstaller.installedRuntime() ?: error("Local runtime is not installed")
+                            if (wasRunning) {
+                                startInstalled(installed)
+                            } else {
+                                mutableState.value = LocalRuntimeStatus.Stopped(installed.metadata.version, installed.metadata.port)
+                            }
+                        }.exceptionOrNull()
+                    }
+                if (restoreError != null) {
+                    error.addSuppressed(restoreError)
+                    mutableState.value = LocalRuntimeStatus.Broken(error.message ?: messages.installFailed)
+                }
+                if (error is CancellationException) throw error
+                mutableLastOperation.value =
+                    LocalRuntimeOperationResult.Failed(
+                        operation = "development-tools-install",
+                        message = error.message ?: messages.installFailed,
+                    )
+                Result.failure(error)
             }
         }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeService.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.launch
 
 internal enum class LocalRuntimeServiceCommand {
     InstallAndStart,
+    InstallFullDevelopmentTools,
     Start,
     Reinstall,
     Update,
@@ -46,6 +47,7 @@ internal enum class LocalRuntimeServiceCommand {
 internal fun localRuntimeServiceCommand(action: String?): LocalRuntimeServiceCommand =
     when (action) {
         LocalRuntimeService.ACTION_INSTALL_AND_START -> LocalRuntimeServiceCommand.InstallAndStart
+        LocalRuntimeService.ACTION_INSTALL_FULL_DEVELOPMENT_TOOLS -> LocalRuntimeServiceCommand.InstallFullDevelopmentTools
         LocalRuntimeService.ACTION_START -> LocalRuntimeServiceCommand.Start
         LocalRuntimeService.ACTION_REINSTALL -> LocalRuntimeServiceCommand.Reinstall
         LocalRuntimeService.ACTION_UPDATE -> LocalRuntimeServiceCommand.Update
@@ -79,6 +81,7 @@ internal fun clearsUserStoppedFlag(command: LocalRuntimeServiceCommand): Boolean
         LocalRuntimeServiceCommand.Rollback,
         -> true
         LocalRuntimeServiceCommand.Stop,
+        LocalRuntimeServiceCommand.InstallFullDevelopmentTools,
         LocalRuntimeServiceCommand.Delete,
         LocalRuntimeServiceCommand.Restore,
         LocalRuntimeServiceCommand.Ignore,
@@ -374,7 +377,18 @@ class LocalRuntimeService : Service() {
             LocalRuntimeServiceCommand.InstallAndStart -> {
                 autoRestartEnabled = true
                 val agents = localRuntimeInstallAgents(intent?.getStringArrayExtra(EXTRA_AGENTS))
-                launchOperation { manager.installAndStart(agents) }
+                val installFullDevelopmentTools = intent?.getBooleanExtra(EXTRA_FULL_DEVELOPMENT_TOOLS, false) == true
+                launchOperation { manager.installAndStart(agents, installFullDevelopmentTools) }
+            }
+            LocalRuntimeServiceCommand.InstallFullDevelopmentTools -> {
+                val runtimeWasRunning = manager.status() is LocalRuntimeStatus.Ready
+                launchOperation {
+                    manager.installFullDevelopmentTools()
+                    if (!runtimeWasRunning) {
+                        stopForeground(STOP_FOREGROUND_REMOVE)
+                        stopSelf()
+                    }
+                }
             }
             LocalRuntimeServiceCommand.Start -> {
                 autoRestartEnabled = true
@@ -693,6 +707,7 @@ class LocalRuntimeService : Service() {
         private const val WAKELOCK_TIMEOUT_MILLIS = 10 * 60 * 1000L
         private const val RUNTIME_OPERATION_LEASE_TAG = "runtime-op"
         const val ACTION_INSTALL_AND_START = "com.yugahashimoto.andcode.local.INSTALL_AND_START"
+        const val ACTION_INSTALL_FULL_DEVELOPMENT_TOOLS = "com.yugahashimoto.andcode.local.INSTALL_FULL_DEVELOPMENT_TOOLS"
         const val ACTION_START = "com.yugahashimoto.andcode.local.START"
         const val ACTION_STOP = "com.yugahashimoto.andcode.local.STOP"
         const val ACTION_RESTART = "com.yugahashimoto.andcode.local.RESTART"
@@ -703,6 +718,7 @@ class LocalRuntimeService : Service() {
 
         /** Ids of the agents an install should provision; see [LocalRuntimeInstaller.install]. */
         const val EXTRA_AGENTS = "com.yugahashimoto.andcode.local.AGENTS"
+        const val EXTRA_FULL_DEVELOPMENT_TOOLS = "com.yugahashimoto.andcode.local.FULL_DEVELOPMENT_TOOLS"
 
         /**
          * Sends a command to the runtime service, starting it when it is not running yet.
@@ -717,9 +733,11 @@ class LocalRuntimeService : Service() {
             context: Context,
             action: String,
             agents: Set<LocalAgent> = emptySet(),
+            installFullDevelopmentTools: Boolean = false,
         ) {
             val intent = Intent(context, LocalRuntimeService::class.java).setAction(action)
             if (agents.isNotEmpty()) intent.putExtra(EXTRA_AGENTS, agents.map(LocalAgent::id).toTypedArray())
+            if (installFullDevelopmentTools) intent.putExtra(EXTRA_FULL_DEVELOPMENT_TOOLS, true)
             runCatching { ContextCompat.startForegroundService(context, intent) }
                 .onFailure { error -> Log.w(TAG, "Foreground start refused for $action", error) }
         }
@@ -732,8 +750,17 @@ class LocalRuntimeServiceController(private val context: Context) {
      * makes ticking Claude Code or Antigravity alongside OpenCode actually install them: their own
      * installers would otherwise have to race this one for the same staging directory.
      */
-    fun installAndStart(agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE)) =
-        LocalRuntimeService.send(context, LocalRuntimeService.ACTION_INSTALL_AND_START, agents)
+    fun installAndStart(
+        agents: Set<LocalAgent> = setOf(LocalAgent.OPEN_CODE),
+        installFullDevelopmentTools: Boolean = false,
+    ) = LocalRuntimeService.send(
+        context,
+        LocalRuntimeService.ACTION_INSTALL_AND_START,
+        agents,
+        installFullDevelopmentTools,
+    )
+
+    fun installFullDevelopmentTools() = LocalRuntimeService.send(context, LocalRuntimeService.ACTION_INSTALL_FULL_DEVELOPMENT_TOOLS)
 
     fun start() = LocalRuntimeService.send(context, LocalRuntimeService.ACTION_START)
 

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/VerifiedRuntimeDownloader.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/VerifiedRuntimeDownloader.kt
@@ -8,6 +8,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
+import java.io.FileOutputStream
 
 class VerifiedRuntimeDownloader(
     private val httpClient: OkHttpClient = OkHttpClient(),
@@ -53,38 +54,86 @@ class VerifiedRuntimeDownloader(
         destination.parentFile?.mkdirs()
         val partial = File(destination.parentFile, destination.name + ".partial")
         val backup = File(destination.parentFile, destination.name + ".backup")
-        partial.delete()
         recoverBackupIfDestinationMissing(destination, backup)
 
+        var completed = false
+        var validationFailed = false
         try {
-            val requestBuilder = Request.Builder().url(parsedUrl).get()
-            headers.forEach { (name, value) -> requestBuilder.header(name, value) }
-            val request = requestBuilder.build()
-            var downloaded = 0L
-            httpClient.newCall(request).execute().use { response ->
-                require(response.isSuccessful) {
-                    "Runtime download failed with HTTP ${response.code}"
-                }
-                val body = requireNotNull(response.body) { "Runtime download response had no body" }
-                partial.outputStream().buffered().use { output ->
-                    body.byteStream().use { input ->
-                        val buffer = ByteArray(64 * 1024)
-                        while (true) {
-                            val count = input.read(buffer)
-                            if (count < 0) break
-                            output.write(buffer, 0, count)
-                            downloaded += count
-                            onProgress(expectedSizeBytes?.let { downloaded.toFloat() / it })
+            var downloaded = partial.length().coerceAtLeast(0L)
+            if (expectedSizeBytes != null && downloaded > expectedSizeBytes) {
+                partial.delete()
+                downloaded = 0L
+            }
+            // The process may have died after writing the final byte but before verification. In
+            // that case a range request starts at EOF and commonly receives HTTP 416 forever.
+            // Verify the preserved body first so a complete partial can be activated offline.
+            val partialAlreadyComplete =
+                downloaded > 0L &&
+                    (expectedSizeBytes == null || downloaded == expectedSizeBytes) &&
+                    runCatching {
+                        RuntimeArchive.verifySha256(partial, expectedSha256)
+                    }.isSuccess
+            if (!partialAlreadyComplete && expectedSizeBytes != null && downloaded == expectedSizeBytes) {
+                partial.delete()
+                downloaded = 0L
+            }
+            if (!partialAlreadyComplete) {
+                val resume = downloaded > 0L
+                val requestBuilder = Request.Builder().url(parsedUrl).get()
+                headers.forEach { (name, value) -> requestBuilder.header(name, value) }
+                if (resume) requestBuilder.header("Range", "bytes=$downloaded-")
+                val request = requestBuilder.build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (resume && response.code == 416) {
+                        require(partial.delete()) { "Unable to discard an invalid partial download" }
+                        response.close()
+                        return downloadLocked(
+                            url = url,
+                            destination = destination,
+                            expectedSha256 = expectedSha256,
+                            expectedSizeBytes = expectedSizeBytes,
+                            headers = headers,
+                            onProgress = onProgress,
+                        )
+                    }
+                    require(response.isSuccessful) {
+                        "Runtime download failed with HTTP ${response.code}"
+                    }
+                    val body = requireNotNull(response.body) { "Runtime download response had no body" }
+                    // A compliant server returns 206 for a range request. If it ignores Range and
+                    // returns 200, restart from byte zero rather than duplicating the prefix.
+                    val append = resume && response.code == 206
+                    if (append) {
+                        validationFailed = true
+                        require(response.header("Content-Range")?.startsWith("bytes $downloaded-") == true) {
+                            "Runtime download returned an invalid Content-Range"
+                        }
+                        validationFailed = false
+                    }
+                    if (!append) downloaded = 0L
+                    FileOutputStream(partial, append).buffered().use { output ->
+                        body.byteStream().use { input ->
+                            val buffer = ByteArray(64 * 1024)
+                            while (true) {
+                                val count = input.read(buffer)
+                                if (count < 0) break
+                                output.write(buffer, 0, count)
+                                downloaded += count
+                                onProgress(expectedSizeBytes?.let { downloaded.toFloat() / it })
+                            }
                         }
                     }
                 }
-            }
-            expectedSizeBytes?.let { expected ->
-                require(downloaded == expected) {
-                    "Runtime download size mismatch: expected $expected, got $downloaded"
+                expectedSizeBytes?.let { expected ->
+                    validationFailed = true
+                    require(downloaded == expected) {
+                        "Runtime download size mismatch: expected $expected, got $downloaded"
+                    }
                 }
+                validationFailed = true
+                RuntimeArchive.verifySha256(partial, expectedSha256)
+                validationFailed = false
             }
-            RuntimeArchive.verifySha256(partial, expectedSha256)
 
             if (destination.isFile &&
                 runCatching {
@@ -107,6 +156,7 @@ class VerifiedRuntimeDownloader(
             try {
                 move(partial, destination)
                 backup.delete()
+                completed = true
             } catch (error: Throwable) {
                 destination.delete()
                 if (backup.exists()) {
@@ -117,8 +167,13 @@ class VerifiedRuntimeDownloader(
                 throw error
             }
             onProgress(1f)
+        } catch (error: Throwable) {
+            // Keep an incomplete body for transient network/process failures. Invalid complete
+            // bodies are never useful for a retry and are removed just as before.
+            if (validationFailed) partial.delete()
+            throw error
         } finally {
-            partial.delete()
+            if (completed) partial.delete()
             recoverBackupIfDestinationMissing(destination, backup)
         }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -97,6 +97,7 @@ import com.yugahashimoto.andcode.feature.workspace.WorkspaceViewModel
 import com.yugahashimoto.andcode.runtime.RuntimeState
 import com.yugahashimoto.andcode.runtime.WorkspaceRef
 import com.yugahashimoto.andcode.runtime.local.GitCloneResult
+import com.yugahashimoto.andcode.runtime.local.LocalRuntimeOperationResult
 import com.yugahashimoto.andcode.ui.components.SessionStatus
 import com.yugahashimoto.andcode.ui.navigation.ClaudeSettingsActions
 import com.yugahashimoto.andcode.ui.navigation.DRAWER_ROOT_ROUTES
@@ -868,11 +869,16 @@ fun AndCodeApp(
 
                     composable(ROUTE_ANDROID_SETUP) {
                         val localRuntimeStatus by app.localRuntimeManager.state.collectAsState()
+                        val localRuntimeLastOperation by app.localRuntimeManager.lastOperation.collectAsState()
                         AndroidSetupScreen(
                             runtimeStatus = localRuntimeStatus,
                             claude = workspaceState.claude,
                             antigravity = antigravityState,
-                            onStartSetup = { agents ->
+                            fullDevelopmentToolsInstalled = app.localRuntimeManager.fullDevelopmentToolsInstalled(),
+                            fullDevelopmentToolsInstallFailed =
+                                (localRuntimeLastOperation as? LocalRuntimeOperationResult.Failed)?.operation ==
+                                    "development-tools-install",
+                            onStartSetup = { agents, installFullDevelopmentTools ->
                                 // Ticking Claude Code or Antigravity next to OpenCode used to install
                                 // neither of them: the two branches below were guarded on OpenCode
                                 // *not* being selected, and the OpenCode path never received the
@@ -881,11 +887,11 @@ fun AndCodeApp(
                                 // already knew how to do - and it must stay one install, because a
                                 // second one would race it for the same staging directory.
                                 if (com.yugahashimoto.andcode.runtime.LocalAgent.OPEN_CODE in agents) {
-                                    workspaceViewModel.setupLocalRuntime(agents)
+                                    workspaceViewModel.setupLocalRuntime(agents, installFullDevelopmentTools)
                                 } else if (com.yugahashimoto.andcode.runtime.LocalAgent.ANTIGRAVITY in agents) {
-                                    app.antigravityController.install(agents)
+                                    app.antigravityController.install(agents, installFullDevelopmentTools)
                                 } else if (com.yugahashimoto.andcode.runtime.LocalAgent.CLAUDE_CODE in agents) {
-                                    workspaceViewModel.installClaudeCode()
+                                    workspaceViewModel.installClaudeCode(installFullDevelopmentTools)
                                 }
                             },
                             onSelectClaudePermissionMode = { mode ->

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
@@ -99,6 +99,9 @@ fun NavGraphBuilder.workspaceNavGraph(
                                 }
                             },
                             repairAction = app.localRuntimeController::reinstall,
+                            installFullDevelopmentToolsAction = app.localRuntimeController::installFullDevelopmentTools,
+                            runtimeEnvironmentInstalledProvider = app.localRuntimeManager::runtimeEnvironmentInstalled,
+                            fullDevelopmentToolsInstalledProvider = app.localRuntimeManager::fullDevelopmentToolsInstalled,
                             deleteAction = app.localRuntimeController::delete,
                             getString = { app.getString(it) },
                             adbState = app.adbConnectionManager.state,
@@ -122,6 +125,7 @@ fun NavGraphBuilder.workspaceNavGraph(
             onBack = { navController.popBackStack() },
             onRefresh = managementViewModel::refresh,
             onRepair = managementViewModel::repair,
+            onInstallFullDevelopmentTools = managementViewModel::installFullDevelopmentTools,
             onRequestDelete = managementViewModel::requestDelete,
             onDismissDelete = managementViewModel::dismissDelete,
             onConfirmDelete = managementViewModel::confirmDelete,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1105,4 +1105,16 @@
     <string name="guest_browser_back">رجوع</string>
     <string name="guest_browser_forward">تقدم</string>
     <string name="guest_browser_reload">إعادة تحميل</string>
+    <string name="setup_step_development_tools">أدوات التطوير</string>
+    <string name="setup_development_tools_description">يتم تثبيت مكونات التشغيل الضرورية فقط افتراضيًا، ويمكنك إضافة مجموعة أدوات التطوير الكاملة.</string>
+    <string name="setup_required_tools_description">سيتم دائمًا تثبيت Linux والوكلاء المحددين وGit وأدوات الدعم التي يستخدمها AndCode.</string>
+    <string name="setup_install_full_development_tools">تثبيت أدوات التطوير الكاملة</string>
+    <string name="setup_install_full_development_tools_description">تضيف بيئات اللغات والمترجمات وأدوات البناء والمحررات والأدوات المساعدة، مع تنزيل بيانات إضافية.</string>
+    <string name="setup_development_tools_settings_hint">يمكنك تخطي ذلك وتثبيت مجموعة الأدوات الكاملة لاحقًا من الإعدادات → بيئة التشغيل المحلية.</string>
+    <string name="install_step_installing_runtime_tools">جارٍ تثبيت أدوات التشغيل الضرورية</string>
+    <string name="full_development_tools_title">أدوات التطوير</string>
+    <string name="full_development_tools_description">بيئات لغات ومترجمات وأدوات بناء وأدوات مساعدة اختيارية للمشاريع.</string>
+    <string name="full_development_tools_installed">تم تثبيت أدوات التطوير الكاملة</string>
+    <string name="install_full_development_tools_button">تثبيت مجموعة الأدوات الكاملة</string>
+    <string name="runtime_full_development_tools_start_failed">تعذر بدء تثبيت أدوات التطوير</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1099,4 +1099,16 @@
     <string name="guest_browser_back">Atrás</string>
     <string name="guest_browser_forward">Avanzar</string>
     <string name="guest_browser_reload">Recargar</string>
+    <string name="setup_step_development_tools">Herramientas de desarrollo</string>
+    <string name="setup_development_tools_description">De forma predeterminada solo se instala lo necesario para ejecutar el entorno, o puedes incluir toda la cadena de desarrollo.</string>
+    <string name="setup_required_tools_description">Linux, los agentes seleccionados, Git y las herramientas de soporte que usa AndCode. Siempre se instalan.</string>
+    <string name="setup_install_full_development_tools">Instalar todas las herramientas de desarrollo</string>
+    <string name="setup_install_full_development_tools_description">Añade runtimes, compiladores, herramientas de compilación, editores y utilidades. Descargará más datos.</string>
+    <string name="setup_development_tools_settings_hint">Puedes omitirlo e instalar la cadena completa más tarde desde Ajustes → Entorno local.</string>
+    <string name="install_step_installing_runtime_tools">Instalando herramientas necesarias</string>
+    <string name="full_development_tools_title">Herramientas de desarrollo</string>
+    <string name="full_development_tools_description">Runtimes, compiladores, herramientas de compilación y utilidades opcionales para proyectos.</string>
+    <string name="full_development_tools_installed">Todas las herramientas de desarrollo están instaladas</string>
+    <string name="install_full_development_tools_button">Instalar cadena completa</string>
+    <string name="runtime_full_development_tools_start_failed">No se pudo iniciar la instalación de herramientas</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1099,4 +1099,16 @@
     <string name="guest_browser_back">Retour</string>
     <string name="guest_browser_forward">Avancer</string>
     <string name="guest_browser_reload">Recharger</string>
+    <string name="setup_step_development_tools">Outils de développement</string>
+    <string name="setup_development_tools_description">Installe uniquement le nécessaire par défaut, ou incluez la chaîne complète d’outils.</string>
+    <string name="setup_required_tools_description">Linux, les agents sélectionnés, Git et les outils requis par AndCode. Ils sont toujours installés.</string>
+    <string name="setup_install_full_development_tools">Installer tous les outils de développement</string>
+    <string name="setup_install_full_development_tools_description">Ajoute les runtimes, compilateurs, outils de build, éditeurs et utilitaires. Plus de données seront téléchargées.</string>
+    <string name="setup_development_tools_settings_hint">Vous pouvez ignorer cette étape et installer la chaîne complète plus tard dans Paramètres → Environnement local.</string>
+    <string name="install_step_installing_runtime_tools">Installation des outils nécessaires</string>
+    <string name="full_development_tools_title">Outils de développement</string>
+    <string name="full_development_tools_description">Runtimes, compilateurs, outils de build et utilitaires facultatifs pour vos projets.</string>
+    <string name="full_development_tools_installed">Tous les outils de développement sont installés</string>
+    <string name="install_full_development_tools_button">Installer la chaîne complète</string>
+    <string name="runtime_full_development_tools_start_failed">Impossible de démarrer l’installation des outils</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1115,4 +1115,16 @@
     <string name="guest_browser_back">戻る</string>
     <string name="guest_browser_forward">進む</string>
     <string name="guest_browser_reload">再読み込み</string>
+    <string name="setup_step_development_tools">開発ツール</string>
+    <string name="setup_development_tools_description">既定では実行に必要なものだけをインストールします。完全な開発ツールチェーンも選択できます。</string>
+    <string name="setup_required_tools_description">Linux、選択したエージェント、Git、および AndCode が使用するサポートツールです。これらは常にインストールされます。</string>
+    <string name="setup_install_full_development_tools">完全な開発ツールをインストール</string>
+    <string name="setup_install_full_development_tools_description">言語ランタイム、コンパイラ、ビルドツール、エディターなどを追加します。より多くのデータをダウンロードします。</string>
+    <string name="setup_development_tools_settings_hint">この手順はスキップして、後で「設定 → ローカルランタイム」から完全なツールチェーンをインストールできます。</string>
+    <string name="install_step_installing_runtime_tools">必要なランタイムツールをインストールしています</string>
+    <string name="full_development_tools_title">開発ツール</string>
+    <string name="full_development_tools_description">プロジェクト向けの追加言語ランタイム、コンパイラ、ビルドツール、ユーティリティです。</string>
+    <string name="full_development_tools_installed">完全な開発ツールをインストール済み</string>
+    <string name="install_full_development_tools_button">完全なツールチェーンをインストール</string>
+    <string name="runtime_full_development_tools_start_failed">開発ツールのインストールを開始できません</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1099,4 +1099,16 @@
     <string name="guest_browser_back">Voltar</string>
     <string name="guest_browser_forward">Avançar</string>
     <string name="guest_browser_reload">Recarregar</string>
+    <string name="setup_step_development_tools">Ferramentas de desenvolvimento</string>
+    <string name="setup_development_tools_description">Por padrão, instale apenas o necessário para executar, ou inclua a cadeia completa de desenvolvimento.</string>
+    <string name="setup_required_tools_description">Linux, os agentes selecionados, Git e as ferramentas de suporte usadas pelo AndCode. São sempre instalados.</string>
+    <string name="setup_install_full_development_tools">Instalar todas as ferramentas de desenvolvimento</string>
+    <string name="setup_install_full_development_tools_description">Adiciona runtimes, compiladores, ferramentas de build, editores e utilitários. Mais dados serão baixados.</string>
+    <string name="setup_development_tools_settings_hint">Você pode ignorar esta etapa e instalar a cadeia completa depois em Configurações → Ambiente local.</string>
+    <string name="install_step_installing_runtime_tools">Instalando ferramentas necessárias</string>
+    <string name="full_development_tools_title">Ferramentas de desenvolvimento</string>
+    <string name="full_development_tools_description">Runtimes, compiladores, ferramentas de build e utilitários opcionais para projetos.</string>
+    <string name="full_development_tools_installed">Todas as ferramentas de desenvolvimento estão instaladas</string>
+    <string name="install_full_development_tools_button">Instalar cadeia completa</string>
+    <string name="runtime_full_development_tools_start_failed">Não foi possível iniciar a instalação das ferramentas</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1101,4 +1101,16 @@
     <string name="guest_browser_back">Назад</string>
     <string name="guest_browser_forward">Вперёд</string>
     <string name="guest_browser_reload">Обновить</string>
+    <string name="setup_step_development_tools">Инструменты разработки</string>
+    <string name="setup_development_tools_description">По умолчанию устанавливаются только необходимые компоненты. При желании можно добавить полный набор инструментов.</string>
+    <string name="setup_required_tools_description">Linux, выбранные агенты, Git и вспомогательные инструменты AndCode. Они устанавливаются всегда.</string>
+    <string name="setup_install_full_development_tools">Установить полный набор инструментов</string>
+    <string name="setup_install_full_development_tools_description">Добавляет языковые среды, компиляторы, инструменты сборки, редакторы и утилиты. Будет загружено больше данных.</string>
+    <string name="setup_development_tools_settings_hint">Можно пропустить этот шаг и установить полный набор позже в Настройки → Локальная среда.</string>
+    <string name="install_step_installing_runtime_tools">Установка необходимых инструментов</string>
+    <string name="full_development_tools_title">Инструменты разработки</string>
+    <string name="full_development_tools_description">Дополнительные языковые среды, компиляторы, инструменты сборки и утилиты для проектов.</string>
+    <string name="full_development_tools_installed">Полный набор инструментов установлен</string>
+    <string name="install_full_development_tools_button">Установить полный набор</string>
+    <string name="runtime_full_development_tools_start_failed">Не удалось начать установку инструментов разработки</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1095,4 +1095,16 @@
     <string name="guest_browser_back">后退</string>
     <string name="guest_browser_forward">前进</string>
     <string name="guest_browser_reload">重新加载</string>
+    <string name="setup_step_development_tools">开发工具</string>
+    <string name="setup_development_tools_description">默认只安装运行所需组件，也可以一并安装完整开发工具链。</string>
+    <string name="setup_required_tools_description">Linux、所选智能体、Git 以及 AndCode 功能依赖的支持工具，将始终安装。</string>
+    <string name="setup_install_full_development_tools">安装完整开发工具</string>
+    <string name="setup_install_full_development_tools_description">将添加语言运行时、编译器、构建工具、编辑器和其他实用工具，需要下载更多数据。</string>
+    <string name="setup_development_tools_settings_hint">可以跳过此步骤，稍后在“设置 → 本地运行时”中安装完整工具链。</string>
+    <string name="install_step_installing_runtime_tools">正在安装运行所需工具</string>
+    <string name="full_development_tools_title">开发工具</string>
+    <string name="full_development_tools_description">用于项目的可选语言运行时、编译器、构建工具和实用程序。</string>
+    <string name="full_development_tools_installed">完整开发工具已安装</string>
+    <string name="install_full_development_tools_button">安装完整工具链</string>
+    <string name="runtime_full_development_tools_start_failed">无法开始安装开发工具</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1118,4 +1118,16 @@
     <string name="guest_browser_back">Back</string>
     <string name="guest_browser_forward">Forward</string>
     <string name="guest_browser_reload">Reload</string>
+    <string name="setup_step_development_tools">Development tools</string>
+    <string name="setup_development_tools_description">Install only the runtime by default, or include the complete development toolchain.</string>
+    <string name="setup_required_tools_description">Linux, the selected agents, Git, and the support tools used by AndCode. These are always installed.</string>
+    <string name="setup_install_full_development_tools">Install complete development tools</string>
+    <string name="setup_install_full_development_tools_description">Adds language runtimes, compilers, build tools, editors, and other utilities. This downloads more data.</string>
+    <string name="setup_development_tools_settings_hint">You can skip this and install the complete toolchain later from Settings → Local runtime.</string>
+    <string name="install_step_installing_runtime_tools">Installing required runtime tools</string>
+    <string name="full_development_tools_title">Development tools</string>
+    <string name="full_development_tools_description">Optional language runtimes, compilers, build tools, and utilities for projects.</string>
+    <string name="full_development_tools_installed">Complete development tools are installed</string>
+    <string name="install_full_development_tools_button">Install complete toolchain</string>
+    <string name="runtime_full_development_tools_start_failed">Could not start development tool installation</string>
 </resources>

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreenTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreenTest.kt
@@ -1,0 +1,29 @@
+package com.yugahashimoto.andcode.feature.onboarding
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidSetupScreenTest {
+    @Test
+    fun `minimal install is skipped only when the selected agents are already installed`() {
+        assertTrue(shouldStartRuntimeInstall(installComplete = false, installFullDevelopmentTools = false))
+        assertFalse(shouldStartRuntimeInstall(installComplete = true, installFullDevelopmentTools = false))
+    }
+
+    @Test
+    fun `full toolchain option runs even when the selected agents are already installed`() {
+        assertTrue(shouldStartRuntimeInstall(installComplete = true, installFullDevelopmentTools = true))
+    }
+
+    @Test
+    fun `full toolchain is not started again when it is already installed`() {
+        assertFalse(
+            shouldStartRuntimeInstall(
+                installComplete = true,
+                installFullDevelopmentTools = true,
+                fullDevelopmentToolsInstalled = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/LocalRuntimeManagementViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/LocalRuntimeManagementViewModelTest.kt
@@ -165,6 +165,27 @@ class LocalRuntimeManagementViewModelTest {
         }
 
     @Test
+    fun `development tool state is loaded and install action is invoked`() =
+        runTest(dispatcher) {
+            // Agent-only runtimes have a Linux environment without an OpenCode server.
+            val runtimeState = MutableStateFlow<LocalRuntimeStatus>(LocalRuntimeStatus.NotInstalled)
+            var installCalls = 0
+            val viewModel =
+                viewModel(
+                    runtimeState = runtimeState,
+                    runtimeEnvironmentInstalledProvider = { true },
+                    fullDevelopmentToolsInstalledProvider = { false },
+                    installFullDevelopmentToolsAction = { installCalls++ },
+                )
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.runtimeEnvironmentInstalled)
+            assertFalse(viewModel.state.value.fullDevelopmentToolsInstalled)
+            viewModel.installFullDevelopmentTools()
+            assertEquals(1, installCalls)
+        }
+
+    @Test
     fun `adb state is collected from adb state flow`() =
         runTest(dispatcher) {
             val runtimeState = MutableStateFlow<LocalRuntimeStatus>(LocalRuntimeStatus.Ready("1.18.3", 4097))
@@ -264,6 +285,9 @@ class LocalRuntimeManagementViewModelTest {
         diagnosticsProvider: suspend () -> LocalRuntimeDiagnostics = { diagnostics(runtimeState.value) },
         lastOperationState: MutableStateFlow<LocalRuntimeOperationResult?> = MutableStateFlow(null),
         repairAction: () -> Unit = {},
+        installFullDevelopmentToolsAction: () -> Unit = {},
+        runtimeEnvironmentInstalledProvider: () -> Boolean = { false },
+        fullDevelopmentToolsInstalledProvider: () -> Boolean = { false },
         deleteAction: () -> Unit = {},
         deleteTimeoutMillis: Long = 30_000L,
         adbState: MutableStateFlow<AdbConnectionState>? = null,
@@ -276,6 +300,9 @@ class LocalRuntimeManagementViewModelTest {
         lastOperationState = lastOperationState,
         diagnosticsProvider = diagnosticsProvider,
         repairAction = repairAction,
+        installFullDevelopmentToolsAction = installFullDevelopmentToolsAction,
+        runtimeEnvironmentInstalledProvider = runtimeEnvironmentInstalledProvider,
+        fullDevelopmentToolsInstalledProvider = fullDevelopmentToolsInstalledProvider,
         deleteAction = deleteAction,
         getString = { resId -> "string/$resId" },
         deleteTimeoutMillis = deleteTimeoutMillis,

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeDiagnosticsTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeDiagnosticsTest.kt
@@ -94,6 +94,25 @@ class LocalRuntimeDiagnosticsTest {
     }
 
     @Test
+    fun `full toolchain diagnostics include optional tools`() {
+        val runtime = temporaryFolder.newFolder("full-toolchain")
+        val collector =
+            LocalRuntimeDiagnosticsCollector(
+                runtimeDirectory = runtime,
+                abi = "arm64-v8a",
+                statusProvider = { LocalRuntimeStatus.Ready("1.18.3", 4097) },
+                processMetricsProvider = { null },
+                commandExecutor = { LocalRuntimeCommandResult(0, "installed") },
+                fullDevelopmentToolsInstalledProvider = { true },
+            )
+
+        val result = collector.collect()
+
+        assertTrue(result.tools.any { it.id == "java" })
+        assertTrue(result.tools.any { it.id == "node" })
+    }
+
+    @Test
     fun `sums resident memory for the full runtime process tree`() {
         val statuses =
             mapOf(

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManagerTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeManagerTest.kt
@@ -1,8 +1,11 @@
 package com.yugahashimoto.andcode.runtime.local
 
+import com.yugahashimoto.andcode.runtime.LocalAgent
 import com.yugahashimoto.andcode.runtime.LocalRuntimeStatus
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -98,6 +101,30 @@ class LocalRuntimeManagerTest {
             )
 
         assertEquals(LocalRuntimeStatus.Stopped("1.17.20", 4096), manager.status())
+    }
+
+    @Test
+    fun `legacy metadata defaults to the full development toolchain`() {
+        val metadata =
+            Json.decodeFromString<LocalRuntimeMetadata>(
+                """{"version":"1.17.20","port":4096,"installedAt":123}""",
+            )
+
+        assertTrue(metadata.fullDevelopmentToolsInstalled)
+        assertTrue(metadata.hasFullDevelopmentTools())
+    }
+
+    @Test
+    fun `legacy Antigravity runtime still offers the Debian toolchain`() {
+        val metadata =
+            Json.decodeFromString<LocalRuntimeMetadata>(
+                """{"version":"1.17.20","port":4096,"installedAt":123,"components":["opencode","antigravity"]}""",
+            )
+
+        assertTrue(metadata.fullDevelopmentToolsInstalled)
+        assertFalse(metadata.hasFullDevelopmentTools())
+        assertTrue(metadata.copy(fullDebianDevelopmentToolsInstalled = true).hasFullDevelopmentTools())
+        assertTrue(metadata.without(LocalAgent.ANTIGRAVITY).hasFullDevelopmentTools())
     }
 
     @Test

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimePackageSelectionTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimePackageSelectionTest.kt
@@ -1,0 +1,39 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalRuntimePackageSelectionTest {
+    @Test
+    fun `Alpine default excludes heavy development packages`() {
+        assertTrue(LocalRuntimeInstaller.REQUIRED_RUNTIME_PACKAGES.containsAll(listOf("git", "android-tools", "python3")))
+        assertFalse(LocalRuntimeInstaller.REQUIRED_RUNTIME_PACKAGES.any { it in listOf("openjdk17", "gradle", "nodejs", "gcc", "go") })
+        assertTrue(LocalRuntimeInstaller.OPTIONAL_DEVELOPMENT_PACKAGES.containsAll(listOf("openjdk17", "gradle", "nodejs", "gcc", "go")))
+        assertTrue(
+            LocalRuntimeInstaller.REQUIRED_RUNTIME_PACKAGES
+                .intersect(LocalRuntimeInstaller.OPTIONAL_DEVELOPMENT_PACKAGES.toSet())
+                .isEmpty(),
+        )
+    }
+
+    @Test
+    fun `Debian default excludes heavy development packages`() {
+        assertTrue(DebianRootfsInstaller.REQUIRED_RUNTIME_PACKAGES.containsAll(listOf("git", "adb", "python3")))
+        assertFalse(
+            DebianRootfsInstaller.REQUIRED_RUNTIME_PACKAGES.any {
+                it in listOf("openjdk-17-jdk-headless", "gradle", "nodejs", "gcc", "golang-go")
+            },
+        )
+        assertTrue(
+            DebianRootfsInstaller.OPTIONAL_DEVELOPMENT_PACKAGES.containsAll(
+                listOf("openjdk-17-jdk-headless", "gradle", "nodejs", "gcc", "golang-go"),
+            ),
+        )
+        assertTrue(
+            DebianRootfsInstaller.REQUIRED_RUNTIME_PACKAGES
+                .intersect(DebianRootfsInstaller.OPTIONAL_DEVELOPMENT_PACKAGES.toSet())
+                .isEmpty(),
+        )
+    }
+}

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeServiceCommandTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeServiceCommandTest.kt
@@ -15,6 +15,10 @@ class LocalRuntimeServiceCommandTest {
             localRuntimeServiceCommand(LocalRuntimeService.ACTION_INSTALL_AND_START),
         )
         assertEquals(
+            LocalRuntimeServiceCommand.InstallFullDevelopmentTools,
+            localRuntimeServiceCommand(LocalRuntimeService.ACTION_INSTALL_FULL_DEVELOPMENT_TOOLS),
+        )
+        assertEquals(
             LocalRuntimeServiceCommand.Start,
             localRuntimeServiceCommand(LocalRuntimeService.ACTION_START),
         )
@@ -143,6 +147,7 @@ class LocalRuntimeServiceCommandTest {
     @Test
     fun `commands that are not an explicit start leave the user-stopped flag alone`() {
         assertFalse(clearsUserStoppedFlag(LocalRuntimeServiceCommand.Stop))
+        assertFalse(clearsUserStoppedFlag(LocalRuntimeServiceCommand.InstallFullDevelopmentTools))
         assertFalse(clearsUserStoppedFlag(LocalRuntimeServiceCommand.Restore))
         assertFalse(clearsUserStoppedFlag(LocalRuntimeServiceCommand.Delete))
         assertFalse(clearsUserStoppedFlag(LocalRuntimeServiceCommand.Ignore))

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeUpdaterTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/LocalRuntimeUpdaterTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -15,6 +16,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.io.IOException
 import java.security.MessageDigest
 
 class LocalRuntimeUpdaterTest {
@@ -388,6 +390,174 @@ class VerifiedRuntimeDownloaderTest {
                 assertTrue(error?.message.orEmpty().contains("SHA-256"))
                 assertEquals("existing", destination.readText())
                 assertFalse(root.resolve("asset.tar.gz.partial").exists())
+            } finally {
+                root.deleteRecursively()
+            }
+        }
+
+    @Test
+    fun `partial download resumes with an HTTP range request`() =
+        runTest {
+            val root = createTempDir(prefix = "verified-downloader-resume-")
+            try {
+                val destination = root.resolve("asset.tar.gz")
+                root.resolve("asset.tar.gz.partial").writeText("hello ")
+                val payload = "hello world"
+                server.enqueue(
+                    MockResponse()
+                        .setResponseCode(206)
+                        .setHeader("Content-Range", "bytes 6-10/11")
+                        .setBody("world"),
+                )
+
+                VerifiedRuntimeDownloader(OkHttpClient()).download(
+                    url = server.url("/asset").toString(),
+                    destination = destination,
+                    expectedSha256 = sha256(payload),
+                    expectedSizeBytes = payload.toByteArray().size.toLong(),
+                )
+
+                assertEquals("bytes=6-", server.takeRequest().getHeader("Range"))
+                assertEquals(payload, destination.readText())
+                assertFalse(root.resolve("asset.tar.gz.partial").exists())
+            } finally {
+                root.deleteRecursively()
+            }
+        }
+
+    @Test
+    fun `server ignoring range restarts the partial download`() =
+        runTest {
+            val root = createTempDir(prefix = "verified-downloader-restart-")
+            try {
+                val destination = root.resolve("asset.tar.gz")
+                root.resolve("asset.tar.gz.partial").writeText("stale prefix")
+                val payload = "complete payload"
+                server.enqueue(MockResponse().setResponseCode(200).setBody(payload))
+
+                VerifiedRuntimeDownloader(OkHttpClient()).download(
+                    url = server.url("/asset").toString(),
+                    destination = destination,
+                    expectedSha256 = sha256(payload),
+                    expectedSizeBytes = payload.toByteArray().size.toLong(),
+                )
+
+                assertEquals("bytes=12-", server.takeRequest().getHeader("Range"))
+                assertEquals(payload, destination.readText())
+            } finally {
+                root.deleteRecursively()
+            }
+        }
+
+    @Test
+    fun `interrupted response retains bytes and the next attempt resumes`() =
+        runTest {
+            val root = kotlin.io.path.createTempDirectory("verified-downloader-interrupted-").toFile()
+            try {
+                val destination = root.resolve("asset.tar.gz").apply { writeText("existing") }
+                val partial = root.resolve("asset.tar.gz.partial")
+                val payload = "0123456789abcdef".repeat(8192)
+                val downloader = VerifiedRuntimeDownloader(OkHttpClient())
+                server.enqueue(MockResponse().setBody(payload).setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY))
+
+                val failure =
+                    runCatching {
+                        downloader.download(server.url("/asset").toString(), destination, sha256(payload), payload.length.toLong())
+                    }.exceptionOrNull()
+
+                assertTrue(failure is IOException)
+                assertEquals("existing", destination.readText())
+                val offset = partial.length()
+                assertTrue(offset in 1 until payload.length.toLong())
+                assertEquals(payload.take(offset.toInt()), partial.readText())
+                server.takeRequest()
+                server.enqueue(
+                    MockResponse()
+                        .setResponseCode(206)
+                        .setHeader("Content-Range", "bytes $offset-${payload.lastIndex}/${payload.length}")
+                        .setBody(payload.drop(offset.toInt())),
+                )
+
+                downloader.download(server.url("/asset").toString(), destination, sha256(payload), payload.length.toLong())
+
+                assertEquals("bytes=$offset-", server.takeRequest().getHeader("Range"))
+                assertEquals(payload, destination.readText())
+                assertFalse(partial.exists())
+            } finally {
+                root.deleteRecursively()
+            }
+        }
+
+    @Test
+    fun `invalid range discards partial without replacing the active file`() =
+        runTest {
+            val root = kotlin.io.path.createTempDirectory("verified-downloader-bad-range-").toFile()
+            try {
+                val destination = root.resolve("asset.tar.gz").apply { writeText("existing") }
+                val partial = root.resolve("asset.tar.gz.partial").apply { writeText("hello ") }
+                server.enqueue(MockResponse().setResponseCode(206).setHeader("Content-Range", "bytes 0-4/11").setBody("world"))
+
+                val failure =
+                    runCatching {
+                        VerifiedRuntimeDownloader(OkHttpClient()).download(
+                            server.url("/asset").toString(),
+                            destination,
+                            sha256("hello world"),
+                            11L,
+                        )
+                    }.exceptionOrNull()
+
+                assertTrue(failure?.message.orEmpty().contains("Content-Range"))
+                assertEquals("existing", destination.readText())
+                assertFalse(partial.exists())
+            } finally {
+                root.deleteRecursively()
+            }
+        }
+
+    @Test
+    fun `complete partial download is reused without another request`() =
+        runTest {
+            val root = createTempDir(prefix = "verified-downloader-complete-partial-")
+            try {
+                val destination = root.resolve("asset.tar.gz")
+                val payload = "complete payload"
+                root.resolve("asset.tar.gz.partial").writeText(payload)
+
+                VerifiedRuntimeDownloader(OkHttpClient()).download(
+                    url = server.url("/asset").toString(),
+                    destination = destination,
+                    expectedSha256 = sha256(payload),
+                )
+
+                assertEquals(payload, destination.readText())
+                assertEquals(0, server.requestCount)
+                assertFalse(root.resolve("asset.tar.gz.partial").exists())
+            } finally {
+                root.deleteRecursively()
+            }
+        }
+
+    @Test
+    fun `range not satisfiable retries once from byte zero`() =
+        runTest {
+            val root = createTempDir(prefix = "verified-downloader-range-retry-")
+            try {
+                val destination = root.resolve("asset.tar.gz")
+                root.resolve("asset.tar.gz.partial").writeText("stale")
+                val payload = "complete payload"
+                server.enqueue(MockResponse().setResponseCode(416))
+                server.enqueue(MockResponse().setResponseCode(200).setBody(payload))
+
+                VerifiedRuntimeDownloader(OkHttpClient()).download(
+                    url = server.url("/asset").toString(),
+                    destination = destination,
+                    expectedSha256 = sha256(payload),
+                )
+
+                assertEquals("bytes=5-", server.takeRequest().getHeader("Range"))
+                assertEquals(null, server.takeRequest().getHeader("Range"))
+                assertEquals(payload, destination.readText())
             } finally {
                 root.deleteRecursively()
             }


### PR DESCRIPTION
## Why

The first local Runtime setup previously installed the complete development toolchain in the same large `apk add` transaction as the required Runtime dependencies. On a mobile network, an interruption late in that transaction could discard the staging environment and force the user to download the toolchain again from the beginning.

## What changed

### Minimal-by-default Runtime setup

- The Android onboarding flow now has five steps: agent selection, development tools, Runtime installation, sign-in, and GitHub.
- The development-tools step keeps the Runtime requirements checked and non-editable.
- The single “Install complete development tools” option is unchecked by default.
- The step explains that the full toolchain can be installed later from Settings.
- The onboarding waits for the optional installation to finish before advancing, prevents duplicate clicks, and recovers from fast failures so the user can retry.

### Optional toolchain from Settings

- Settings → Local Runtime shows a development-tools card after a Runtime environment exists.
- The card detects whether the complete toolchain is already installed.
- If it is missing, one action installs the remaining toolchain into the existing Runtime; if it is present, the card reports that it is installed.
- This works with the existing Alpine and Debian local-agent paths without changing OpenCode, Claude Code, or Antigravity behavior.

### Package and state handling

- Required packages remain limited to the tools needed to run the selected agents and AndCode integration (including Git, ADB, Python/Pillow, certificates, and shell/network utilities).
- Editors, convenience utilities, GitHub CLI, JDK/Gradle, Node/npm, compilers/build tools, Go, SQLite, and archive utilities are optional.
- Alpine and Debian installers now keep separate required/optional package sets.
- Runtime metadata records whether the full Alpine and Debian toolchains are installed; legacy metadata remains compatible with existing Runtimes.
- Optional installation runs against the active Runtime and restores the previous Ready/Stopped state if it fails or is cancelled.

### Download and retry behavior

- Verified Runtime downloads keep their `.partial` files and resume with HTTP Range requests when possible.
- Complete verified files continue to be reused from the existing cache.
- Alpine APKs are stored in a persistent Runtime cache and Debian packages in a persistent apt archive cache, so a retry can reuse packages already downloaded before a network interruption.
- A failed optional install no longer requires rebuilding the Linux rootfs or downloading OpenCode again.

## Verification

- Mandatory repository-reviewer subagent pre-PR review completed with verdict `APPROVE`; the reviewer report is reproduced verbatim at the end of this description.
- Targeted Runtime/onboarding unit tests passed (28 actionable Gradle tasks), including package selection, onboarding navigation, manager/service failure recovery, diagnostics, and resumable downloader coverage.
- `spotlessApply`, `detekt`, `spotlessCheck`, locale-key parity, and `git diff --check` passed.
- F-Droid debug APK built successfully for arm64-v8a.
- Real-device validation used the isolated test package `com.yugahashimoto.andcode.runtimetest` on an arm64 Android phone, leaving the official AndCode installation untouched. It confirmed:
  - the five-step onboarding and unchecked full-toolchain option;
  - a successful minimal install with `fullDevelopmentToolsInstalled=false` and only required Alpine packages;
  - the Settings → Local Runtime “Install complete toolchain” entry;
  - a successful follow-up install reaching Alpine `apk` 109/109 and `OK: 1435.8 MiB in 258 packages`;
  - metadata changing to `fullDevelopmentToolsInstalled=true` and the Settings card changing to “complete development tools installed”;
  - diagnostics reporting the installed Bash, Node/npm, Go, Make, GCC, and Gradle versions.
- The test device reports an Android/PRoot executable-memory limitation when launching Java. The JDK files are installed; this pre-existing runtime compatibility issue is outside this installer change.

<!-- pre-pr-review: approved -->
## Pre-PR review

APPROVE

I re-read the latest `origin/main...HEAD` diff and didn’t find any remaining blocking issue in the requested areas. The fast-failure onboarding case you called out is now handled, and the rest of the runtime-install, resume, settings-entry, and localization changes look internally consistent from the diff.