### PR TITLE
fix(chat): stop crash when removing an image attachment

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatHomeScreen.kt
@@ -88,10 +88,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -236,12 +234,6 @@ fun ChatHomeScreen(
     val coroutineScope = rememberCoroutineScope()
     var showSlashCommands by remember { mutableStateOf(false) }
     var showSidePanel by remember { mutableStateOf(false) }
-    val attachedImages = remember { mutableStateListOf<Bitmap>() }
-    DisposableEffect(Unit) {
-        onDispose {
-            attachedImages.clear()
-        }
-    }
     val context = androidx.compose.ui.platform.LocalContext.current
     val imageSaveLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("image/*")) { uri ->
@@ -264,7 +256,6 @@ fun ChatHomeScreen(
             ActivityResultContracts.TakePicturePreview(),
         ) { bitmap ->
             if (bitmap != null) {
-                attachedImages.add(bitmap)
                 onImageAttachment(bitmap)
             }
         }
@@ -287,7 +278,6 @@ fun ChatHomeScreen(
                             android.graphics.BitmapFactory.decodeStream(it)
                         }
                     if (bitmap != null) {
-                        attachedImages.add(bitmap)
                         onImageAttachment(bitmap)
                     }
                 } catch (e: Exception) {
@@ -330,12 +320,6 @@ fun ChatHomeScreen(
     // A subagent session is a detour, not a destination: the system back gesture returns to the
     // main agent instead of leaving the chat, matching the in-chat return banner.
     BackHandler(enabled = state.parentSession != null) { onReturnToParentSession() }
-
-    LaunchedEffect(state.attachments) {
-        if (state.attachments.isEmpty()) {
-            attachedImages.clear()
-        }
-    }
 
     Box(
         modifier =
@@ -622,11 +606,12 @@ fun ChatHomeScreen(
                     githubRefs = githubRefs,
                     pullRequests = state.pullRequests,
                     onOpenUrl = onOpenUrl,
-                    attachedImages = attachedImages,
-                    onRemoveImage = {
-                        val removed = attachedImages.removeAt(it)
-                        if (!removed.isRecycled) removed.recycle()
-                        onRemoveAttachment(it)
+                    // The composer thumbnails render the ViewModel's previews directly: a local
+                    // copy of the list drifted out of step with the attachments it stood for, so a
+                    // removal could drop the wrong image or leave a thumbnail with nothing behind it.
+                    attachedImages = state.imagePreviews,
+                    onRemoveImage = { previewIndex ->
+                        attachmentIndexForPreview(state.attachments, previewIndex)?.let(onRemoveAttachment)
                     },
                     onCameraLaunch = {
                         if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -300,6 +300,30 @@ internal fun imageMime(
 }
 
 /**
+ * Maps an index into [ChatUiState.attachments] onto its index in [ChatUiState.imagePreviews],
+ * or null when the attachment carries no preview.
+ *
+ * The two lists are not parallel: a file picked with the paperclip appends an attachment without a
+ * preview bitmap, so the previews line up with the *image* attachments in attachment order rather
+ * than with every attachment. Removing attachment 2 must not drop preview 2 when the images sit at
+ * different offsets.
+ */
+internal fun previewIndexForAttachment(
+    attachments: List<PromptAttachment>,
+    attachmentIndex: Int,
+): Int? {
+    val attachment = attachments.getOrNull(attachmentIndex) ?: return null
+    if (!attachment.mime.startsWith("image/")) return null
+    return attachments.take(attachmentIndex).count { it.mime.startsWith("image/") }
+}
+
+/** Inverse of [previewIndexForAttachment]: the attachment behind the preview thumbnail at [previewIndex]. */
+internal fun attachmentIndexForPreview(
+    attachments: List<PromptAttachment>,
+    previewIndex: Int,
+): Int? = attachments.indices.filter { attachments[it].mime.startsWith("image/") }.getOrNull(previewIndex)
+
+/**
  * Appends the message-level error reported by the runtime when the turn itself carries no error
  * part. A failed provider request is persisted with the error on the message (`info.error`) and
  * often nothing else, so without this the transcript would silently drop the failed turn.
@@ -780,12 +804,23 @@ class ChatViewModel(
         }
     }
 
+    /**
+     * Drops the attachment at [index], along with its preview thumbnail when it has one.
+     *
+     * The preview bitmap is dropped, never recycled: the same instance is still referenced by the
+     * composer row Compose is drawing this frame (and, once sent, by the optimistic message in the
+     * transcript and by any queued prompt), so recycling it here crashed the next draw pass with
+     * "Canvas: trying to use a recycled bitmap". Since API 26 the pixels live on the native heap
+     * and are freed with the bitmap by the GC, so letting the last reference go is enough.
+     */
     fun removeAttachment(index: Int) {
-        _uiState.value.imagePreviews.getOrNull(index)?.let { if (!it.isRecycled) it.recycle() }
         _uiState.update { state ->
+            val previewIndex = previewIndexForAttachment(state.attachments, index)
             state.copy(
                 attachments = state.attachments.filterIndexed { i, _ -> i != index },
-                imagePreviews = state.imagePreviews.filterIndexed { i, _ -> i != index },
+                imagePreviews =
+                    previewIndex?.let { removed -> state.imagePreviews.filterIndexed { i, _ -> i != removed } }
+                        ?: state.imagePreviews,
             )
         }
     }
@@ -1039,10 +1074,13 @@ class ChatViewModel(
         val normalized = text.trim()
         val pendingAttachments = _uiState.value.attachments
         val messageIdsBeforeSend = _uiState.value.messages.map { it.id }.toSet()
+        val pendingPreviews = _uiState.value.imagePreviews
         val pendingPreviewsByFilename =
-            pendingAttachments.mapIndexedNotNull { index, attachment ->
-                _uiState.value.imagePreviews.getOrNull(index)?.let { attachment.filename to it }
-            }.toMap()
+            pendingAttachments
+                .filter { it.mime.startsWith("image/") }
+                .mapIndexedNotNull { index, attachment ->
+                    pendingPreviews.getOrNull(index)?.let { attachment.filename to it }
+                }.toMap()
         if (normalized.isEmpty() && pendingAttachments.isEmpty()) return
         val currentBackend = backend
         if (currentBackend == null) {
@@ -2259,10 +2297,8 @@ class ChatViewModel(
     }
 
     override fun onCleared() {
-        _uiState.value.imagePreviews.forEach { if (!it.isRecycled) it.recycle() }
-        _uiState.value.messages.forEach { msg ->
-            msg.imagePreviews.forEach { if (!it.isRecycled) it.recycle() }
-        }
+        // Preview bitmaps are deliberately not recycled here either: the composition that draws
+        // them can outlive the ViewModel during teardown, and the GC reclaims them anyway.
         eventJob?.cancel()
         tts?.stop()
         tts = null

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatAttachmentPreviewIndexTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatAttachmentPreviewIndexTest.kt
@@ -1,0 +1,53 @@
+package com.yugahashimoto.andcode.feature.chat
+
+import com.yugahashimoto.andcode.core.api.PromptAttachment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChatAttachmentPreviewIndexTest {
+    private fun image(name: String) = PromptAttachment(name, "image/jpeg", "data:image/jpeg;base64,AQ==")
+
+    private fun file(name: String) = PromptAttachment(name, "text/plain", "file:///tmp/$name")
+
+    @Test
+    fun `preview index counts only images before the attachment`() {
+        val attachments = listOf(file("notes.txt"), image("first.jpg"), file("log.txt"), image("second.jpg"))
+
+        assertEquals(0, previewIndexForAttachment(attachments, 1))
+        assertEquals(1, previewIndexForAttachment(attachments, 3))
+    }
+
+    @Test
+    fun `non-image attachment has no preview`() {
+        val attachments = listOf(image("first.jpg"), file("notes.txt"))
+
+        assertNull(previewIndexForAttachment(attachments, 1))
+    }
+
+    @Test
+    fun `out of range attachment has no preview`() {
+        assertNull(previewIndexForAttachment(listOf(image("first.jpg")), 4))
+        assertNull(previewIndexForAttachment(emptyList(), 0))
+    }
+
+    @Test
+    fun `thumbnail maps back to the attachment it stands for`() {
+        val attachments = listOf(file("notes.txt"), image("first.jpg"), file("log.txt"), image("second.jpg"))
+
+        assertEquals(1, attachmentIndexForPreview(attachments, 0))
+        assertEquals(3, attachmentIndexForPreview(attachments, 1))
+        assertNull(attachmentIndexForPreview(attachments, 2))
+    }
+
+    @Test
+    fun `mappings are inverses of each other`() {
+        val attachments = listOf(image("a.jpg"), file("b.txt"), image("c.png"), image("d.webp"))
+
+        attachments.indices
+            .mapNotNull { previewIndexForAttachment(attachments, it)?.to(it) }
+            .forEach { (previewIndex, attachmentIndex) ->
+                assertEquals(attachmentIndex, attachmentIndexForPreview(attachments, previewIndex))
+            }
+    }
+}


### PR DESCRIPTION
Fixes #298

## The crash

Tapping the `x` on a composer image thumbnail recycled the preview bitmap immediately, in two places at once:

- `ChatHomeScreen` — `attachedImages.removeAt(index).recycle()`
- `ChatViewModel.removeAttachment` — `imagePreviews[index].recycle()`

That `Bitmap` instance is still referenced by the composition Compose is about to draw (and, once the message is sent, by the optimistic message in the transcript and by any queued prompt), so the next draw pass died with `java.lang.RuntimeException: Canvas: trying to use a recycled bitmap`, exactly as in the reported stack trace.

## The fix

Preview bitmaps are dropped, never recycled. Since API 26 (the app's `minSdk`) the pixels live on the native heap and are freed with the bitmap by the GC, so releasing the last reference is enough. The same reasoning applies to `onCleared`, where the composition can outlive the ViewModel during teardown — those recycle loops are gone too. Steady-state retention is unchanged: the previews the transcript holds were already alive for the session's lifetime.

Removal was also going through the wrong list, which the same tap could hit:

- The composer kept its own `mutableStateListOf<Bitmap>` copy of the attached bitmaps. It drifted out of step with the ViewModel's attachments whenever an import failed (thumbnail with no attachment behind it, shifting every later index) or an image was removed from the attachment tray instead (stale thumbnail left behind). The composer now renders `state.imagePreviews` directly, so there is one source of truth.
- `removeAttachment` and `sendMessage` both assumed previews were indexed like attachments, but a file picked with the paperclip appends an attachment with no preview. The two lists are now mapped by image ordinal via `previewIndexForAttachment` / `attachmentIndexForPreview`, matching what `ChatMessageComponents` already does when it renders a sent message.

One behaviour change: a captured or picked image now appears in the composer once its import finishes rather than instantly, since the thumbnail follows the attachment it stands for.

## Testing

- New `ChatAttachmentPreviewIndexTest` covers the attachment ↔ preview index mapping in both directions, including files interleaved with images and out-of-range indices.
- `./gradlew :app:testGithubDebugUnitTest` — 1011 tests, 0 failures.
- `./gradlew detekt spotlessCheck` — passing.
- Not verified on a device: this environment has no emulator, so the crash repro itself was reasoned from the stack trace and the code path, not reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UrPtQypHwG6pRhoynykQc

---
_Generated by [Claude Code](https://claude.ai/code/session_017UrPtQypHwG6pRhoynykQc)_