### PR TITLE
fix(app): stop file-link and wake-word foreground crashes (#300 #301)

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/core/UrlLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/UrlLauncher.kt
@@ -1,5 +1,6 @@
 package com.yugahashimoto.andcode.core
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -10,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
+import java.util.Locale
 
 /**
  * Single choke point for opening URLs in an external app.
@@ -35,7 +37,7 @@ object UrlLauncher {
         if (colon <= 0) return false
         val scheme = trimmed.substring(0, colon)
         if (!scheme.matches(SCHEME_REGEX)) return false
-        val normalized = scheme.lowercase()
+        val normalized = scheme.lowercase(Locale.ROOT)
         if (normalized != "http" && normalized != "https") return false
         // Require the authority form ("http://..."), not "http:foo".
         return trimmed.regionMatches(colon + 1, "//", 0, 2, ignoreCase = false)
@@ -58,7 +60,7 @@ object UrlLauncher {
             val intent =
                 Intent(Intent.ACTION_VIEW, Uri.parse(url.trim())).apply {
                     // Callers pass activity and application contexts alike.
-                    if (context !is android.app.Activity) {
+                    if (context !is Activity) {
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     }
                 }

--- a/app/src/main/java/com/yugahashimoto/andcode/core/UrlLauncher.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/core/UrlLauncher.kt
@@ -1,0 +1,94 @@
+package com.yugahashimoto.andcode.core
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+
+/**
+ * Single choke point for opening URLs in an external app.
+ *
+ * Chat messages render agent-authored Markdown, and a link such as
+ * `[workspace](file:///workspace/my-workspace)` used to reach Compose's default
+ * [UriHandler], which fires `ACTION_VIEW` with the raw `file://` URI. Android 7+
+ * rejects that with [android.os.FileUriExposedException] and the app crashed
+ * (issue #300). Only `http`/`https` URLs are ever handed to another app now;
+ * anything else is ignored.
+ */
+object UrlLauncher {
+    private const val TAG = "UrlLauncher"
+    private val SCHEME_REGEX = Regex("[a-zA-Z][a-zA-Z0-9+.-]*")
+
+    // Pure-Kotlin scheme check (no android.net.Uri, so plain JVM tests can cover it).
+    // Only http/https are ever handed to another app; file://, content://, intent://,
+    // javascript:, data: and bare paths are all refused.
+    fun isOpenableUrl(url: String): Boolean {
+        val trimmed = url.trim()
+        if (trimmed.isEmpty()) return false
+        val colon = trimmed.indexOf(':')
+        if (colon <= 0) return false
+        val scheme = trimmed.substring(0, colon)
+        if (!scheme.matches(SCHEME_REGEX)) return false
+        val normalized = scheme.lowercase()
+        if (normalized != "http" && normalized != "https") return false
+        // Require the authority form ("http://..."), not "http:foo".
+        return trimmed.regionMatches(colon + 1, "//", 0, 2, ignoreCase = false)
+    }
+
+    /**
+     * Opens [url] in an external app when it is an http(s) URL.
+     *
+     * @return true when an external activity was started, false otherwise.
+     */
+    fun openUrl(
+        context: Context,
+        url: String,
+    ): Boolean {
+        if (!isOpenableUrl(url)) {
+            Log.w(TAG, "Refusing to open non-http(s) URL")
+            return false
+        }
+        return runCatching {
+            val intent =
+                Intent(Intent.ACTION_VIEW, Uri.parse(url.trim())).apply {
+                    // Callers pass activity and application contexts alike.
+                    if (context !is android.app.Activity) {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                }
+            context.startActivity(intent)
+            true
+        }.onFailure { error ->
+            Log.w(TAG, "Unable to open URL", error)
+        }.getOrDefault(false)
+    }
+}
+
+/**
+ * A [UriHandler] that only opens http(s) URLs, guarding every
+ * `LinkAnnotation.Url` click rendered from agent-authored Markdown.
+ */
+private class SafeUriHandler(
+    private val context: Context,
+) : UriHandler {
+    override fun openUri(uri: String) {
+        UrlLauncher.openUrl(context, uri)
+    }
+}
+
+/**
+ * Wraps [content] so that Markdown link clicks anywhere below only ever open
+ * http(s) URLs externally instead of crashing on `file://` URIs.
+ */
+@Composable
+fun ProvideSafeUriHandler(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val handler = remember(context) { SafeUriHandler(context) }
+    CompositionLocalProvider(LocalUriHandler provides handler, content = content)
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatMessageComponents.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.R
+import com.yugahashimoto.andcode.core.ProvideSafeUriHandler
 import com.yugahashimoto.andcode.core.api.PermissionRequest
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.ui.theme.LocalThemeColors
@@ -285,8 +286,12 @@ private fun InlineText(
         remember(inlines, linkColor, codeBackground) {
             renderInline(inlines, codeBackground, linkColor)
         }
-    SelectionContainer {
-        Text(text = annotated, style = style)
+    // Agent-authored Markdown can contain file:// links: the default UriHandler would
+    // forward those to another app and crash with FileUriExposedException (issue #300).
+    ProvideSafeUriHandler {
+        SelectionContainer {
+            Text(text = annotated, style = style)
+        }
     }
 }
 
@@ -332,7 +337,10 @@ private fun LinkedText(
                 }
             }
         }
-    Text(text = annotated, style = style)
+    // Same file:// guard as InlineText above (issue #300).
+    ProvideSafeUriHandler {
+        Text(text = annotated, style = style)
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
@@ -1,6 +1,5 @@
 package com.yugahashimoto.andcode.feature.onboarding
 
-import android.content.Intent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -383,9 +382,7 @@ fun AndroidSetupScreen(
             onSubmit = onSubmitProviderAuth,
             onCompleteCode = onCompleteProviderOAuth,
             onLaunchBrowser = { url ->
-                runCatching {
-                    context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)))
-                }
+                com.yugahashimoto.andcode.core.UrlLauncher.openUrl(context, url)
             },
             onDismiss = onDismissProviderAuth,
         )

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/onboarding/AndroidSetupScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.R
+import com.yugahashimoto.andcode.core.UrlLauncher
 import com.yugahashimoto.andcode.core.api.OpenCodeProvider
 import com.yugahashimoto.andcode.core.api.ProviderAuthMethod
 import com.yugahashimoto.andcode.feature.settings.ProviderAuthDialog
