### PR TITLE
fix(schedule): allow independent schedules to run concurrently

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinator.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinator.kt
@@ -1,0 +1,25 @@
+package com.yugahashimoto.andcode.feature.schedule
+
+import android.os.SystemClock
+import java.util.Collections
+
+/** Tracks schedule jobs independently while the shared foreground service is alive. */
+internal class ScheduleExecutionCoordinator {
+    private val activeSchedules = Collections.synchronizedSet(mutableSetOf<String>())
+
+    fun tryStart(scheduleId: String): Boolean = activeSchedules.add(scheduleId)
+
+    /** Returns true when this completion leaves no schedule job running. */
+    fun finish(scheduleId: String): Boolean = activeSchedules.remove(scheduleId) && activeSchedules.isEmpty()
+}
+
+/** Progress and stream state owned by one scheduled session. */
+internal class ScheduleExecutionState {
+    @Volatile var streamFailure: String? = null
+
+    @Volatile var lastProgressAt: Long = 0L
+
+    fun markProgress() {
+        lastProgressAt = SystemClock.elapsedRealtime()
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinator.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinator.kt
@@ -1,16 +1,27 @@
 package com.yugahashimoto.andcode.feature.schedule
 
 import android.os.SystemClock
-import java.util.Collections
 
 /** Tracks schedule jobs independently while the shared foreground service is alive. */
 internal class ScheduleExecutionCoordinator {
-    private val activeSchedules = Collections.synchronizedSet(mutableSetOf<String>())
+    private val activeSchedules = mutableSetOf<String>()
+    private var latestStartId = 0
 
-    fun tryStart(scheduleId: String): Boolean = activeSchedules.add(scheduleId)
+    @Synchronized
+    fun tryStart(
+        scheduleId: String,
+        startId: Int,
+    ): Boolean {
+        latestStartId = maxOf(latestStartId, startId)
+        return activeSchedules.add(scheduleId)
+    }
 
-    /** Returns true when this completion leaves no schedule job running. */
-    fun finish(scheduleId: String): Boolean = activeSchedules.remove(scheduleId) && activeSchedules.isEmpty()
+    /** Returns the newest service start ID when this completion leaves no job running. */
+    @Synchronized
+    fun finish(scheduleId: String): Int? {
+        if (!activeSchedules.remove(scheduleId) || activeSchedules.isNotEmpty()) return null
+        return latestStartId
+    }
 }
 
 /** Progress and stream state owned by one scheduled session. */

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.Collections
 
 /**
  * Executes a scheduled prompt in the foreground.
@@ -58,7 +57,7 @@ class ScheduleExecutionService : Service() {
     private var inForeground = false
 
     /** Active schedule IDs; different schedules use independent sessions concurrently. */
-    private val activeSchedules = Collections.synchronizedSet(mutableSetOf<String>())
+    private val executionCoordinator = ScheduleExecutionCoordinator()
 
     override fun onCreate() {
         super.onCreate()
@@ -102,7 +101,7 @@ class ScheduleExecutionService : Service() {
             stopSelf()
             return START_NOT_STICKY
         }
-        if (scheduleId in activeSchedules) {
+        if (!executionCoordinator.tryStart(scheduleId)) {
             // A service instance can host multiple independent schedules. Only the same schedule
             // is rejected here; a different schedule gets its own session and execution state.
             app.scheduleRepository.schedule(scheduleId)?.let { schedule ->
@@ -115,15 +114,14 @@ class ScheduleExecutionService : Service() {
             }
             return START_NOT_STICKY
         }
-        activeSchedules += scheduleId
+        val executionStartId = startId
         scope.launch {
             try {
                 execute(scheduleId, failedAttempts, automatic)
             } finally {
-                activeSchedules -= scheduleId
-                if (activeSchedules.isEmpty()) {
+                if (executionCoordinator.finish(scheduleId)) {
                     stopForeground(STOP_FOREGROUND_REMOVE)
-                    stopSelf()
+                    stopSelfResult(executionStartId)
                 }
             }
         }
@@ -214,7 +212,7 @@ class ScheduleExecutionService : Service() {
             // The slot is covered; a retry armed by an earlier attempt would now start a second run.
             app.scheduleManager.cancelRetry(schedule.id)
             updateForegroundNotification(app.getString(R.string.schedule_notification_running))
-            runPrompt(target, schedule, run, ExecutionState())
+            runPrompt(target, schedule, run, ScheduleExecutionState())
         } catch (cancellation: CancellationException) {
             // The system stopped the service under us. Settle the run so hasActiveRun does not go
             // on blocking the schedule until the next process start, but never report it as a
@@ -278,7 +276,7 @@ class ScheduleExecutionService : Service() {
         target: RuntimeTarget,
         schedule: Schedule,
         run: ScheduleRun,
-        state: ExecutionState,
+        state: ScheduleExecutionState,
     ) {
         val autoAccept = schedule.autoAcceptPermissions ?: app.settings.autoAcceptPermissions
         state.markProgress()
@@ -338,7 +336,7 @@ class ScheduleExecutionService : Service() {
      */
     private suspend fun awaitSettlement(
         settled: Deferred<ScheduleCompletion>,
-        state: ExecutionState,
+        state: ScheduleExecutionState,
     ): ScheduleSettlement {
         val startedAt = SystemClock.elapsedRealtime()
         while (true) {
@@ -437,7 +435,7 @@ class ScheduleExecutionService : Service() {
         schedule: Schedule,
         run: ScheduleRun,
         autoAccept: Boolean,
-        state: ExecutionState,
+        state: ScheduleExecutionState,
     ): ScheduleCompletion {
         val reason =
             try {
@@ -461,7 +459,7 @@ class ScheduleExecutionService : Service() {
     private suspend fun pollForCompletion(
         target: RuntimeTarget,
         run: ScheduleRun,
-        state: ExecutionState,
+        state: ScheduleExecutionState,
     ): ScheduleCompletion {
         var settling: String? = null
         var progressMark: String? = null
@@ -504,7 +502,7 @@ class ScheduleExecutionService : Service() {
         schedule: Schedule,
         run: ScheduleRun,
         autoAccept: Boolean,
-        state: ExecutionState,
+        state: ScheduleExecutionState,
     ): ScheduleCompletion? {
         val targetSessionId = run.sessionId
         val notifyUser = target.id != app.runtimeRegistry.selected.value?.id
@@ -551,16 +549,6 @@ class ScheduleExecutionService : Service() {
             return signal.result
         }
         return null
-    }
-
-    private class ExecutionState {
-        @Volatile var streamFailure: String? = null
-
-        @Volatile var lastProgressAt: Long = 0L
-
-        fun markProgress() {
-            lastProgressAt = SystemClock.elapsedRealtime()
-        }
     }
 
     private fun recordCompleted(run: ScheduleRun) {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
@@ -40,6 +39,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.Collections
 
 /**
  * Executes a scheduled prompt in the foreground.
@@ -56,27 +56,9 @@ class ScheduleExecutionService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var app: AndCodeApplication
     private var inForeground = false
-    private var executionJob: Job? = null
 
-    /**
-     * Which schedule [executionJob] belongs to.
-     *
-     * The service is one instance shared by every schedule, so the job alone cannot say whose run
-     * is in flight - and reporting another schedule's run as this one's "previous run" would be a
-     * plain lie in the history and in the notification.
-     */
-    private var runningScheduleId: String? = null
-
-    /** Why the event stream stopped, when it stopped before the run settled. */
-    @Volatile
-    private var streamFailure: String? = null
-
-    /**
-     * Elapsed-realtime stamp of the last sign of life from the run, on which the idle timeout is
-     * measured. Written by the event stream and the transcript poll, read by [awaitSettlement].
-     */
-    @Volatile
-    private var lastProgressAt: Long = 0L
+    /** Active schedule IDs; different schedules use independent sessions concurrently. */
+    private val activeSchedules = Collections.synchronizedSet(mutableSetOf<String>())
 
     override fun onCreate() {
         super.onCreate()
@@ -120,38 +102,31 @@ class ScheduleExecutionService : Service() {
             stopSelf()
             return START_NOT_STICKY
         }
-        if (executionJob?.isActive == true) {
-            // One service instance runs one schedule at a time, and per-run state (the idle stamp,
-            // the stream failure) lives on it, so a second run cannot simply be started alongside.
-            // Which schedule is holding the slot decides what to say and whether to try again.
-            val ownRun = runningScheduleId == scheduleId
+        if (scheduleId in activeSchedules) {
+            // A service instance can host multiple independent schedules. Only the same schedule
+            // is rejected here; a different schedule gets its own session and execution state.
             app.scheduleRepository.schedule(scheduleId)?.let { schedule ->
                 app.reportScheduleStartFailure(
                     schedule = schedule,
-                    reason =
-                        getString(
-                            if (ownRun) R.string.schedule_run_overlapping else R.string.schedule_service_busy,
-                        ),
+                    reason = getString(R.string.schedule_run_overlapping),
                     failedAttempts = failedAttempts,
-                    // This schedule's own run is still going: a retry would only ask the same
-                    // question and stack a second session on it if the answer ever changed. Another
-                    // schedule's run is the opposite - it ends on its own, and the retry is exactly
-                    // what lets this slot still happen instead of being lost to a neighbour.
-                    retryable = !ownRun && automatic,
+                    retryable = false,
                 )
             }
             return START_NOT_STICKY
         }
-        runningScheduleId = scheduleId
-        executionJob =
-            scope.launch {
-                try {
-                    execute(scheduleId, failedAttempts, automatic)
-                } finally {
+        activeSchedules += scheduleId
+        scope.launch {
+            try {
+                execute(scheduleId, failedAttempts, automatic)
+            } finally {
+                activeSchedules -= scheduleId
+                if (activeSchedules.isEmpty()) {
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     stopSelf()
                 }
             }
+        }
         return START_NOT_STICKY
     }
 
@@ -239,7 +214,7 @@ class ScheduleExecutionService : Service() {
             // The slot is covered; a retry armed by an earlier attempt would now start a second run.
             app.scheduleManager.cancelRetry(schedule.id)
             updateForegroundNotification(app.getString(R.string.schedule_notification_running))
-            runPrompt(target, schedule, run)
+            runPrompt(target, schedule, run, ExecutionState())
         } catch (cancellation: CancellationException) {
             // The system stopped the service under us. Settle the run so hasActiveRun does not go
             // on blocking the schedule until the next process start, but never report it as a
@@ -303,17 +278,17 @@ class ScheduleExecutionService : Service() {
         target: RuntimeTarget,
         schedule: Schedule,
         run: ScheduleRun,
+        state: ExecutionState,
     ) {
         val autoAccept = schedule.autoAcceptPermissions ?: app.settings.autoAcceptPermissions
-        streamFailure = null
-        markProgress()
+        state.markProgress()
         // Subscribe before sending: fast runtimes can emit idle during sendMessage itself.
         val watcher: Deferred<ScheduleCompletion> =
             scope.async(start = CoroutineStart.UNDISPATCHED) {
-                awaitStreamCompletion(target, schedule, run, autoAccept)
+                awaitStreamCompletion(target, schedule, run, autoAccept, state)
             }
         // The poll sleeps before its first read, so it only ever sees this prompt's own turn.
-        val transcriptPoll: Deferred<ScheduleCompletion> = scope.async { pollForCompletion(target, run) }
+        val transcriptPoll: Deferred<ScheduleCompletion> = scope.async { pollForCompletion(target, run, state) }
         val settled: Deferred<ScheduleCompletion> =
             scope.async {
                 select<ScheduleCompletion> {
@@ -331,14 +306,14 @@ class ScheduleExecutionService : Service() {
                     agent = schedule.agentId,
                 ),
             )
-            when (val settlement = awaitSettlement(settled)) {
+            when (val settlement = awaitSettlement(settled, state)) {
                 is ScheduleSettlement.Settled -> settle(target, schedule, run, settlement.completion)
                 is ScheduleSettlement.GaveUp -> {
                     val message =
                         when (settlement.timeout) {
                             // A stream that stopped early explains the silence better than the
                             // timeout does.
-                            ScheduleRunTimeout.IDLE -> streamFailure ?: getString(R.string.schedule_completion_timeout)
+                            ScheduleRunTimeout.IDLE -> state.streamFailure ?: getString(R.string.schedule_completion_timeout)
                             ScheduleRunTimeout.MAX_DURATION -> getString(R.string.schedule_max_duration)
                         }
                     recordFailed(run, message)
@@ -361,7 +336,10 @@ class ScheduleExecutionService : Service() {
      * The old flat cap on the whole run failed every schedule whose work honestly takes longer than
      * the cap, however healthy it was - a prompt that writes twenty articles never stood a chance.
      */
-    private suspend fun awaitSettlement(settled: Deferred<ScheduleCompletion>): ScheduleSettlement {
+    private suspend fun awaitSettlement(
+        settled: Deferred<ScheduleCompletion>,
+        state: ExecutionState,
+    ): ScheduleSettlement {
         val startedAt = SystemClock.elapsedRealtime()
         while (true) {
             withTimeoutOrNull(WATCHDOG_TICK_MS) { settled.await() }
@@ -369,7 +347,7 @@ class ScheduleExecutionService : Service() {
             val now = SystemClock.elapsedRealtime()
             scheduleRunTimeout(
                 elapsedMs = now - startedAt,
-                sinceProgressMs = now - lastProgressAt,
+                sinceProgressMs = now - state.lastProgressAt,
                 idleTimeoutMs = IDLE_TIMEOUT_MS,
                 maxDurationMs = MAX_RUN_DURATION_MS,
             )?.let { return ScheduleSettlement.GaveUp(it) }
@@ -459,10 +437,11 @@ class ScheduleExecutionService : Service() {
         schedule: Schedule,
         run: ScheduleRun,
         autoAccept: Boolean,
+        state: ExecutionState,
     ): ScheduleCompletion {
         val reason =
             try {
-                watchForCompletion(target, schedule, run, autoAccept)?.let { return it }
+                watchForCompletion(target, schedule, run, autoAccept, state)?.let { return it }
                 getString(R.string.schedule_event_stream_ended)
             } catch (cancellation: CancellationException) {
                 throw cancellation
@@ -470,7 +449,7 @@ class ScheduleExecutionService : Service() {
                 error.message?.takeIf(String::isNotBlank) ?: error.javaClass.simpleName
             }
         Log.w(TAG, "Event stream stopped before the run settled: $reason")
-        streamFailure = reason
+        state.streamFailure = reason
         awaitCancellation()
     }
 
@@ -482,6 +461,7 @@ class ScheduleExecutionService : Service() {
     private suspend fun pollForCompletion(
         target: RuntimeTarget,
         run: ScheduleRun,
+        state: ExecutionState,
     ): ScheduleCompletion {
         var settling: String? = null
         var progressMark: String? = null
@@ -497,7 +477,7 @@ class ScheduleExecutionService : Service() {
             // holds the idle timeout off.
             val mark = transcriptProgressMarkOf(messages)
             if (mark != progressMark) {
-                if (progressMark != null) markProgress()
+                if (progressMark != null) state.markProgress()
                 progressMark = mark
             }
             val newest = messages.lastOrNull()?.info
@@ -524,13 +504,14 @@ class ScheduleExecutionService : Service() {
         schedule: Schedule,
         run: ScheduleRun,
         autoAccept: Boolean,
+        state: ExecutionState,
     ): ScheduleCompletion? {
         val targetSessionId = run.sessionId
         val notifyUser = target.id != app.runtimeRegistry.selected.value?.id
 
         try {
             target.events().collect { event ->
-                if (progressSessionIdOf(event) == targetSessionId) markProgress()
+                if (progressSessionIdOf(event) == targetSessionId) state.markProgress()
                 when (event) {
                     is OpenCodeEvent.SessionIdle -> {
                         if (event.sessionId == targetSessionId) {
@@ -572,8 +553,14 @@ class ScheduleExecutionService : Service() {
         return null
     }
 
-    private fun markProgress() {
-        lastProgressAt = SystemClock.elapsedRealtime()
+    private class ExecutionState {
+        @Volatile var streamFailure: String? = null
+
+        @Volatile var lastProgressAt: Long = 0L
+
+        fun markProgress() {
+            lastProgressAt = SystemClock.elapsedRealtime()
+        }
     }
 
     private fun recordCompleted(run: ScheduleRun) {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionService.kt
@@ -101,7 +101,7 @@ class ScheduleExecutionService : Service() {
             stopSelf()
             return START_NOT_STICKY
         }
-        if (!executionCoordinator.tryStart(scheduleId)) {
+        if (!executionCoordinator.tryStart(scheduleId, startId)) {
             // A service instance can host multiple independent schedules. Only the same schedule
             // is rejected here; a different schedule gets its own session and execution state.
             app.scheduleRepository.schedule(scheduleId)?.let { schedule ->
@@ -114,14 +114,13 @@ class ScheduleExecutionService : Service() {
             }
             return START_NOT_STICKY
         }
-        val executionStartId = startId
         scope.launch {
             try {
                 execute(scheduleId, failedAttempts, automatic)
             } finally {
-                if (executionCoordinator.finish(scheduleId)) {
+                executionCoordinator.finish(scheduleId)?.let { latestStartId ->
                     stopForeground(STOP_FOREGROUND_REMOVE)
-                    stopSelfResult(executionStartId)
+                    stopSelfResult(latestStartId)
                 }
             }
         }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinatorTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinatorTest.kt
@@ -1,5 +1,6 @@
 package com.yugahashimoto.andcode.feature.schedule
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotSame
@@ -11,20 +12,20 @@ class ScheduleExecutionCoordinatorTest {
     fun `different schedules can run at the same time`() {
         val coordinator = ScheduleExecutionCoordinator()
 
-        assertTrue(coordinator.tryStart("first"))
-        assertTrue(coordinator.tryStart("second"))
-        assertFalse(coordinator.finish("first"))
-        assertTrue(coordinator.finish("second"))
+        assertTrue(coordinator.tryStart("first", 1))
+        assertTrue(coordinator.tryStart("second", 2))
+        assertEquals(null, coordinator.finish("first"))
+        assertEquals(2, coordinator.finish("second"))
     }
 
     @Test
     fun `same schedule cannot be started twice`() {
         val coordinator = ScheduleExecutionCoordinator()
 
-        assertTrue(coordinator.tryStart("same"))
-        assertFalse(coordinator.tryStart("same"))
-        assertTrue(coordinator.finish("same"))
-        assertTrue(coordinator.tryStart("same"))
+        assertTrue(coordinator.tryStart("same", 1))
+        assertFalse(coordinator.tryStart("same", 2))
+        assertEquals(2, coordinator.finish("same"))
+        assertTrue(coordinator.tryStart("same", 3))
     }
 
     @Test

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinatorTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/schedule/ScheduleExecutionCoordinatorTest.kt
@@ -1,0 +1,42 @@
+package com.yugahashimoto.andcode.feature.schedule
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScheduleExecutionCoordinatorTest {
+    @Test
+    fun `different schedules can run at the same time`() {
+        val coordinator = ScheduleExecutionCoordinator()
+
+        assertTrue(coordinator.tryStart("first"))
+        assertTrue(coordinator.tryStart("second"))
+        assertFalse(coordinator.finish("first"))
+        assertTrue(coordinator.finish("second"))
+    }
+
+    @Test
+    fun `same schedule cannot be started twice`() {
+        val coordinator = ScheduleExecutionCoordinator()
+
+        assertTrue(coordinator.tryStart("same"))
+        assertFalse(coordinator.tryStart("same"))
+        assertTrue(coordinator.finish("same"))
+        assertTrue(coordinator.tryStart("same"))
+    }
+
+    @Test
+    fun `execution state is not shared between sessions`() {
+        val first = ScheduleExecutionState()
+        val second = ScheduleExecutionState()
+
+        first.streamFailure = "first failure"
+        first.lastProgressAt = 1L
+
+        assertNotSame(first, second)
+        assertNotEquals(first.streamFailure, second.streamFailure)
+        assertNotEquals(first.lastProgressAt, second.lastProgressAt)
+    }
+}


### PR DESCRIPTION
## Summary
- Allow different schedules to run in independent sessions concurrently.
- Keep duplicate runs of the same schedule rejected.
- Isolate per-run progress state and guard service shutdown with the latest start ID.

## Verification
- `ANDROID_HOME=/opt/android-sdk ANDROID_SDK_ROOT=/opt/android-sdk ./gradlew detekt spotlessCheck :app:testGithubDebugUnitTest --tests 'com.yugahashimoto.andcode.feature.schedule.ScheduleExecutionCoordinatorTest'`

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
なし

## 提案（非ブロッキング）
なし

## チェック済み項目
- `origin/main...schedule-parallel-runs` の全差分3ファイルを確認
- Coordinatorの並列実行・同一スケジュール重複防止を確認
- 重複起動後に最新`startId`で`stopSelfResult`する修正を確認
- Coordinatorテスト追加内容を確認
- 関連するService、Manager、AlarmReceiverの呼び出し関係を確認
- `git diff --check`で問題なし
- 今回の変更によるリソースキー追加・i18n変更はなし