@@ -382,7 +383,7 @@ fun AndroidSetupScreen(
             onSubmit = onSubmitProviderAuth,
             onCompleteCode = onCompleteProviderOAuth,
             onLaunchBrowser = { url ->
-                com.yugahashimoto.andcode.core.UrlLauncher.openUrl(context, url)
+                UrlLauncher.openUrl(context, url)
             },
             onDismiss = onDismissProviderAuth,
         )

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/support/GitHubStarUi.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/support/GitHubStarUi.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import com.yugahashimoto.andcode.AndCodeApplication
 import com.yugahashimoto.andcode.R
 import com.yugahashimoto.andcode.core.ProjectLinks
+import com.yugahashimoto.andcode.core.UrlLauncher
 
 @Composable
 fun GitHubStarPromptDialog(
@@ -251,5 +252,5 @@ fun openProjectLink(
     context: Context,
     url: String,
 ) {
-    com.yugahashimoto.andcode.core.UrlLauncher.openUrl(context, url)
+    UrlLauncher.openUrl(context, url)
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/support/GitHubStarUi.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/support/GitHubStarUi.kt
@@ -1,8 +1,6 @@
 package com.yugahashimoto.andcode.feature.support
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -253,11 +251,5 @@ fun openProjectLink(
     context: Context,
     url: String,
 ) {
-    runCatching {
-        context.startActivity(
-            Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            },
-        )
-    }
+    com.yugahashimoto.andcode.core.UrlLauncher.openUrl(context, url)
 }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordService.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/wakeword/WakeWordService.kt
@@ -1,5 +1,6 @@
 package com.yugahashimoto.andcode.feature.wakeword
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -66,11 +67,34 @@ class WakeWordService : Service() {
     // detection stands down until it is handed back.
     @Volatile private var micHoldToken: String? = null
 
+    // Whether the foreground promotion in onCreate succeeded. Every path through
+    // onStartCommand ends in stopSelf when this is false, so the platform never waits
+    // in vain for a startForeground that is never coming (issue #301).
+    private var inForeground = false
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
         super.onCreate()
         activeInstance = this
+        // startForegroundService() obliges the service to call startForeground() within a
+        // few seconds on *every* path - validation failures and ACTION_STOP included -
+        // or the platform kills the app with ForegroundServiceDidNotStartInTimeException
+        // (issue #301). Promoting here, before any permission checks or disk I/O, meets
+        // that deadline; LocalRuntimeService promotes in onCreate for the same reason.
+        inForeground =
+            runCatching { startForegroundWithNotification() }
+                .recoverCatching { error ->
+                    // The microphone-typed promotion needs RECORD_AUDIO; without it the
+                    // typed call throws SecurityException. An untyped promotion still
+                    // satisfies the startForeground deadline before onStartCommand stops
+                    // the service on the permission failure below.
+                    Log.w(TAG, "Typed foreground failed, retrying untyped", error)
+                    startForegroundUntyped()
+                }
+                .onFailure { error ->
+                    Log.e(TAG, "Unable to start wake-word foreground service", error)
+                }.isSuccess
     }
 
     override fun onStartCommand(
@@ -78,6 +102,11 @@ class WakeWordService : Service() {
         flags: Int,
         startId: Int,
     ): Int {
+        if (!inForeground) {
+            persistEnabled(false)
+            stopSelf()
+            return START_NOT_STICKY
+        }
         when (intent?.action) {
             ACTION_STOP -> {
                 persistEnabled(false)
@@ -108,12 +137,6 @@ class WakeWordService : Service() {
             return START_NOT_STICKY
         }
         runCatching { startForegroundWithNotification() }
-            .onFailure {
-                Log.e(TAG, "Unable to start wake-word foreground service", it)
-                persistEnabled(false)
-                stopSelf()
-                return START_NOT_STICKY
-            }
         if (assistantRequestId != null) {
             currentLanguage = language
         } else {
@@ -137,6 +160,19 @@ class WakeWordService : Service() {
     }
 
     private fun startForegroundWithNotification() {
+        val notification = buildNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun startForegroundUntyped() {
+        startForeground(NOTIFICATION_ID, buildNotification())
+    }
+
+    private fun buildNotification(): Notification {
         val channel =
             NotificationChannel(
                 CHANNEL_ID,
@@ -179,11 +215,7 @@ class WakeWordService : Service() {
                 .setSilent(true)
                 .build()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
-        }
+        return notification
     }
 
     /**

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -1,7 +1,6 @@
 package com.yugahashimoto.andcode.ui
 
 import android.Manifest
-import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -70,6 +69,7 @@ import androidx.navigation.navArgument
 import com.yugahashimoto.andcode.AndCodeApplication
 import com.yugahashimoto.andcode.BuildConfig
 import com.yugahashimoto.andcode.R
+import com.yugahashimoto.andcode.core.UrlLauncher
 import com.yugahashimoto.andcode.core.diagnostics.CrashLog
 import com.yugahashimoto.andcode.feature.activity.ActivityViewModel
 import com.yugahashimoto.andcode.feature.assistant.SpeechRecognizerManager
@@ -909,7 +909,7 @@ fun AndCodeApp(
                                 app.antigravityController.setPermissionMode(mode, chatState.sessionId)
                             },
                             onOpenUrl = { url ->
-                                runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))) }
+                                UrlLauncher.openUrl(context, url)
                             },
                             settingsState = settingsState,
                             onOpenProviderAuth = settingsViewModel::openProviderAuth,
@@ -926,7 +926,7 @@ fun AndCodeApp(
                             onRefreshAntigravityState = app.antigravityController::refresh,
                             onConnectGitHub = { settingsViewModel.beginGitHubDeviceFlow() },
                             onOpenGitHubVerification = { url ->
-                                context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)))
+                                UrlLauncher.openUrl(context, url)
                             },
                             onDisconnectGitHub = settingsViewModel::disconnectGitHub,
                             onBack = { navController.popBackStack() },
@@ -1080,7 +1080,7 @@ fun AndCodeApp(
                                 chatViewModel.openParentSession()
                             },
                             onOpenUrl = { url ->
-                                runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))) }
+                                UrlLauncher.openUrl(context, url)
                             },
                         )
                     }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -1,7 +1,6 @@
 package com.yugahashimoto.andcode.ui.navigation
 
 import android.content.Context
-import android.content.Intent
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -14,6 +13,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.yugahashimoto.andcode.R
+import com.yugahashimoto.andcode.core.UrlLauncher
 import com.yugahashimoto.andcode.data.settings.AppPreferences
 import com.yugahashimoto.andcode.data.settings.AppPreferencesRepository
 import com.yugahashimoto.andcode.feature.assistant.TtsPreview
@@ -345,7 +345,7 @@ fun NavGraphBuilder.settingsNavGraph(
             onSignOut = claudeActions.onSignOut,
             onOpenMcp = { navController.navigate(ROUTE_SETTINGS_MCP_CLAUDE) },
             onOpenUrl = { url ->
-                runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))) }
+                UrlLauncher.openUrl(context, url)
             },
             onBack = { navController.popBackStack() },
         )
@@ -363,7 +363,7 @@ fun NavGraphBuilder.settingsNavGraph(
             onSignOut = antigravityActions.onSignOut,
             onOpenMcp = { navController.navigate(ROUTE_SETTINGS_MCP_ANTIGRAVITY) },
             onOpenUrl = { url ->
-                runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))) }
+                UrlLauncher.openUrl(context, url)
             },
             onBack = { navController.popBackStack() },
         )
@@ -384,9 +384,9 @@ fun NavGraphBuilder.settingsNavGraph(
             onDisconnectProvider = settingsViewModel::disconnectProvider,
             onLaunchOAuthBrowser = { url ->
                 runCatching {
-                    context.startActivity(
-                        Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)),
-                    )
+                    if (!UrlLauncher.openUrl(context, url)) {
+                        error("Unsupported URL")
+                    }
                 }.onFailure { error ->
                     settingsViewModel.reportOAuthError(error.message.orEmpty())
                 }
@@ -403,8 +403,11 @@ fun NavGraphBuilder.settingsNavGraph(
             onConnect = settingsViewModel::beginGitHubDeviceFlow,
             onDisconnect = settingsViewModel::disconnectGitHub,
             onOpenVerification = { url ->
-                runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))) }
-                    .onFailure { error -> settingsViewModel.reportOAuthError(error.message.orEmpty()) }
+                runCatching {
+                    if (!UrlLauncher.openUrl(context, url)) {
+                        error("Unsupported URL")
+                    }
+                }.onFailure { error -> settingsViewModel.reportOAuthError(error.message.orEmpty()) }
             },
             onBack = { navController.popBackStack() },
         )
@@ -415,7 +418,7 @@ fun NavGraphBuilder.settingsNavGraph(
             registry = runtimeRegistry,
             agent = com.yugahashimoto.andcode.runtime.LocalAgent.OPEN_CODE,
             onOpenBrowser = { url ->
-                context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)))
+                UrlLauncher.openUrl(context, url)
             },
             onBack = { navController.popBackStack() },
         )

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/SettingsNavGraph.kt
@@ -383,12 +383,8 @@ fun NavGraphBuilder.settingsNavGraph(
             onCompleteProviderOAuth = settingsViewModel::completeProviderOAuth,
             onDisconnectProvider = settingsViewModel::disconnectProvider,
             onLaunchOAuthBrowser = { url ->
-                runCatching {
-                    if (!UrlLauncher.openUrl(context, url)) {
-                        error("Unsupported URL")
-                    }
-                }.onFailure { error ->
-                    settingsViewModel.reportOAuthError(error.message.orEmpty())
+                if (!UrlLauncher.openUrl(context, url)) {
+                    settingsViewModel.reportOAuthError(context.getString(R.string.provider_auth_failed))
                 }
             },
             onDismissProviderAuth = settingsViewModel::dismissProviderAuth,
@@ -403,11 +399,9 @@ fun NavGraphBuilder.settingsNavGraph(
             onConnect = settingsViewModel::beginGitHubDeviceFlow,
             onDisconnect = settingsViewModel::disconnectGitHub,
             onOpenVerification = { url ->
-                runCatching {
-                    if (!UrlLauncher.openUrl(context, url)) {
-                        error("Unsupported URL")
-                    }
-                }.onFailure { error -> settingsViewModel.reportOAuthError(error.message.orEmpty()) }
+                if (!UrlLauncher.openUrl(context, url)) {
+                    settingsViewModel.reportOAuthError(context.getString(R.string.provider_auth_failed))
+                }
             },
             onBack = { navController.popBackStack() },
         )

--- a/app/src/test/java/com/yugahashimoto/andcode/core/UrlLauncherTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/core/UrlLauncherTest.kt
@@ -1,0 +1,33 @@
+package com.yugahashimoto.andcode.core
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UrlLauncherTest {
+    @Test
+    fun `http and https URLs are openable`() {
+        assertTrue(UrlLauncher.isOpenableUrl("http://example.com"))
+        assertTrue(UrlLauncher.isOpenableUrl("https://example.com/path?q=1"))
+        assertTrue(UrlLauncher.isOpenableUrl("  HTTPS://EXAMPLE.COM  "))
+    }
+
+    @Test
+    fun `file URL from issue 300 is refused`() {
+        assertFalse(UrlLauncher.isOpenableUrl("file:///workspace/my-workspace"))
+    }
+
+    @Test
+    fun `non-http schemes and bare paths are refused`() {
+        assertFalse(UrlLauncher.isOpenableUrl("content://com.example/x"))
+        assertFalse(UrlLauncher.isOpenableUrl("intent://example.com#Intent;end"))
+        assertFalse(UrlLauncher.isOpenableUrl("javascript:alert(1)"))
+        assertFalse(UrlLauncher.isOpenableUrl("data:text/plain,hello"))
+        assertFalse(UrlLauncher.isOpenableUrl("/workspace/my-workspace"))
+        assertFalse(UrlLauncher.isOpenableUrl("workspace/my-workspace"))
+        assertFalse(UrlLauncher.isOpenableUrl(""))
+        assertFalse(UrlLauncher.isOpenableUrl("   "))
+        assertFalse(UrlLauncher.isOpenableUrl("http:example.com"))
+        assertFalse(UrlLauncher.isOpenableUrl("1http://example.com"))
+    }
+}


### PR DESCRIPTION
Fixes #300 and #301.

- #300: chat Markdown links with `file://` URIs crashed with `FileUriExposedException` via Compose's default `UriHandler`. New `core/UrlLauncher` only ever opens http(s) URLs externally; `ProvideSafeUriHandler` guards all chat message link rendering, and every explicit `onOpenUrl`/`onOpenBrowser` call site goes through it. Added `UrlLauncherTest`.
- #301: `WakeWordService` could be started via `startForegroundService()` and then return from `onStartCommand` without `startForeground()` (validation failures, ACTION_STOP), causing `ForegroundServiceDidNotStartInTimeException`. The service now promotes itself in `onCreate` (same pattern as `LocalRuntimeService`), with an untyped fallback when RECORD_AUDIO is missing, and every `onStartCommand` path stops only after a successful promotion.

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- `core/UrlLauncher.kt:42` — `if (context !is android.app.Activity)` の完全修飾参照は `import android.app.Activity` に統一できると読みやすくなります（動作・CIには影響なし）。
- `core/UrlLauncher.kt:31` — `scheme.lowercase()` はASCIIスキーム限定のため実害はありませんが、将来的にdetekt指摘を避けたい場合は `lowercase(Locale.ROOT)` 検討。
- `ui/navigation/SettingsNavGraph.kt:415` 付近 — MCP向け `onOpenBrowser` の `context.startActivity(...)` 生呼び出し1箇所だけ旧形式のままです。今回の#300/#301対象外でありレジストリ由来URLのためブロッカーではありませんが、将来 `UrlLauncher` に寄せると防御が一貫します。

## チェック済み項目
- `git diff origin/main...fix-issue-300-301-crash` 全8ファイル（UrlLauncher新規94行、ChatMessageComponents、AndroidSetupScreen、GitHubStarUi、WakeWordService、AndCodeApp、SettingsNavGraph、UrlLauncherTest）を読了
- 前回ブロッカーの修正を確認：`SettingsNavGraph.kt` の `error("Unsupported URL")` ハードコードが消え、`context.getString(R.string.provider_auth_failed)` 2箇所（OAuthブラウザ起動・GitHub検証URL）に置換、`android.content.Intent` import削除・`UrlLauncher` import追加・`android.net.Uri` 完全修飾の除去を確認
- `provider_auth_failed` が全8ロケールに存在することをgrepで確認（values/ar/es/fr/ja/pt-rBR/ru/zh-rCN）
- `SettingsViewModel.reportOAuthError(message: String)` が `takeIf(String::isNotBlank)` でそのまま表示するだけであり、UI層でローカライズ済み文字列を渡す現行パターンに適合することを確認（ViewModel側のi18n違反なし）
- #300修正の正当性を確認：`isOpenableUrl` がhttp/https＋`://`必須でfile/content/intent/javascript/data/ベアパスを拒否、`openUrl` がActivity外context時のみNEW_TASK付与・失敗時false返却、`ProvideSafeUriHandler` がInlineText/LinkedText（TableCellText経由含む）を被覆、AndroidSetupScreen・GitHubStarUi・AndCodeApp3箇所の集約を確認
- #301修正の正当性を確認：`onCreate` 先行フォアグラウンド化＋`inForeground` ガードでACTION_STOP・権限なし・モデル未導入の検証パスでも期限切れを回避、`startForegroundUntyped` フォールバック、`buildNotification(): Notification` 分離と `import android.app.Notification` 追加、`LocalRuntimeService.onCreate` の同パターンと一致することを確認
- ユーザー可視ハードコードなしを確認（追加ログは英語のみ、コメントは英語、表示文字列は既存キー再利用のみ、新規strings.xml差分なし）
- `UrlLauncherTest` 3テスト（http/https許可・file拒否・非http10件拒否）の追加を確認、WakeWordServiceに既存単体テストなしのため追加不要と判断

Note: after this approval only cosmetic commits followed (import/`Locale.ROOT` polish); MCP `onOpenBrowser` noted above was already migrated to `UrlLauncher` in this branch.