### PR TITLE
fix(chat): show thinking content instead of empty reasoning cards

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -135,6 +135,11 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
             turnCompletedAt = maxOf(turnCompletedAt ?: 0L, completed)
         }
         message.parts.forEach { part ->
+            // Blank reasoning carries nothing to expand: the server emits empty reasoning parts
+            // (e.g. an initial streaming snapshot, or a reasoning_details-only part whose text
+            // lives in state), and showing them produced "Thinking" cards that expanded to
+            // nothing. Skip them so they never form an activity group or a detail row.
+            if (part is ChatPart.Reasoning && part.text.isBlank()) return@forEach
             when {
                 part is ChatPart.Tool && part.name == "todowrite" && part.todos.isNotEmpty() -> {
                     flush()
@@ -192,7 +197,7 @@ fun summarizeActivity(parts: List<ChatPart>): ActivitySummary {
 
     parts.forEach { part ->
         when (part) {
-            is ChatPart.Reasoning -> reasoning++
+            is ChatPart.Reasoning -> if (part.text.isNotBlank()) reasoning++
             is ChatPart.Patch -> counts.increment(ToolCategory.EDIT)
             is ChatPart.Tool -> {
                 counts.increment(part.name.toToolCategory())

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityRow.kt
@@ -155,6 +155,9 @@ fun AssistantActivitySheet(
 ) {
     val summary = summarizeActivity(parts)
     val title = if (summary.isEmpty) stringResource(R.string.activity_details_title) else activitySummaryText(summary)
+    // Blank reasoning has no content to expand; the timeline already filters it, but the sheet
+    // re-resolves its parts from the live messages, so filter again as defense in depth.
+    val visibleParts = remember(parts) { parts.filterNot { it is ChatPart.Reasoning && it.text.isBlank() } }
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(start = 8.dp, end = 16.dp, bottom = 4.dp),
@@ -175,7 +178,7 @@ fun AssistantActivitySheet(
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            itemsIndexed(parts, key = ::activityPartKey) { _, part ->
+            itemsIndexed(visibleParts, key = ::activityPartKey) { _, part ->
                 when (part) {
                     is ChatPart.Reasoning -> ReasoningCard(part, autoExpand = autoExpandReasoning)
                     is ChatPart.Tool -> ToolCard(part)
@@ -258,10 +261,10 @@ fun ReasoningCard(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            if (expanded && part.text.isNotBlank()) {
+            if (expanded) {
                 Spacer(Modifier.height(6.dp))
                 Text(
-                    text = part.text,
+                    text = part.text.ifBlank { stringResource(R.string.reasoning_empty) },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
                 )

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -245,7 +245,7 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
     val stateMap = state.orEmpty()
     return when (type) {
         "text" -> ChatPart.Text(partId, text.orEmpty())
-        "reasoning" -> ChatPart.Reasoning(partId, text.orEmpty())
+        "reasoning" -> ChatPart.Reasoning(partId, extractReasoningText(text, stateMap))
         "file", "image" -> {
             val partUrl = url.orEmpty()
             val partMime = imageMime(mime, partUrl)
@@ -278,6 +278,38 @@ internal fun OpenCodePart.toChatPart(): ChatPart? {
         "patch" -> ChatPart.Patch(partId, extractPatchFiles(stateMap))
         else -> null
     }
+}
+
+/**
+ * Reasoning text is normally the part's top-level `text`, but some servers and OpenAI-compatible
+ * providers persist it under `state` instead (e.g. `state.reasoningDetails[*].text`) while leaving
+ * the top level empty. Without this fallback every such part rendered as a "Thinking" card that
+ * showed nothing when expanded.
+ */
+internal fun extractReasoningText(
+    topLevelText: String?,
+    state: Map<String, JsonElement>,
+): String {
+    if (!topLevelText.isNullOrBlank()) return topLevelText
+    state["text"]?.jsonPrimitiveOrNull()?.takeIf { it.isNotBlank() }?.let { return it }
+    state["content"]?.jsonPrimitiveOrNull()?.takeIf { it.isNotBlank() }?.let { return it }
+    state["reasoning"]?.jsonPrimitiveOrNull()?.takeIf { it.isNotBlank() }?.let { return it }
+    for (key in listOf("reasoningDetails", "reasoning_details", "details")) {
+        extractReasoningDetailsText(state[key])?.takeIf { it.isNotBlank() }?.let { return it }
+    }
+    return ""
+}
+
+private fun extractReasoningDetailsText(element: JsonElement?): String? {
+    val array = element as? JsonArray ?: return null
+    val texts =
+        array.mapNotNull { entry ->
+            val obj = entry as? JsonObject ?: return@mapNotNull null
+            obj["text"]?.jsonPrimitiveOrNull()?.takeIf { it.isNotBlank() }
+                ?: obj["content"]?.jsonPrimitiveOrNull()?.takeIf { it.isNotBlank() }
+                ?: obj["summary"]?.jsonPrimitiveOrNull()?.takeIf { it.isNotBlank() }
+        }
+    return texts.joinToString("").takeIf { it.isNotBlank() }
 }
 
 /** Image-producing tools do not consistently include a MIME field in their file parts. */
@@ -1979,11 +2011,38 @@ class ChatViewModel(
                 val partId = part.id ?: messageId
                 val chatPart = part.toChatPart() ?: return
                 val messageParts = streamedParts.getOrPut(messageId) { linkedMapOf() }
-                messageParts[partId] = chatPart
+                // Deltas can arrive before the part event that introduces them (see issue #26924):
+                // they are accumulated under the same part id, and the late snapshot must not wipe
+                // them out with its own (often empty) initial text.
+                val mergedPart =
+                    when (val existing = messageParts[partId]) {
+                        is ChatPart.Text ->
+                            when {
+                                chatPart is ChatPart.Text && chatPart.text.isBlank() && existing.text.isNotBlank() -> existing
+                                // An early delta was stored as Text (deltas carry no part type) but
+                                // the snapshot reveals it was reasoning: keep the accumulated text.
+                                chatPart is ChatPart.Reasoning && chatPart.text.isBlank() && existing.text.isNotBlank() ->
+                                    chatPart.copy(text = existing.text)
+                                else -> chatPart
+                            }
+                        is ChatPart.Reasoning ->
+                            if ((chatPart is ChatPart.Reasoning && chatPart.text.isBlank()) ||
+                                (chatPart is ChatPart.Text && chatPart.text.isBlank())
+                            ) {
+                                if (existing.text.isNotBlank()) existing else chatPart
+                            } else {
+                                chatPart
+                            }
+                        else -> chatPart
+                    }
+                messageParts[partId] = mergedPart
                 updateStreamingMessage(messageId, messageParts.values.toList())
             }
             is OpenCodeEvent.MessagePartDelta -> {
-                if (event.sessionId != activeSession || event.field != "text") return
+                // OpenCode streams both text and reasoning deltas with field="text"; the Claude
+                // bridge uses field="reasoning" for thinking deltas. Anything else carries no
+                // displayable text.
+                if (event.sessionId != activeSession || (event.field != "text" && event.field != "reasoning")) return
                 connectionMonitor.recordStreamToken()
                 val messageParts = streamedParts.getOrPut(event.messageId) { linkedMapOf() }
                 val updatedPart =
@@ -1992,7 +2051,12 @@ class ChatViewModel(
                         is ChatPart.Reasoning -> existing.copy(text = existing.text + event.delta)
                         // A delta can outrun the part event that introduces it; start the part here
                         // rather than dropping the text on the floor.
-                        null -> ChatPart.Text(event.partId, event.delta)
+                        null ->
+                            if (event.field == "reasoning") {
+                                ChatPart.Reasoning(event.partId, event.delta)
+                            } else {
+                                ChatPart.Text(event.partId, event.delta)
+                            }
                         else -> return
                     }
                 messageParts[event.partId] = updatedPart

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">السماح دائمًا</string>
     <string name="reject">رفض</string>
     <string name="reasoning_card_title">الاستدلال</string>
+    <string name="reasoning_empty">لا يوجد محتوى للاستدلال</string>
     <string name="tool_status_pending">قيد الانتظار</string>
     <string name="tool_status_running">قيد التشغيل</string>
     <string name="tool_status_completed">مكتمل</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">Permitir siempre</string>
     <string name="reject">Rechazar</string>
     <string name="reasoning_card_title">Razonamiento</string>
+    <string name="reasoning_empty">Sin contenido de razonamiento</string>
     <string name="tool_status_pending">Pendiente</string>
     <string name="tool_status_running">En ejecución</string>
     <string name="tool_status_completed">Completado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">Toujours autoriser</string>
     <string name="reject">Refuser</string>
     <string name="reasoning_card_title">Raisonnement</string>
+    <string name="reasoning_empty">Aucun contenu de raisonnement</string>
     <string name="tool_status_pending">En attente</string>
     <string name="tool_status_running">En cours</string>
     <string name="tool_status_completed">Terminé</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">常に許可</string>
     <string name="reject">拒否</string>
     <string name="reasoning_card_title">思考</string>
+    <string name="reasoning_empty">思考内容がありません</string>
     <string name="tool_status_pending">保留中</string>
     <string name="tool_status_running">実行中</string>
     <string name="tool_status_completed">完了</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">Sempre permitir</string>
     <string name="reject">Rejeitar</string>
     <string name="reasoning_card_title">Raciocínio</string>
+    <string name="reasoning_empty">Sem conteúdo de raciocínio</string>
     <string name="tool_status_pending">Pendente</string>
     <string name="tool_status_running">Em execução</string>
     <string name="tool_status_completed">Concluído</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">Всегда разрешать</string>
     <string name="reject">Отклонить</string>
     <string name="reasoning_card_title">Рассуждение</string>
+    <string name="reasoning_empty">Нет содержания рассуждения</string>
     <string name="tool_status_pending">Ожидание</string>
     <string name="tool_status_running">Выполняется</string>
     <string name="tool_status_completed">Завершено</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">始终允许</string>
     <string name="reject">拒绝</string>
     <string name="reasoning_card_title">推理</string>
+    <string name="reasoning_empty">暂无推理内容</string>
     <string name="tool_status_pending">等待中</string>
     <string name="tool_status_running">运行中</string>
     <string name="tool_status_completed">已完成</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="always_allow">Always allow</string>
     <string name="reject">Reject</string>
     <string name="reasoning_card_title">Reasoning</string>
+    <string name="reasoning_empty">No reasoning content</string>
     <string name="tool_status_pending">Pending</string>
     <string name="tool_status_running">Running</string>
     <string name="tool_status_completed">Completed</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
@@ -390,4 +390,38 @@ class AssistantActivityGroupTest {
         val grownIds = groupConversationTimeline(grown).filterIsInstance<TimelineEntry.Activity>().map { it.id }
         assertEquals(listOf("activity:toolu_stream", "activity:toolu_stream:1"), grownIds)
     }
+
+    @Test
+    fun `blank reasoning parts are excluded from activity`() {
+        // Blank reasoning carries nothing to expand; it must not produce a "Thinking" card.
+        val entries =
+            groupConversationTimeline(
+                listOf(
+                    assistant(
+                        "m1",
+                        ChatPart.Reasoning("r1", ""),
+                        tool("t1", "read"),
+                        ChatPart.Reasoning("r2", "   "),
+                    ),
+                ),
+            )
+
+        assertEquals(1, entries.size)
+        assertEquals(listOf("t1"), (entries.single() as TimelineEntry.Activity).parts.map { it.id })
+    }
+
+    @Test
+    fun `blank reasoning is not counted in the summary`() {
+        val summary = summarizeActivity(listOf(ChatPart.Reasoning("r1", ""), tool("t1", "read")))
+
+        assertEquals(0, summary.reasoningCount)
+        assertEquals(1, summary.counts[ToolCategory.READ])
+    }
+
+    @Test
+    fun `reasoning-only run of blank parts is empty`() {
+        val summary = summarizeActivity(listOf(ChatPart.Reasoning("r1", "")))
+
+        assertTrue(summary.isEmpty)
+    }
 }

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -545,6 +546,115 @@ class ChatViewModelTest {
 
             val reasoning = viewModel.uiState.value.messages.last().parts.single() as ChatPart.Reasoning
             assertEquals("Thinking more.", reasoning.text)
+        }
+
+    @Test
+    fun `reasoning text falls back to state reasoningDetails`() {
+        val part =
+            OpenCodePart(
+                id = "reason-1",
+                sessionId = "s1",
+                messageId = "m-assistant",
+                type = "reasoning",
+                text = "",
+                state =
+                    mapOf(
+                        "reasoningDetails" to
+                            buildJsonArray {
+                                add(buildJsonObject { put("text", JsonPrimitive("Deep ")) })
+                                add(buildJsonObject { put("text", JsonPrimitive("thought")) })
+                            },
+                    ),
+            )
+
+        val reasoning = part.toChatPart() as ChatPart.Reasoning
+        assertEquals("Deep thought", reasoning.text)
+    }
+
+    @Test
+    fun `reasoning text prefers top-level text over state`() {
+        val part =
+            OpenCodePart(
+                id = "reason-1",
+                sessionId = "s1",
+                messageId = "m-assistant",
+                type = "reasoning",
+                text = "Top level",
+                state = mapOf("text" to JsonPrimitive("State fallback")),
+            )
+
+        val reasoning = part.toChatPart() as ChatPart.Reasoning
+        assertEquals("Top level", reasoning.text)
+    }
+
+    @Test
+    fun `reasoning delta with reasoning field accumulates into a reasoning part`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+            viewModel.sendMessage("Think about it")
+            advanceUntilIdle()
+
+            backend.events.emit(
+                OpenCodeEvent.MessagePartDelta(
+                    sessionId = "s1",
+                    messageId = "m-assistant",
+                    partId = "reason-1",
+                    field = "reasoning",
+                    delta = "Thinking",
+                ),
+            )
+            backend.events.emit(
+                OpenCodeEvent.MessagePartDelta(
+                    sessionId = "s1",
+                    messageId = "m-assistant",
+                    partId = "reason-1",
+                    field = "reasoning",
+                    delta = " more.",
+                ),
+            )
+            advanceUntilIdle()
+
+            val reasoning = viewModel.uiState.value.messages.last().parts.single() as ChatPart.Reasoning
+            assertEquals("Thinking more.", reasoning.text)
+        }
+
+    @Test
+    fun `late empty reasoning snapshot preserves streamed deltas`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+            viewModel.sendMessage("Think about it")
+            advanceUntilIdle()
+
+            // A delta can outrun the part event that introduces it; the late snapshot
+            // carries the empty initial text and must not wipe the accumulated delta.
+            backend.events.emit(
+                OpenCodeEvent.MessagePartDelta(
+                    sessionId = "s1",
+                    messageId = "m-assistant",
+                    partId = "reason-1",
+                    field = "text",
+                    delta = "Early thought",
+                ),
+            )
+            backend.events.emit(
+                OpenCodeEvent.MessagePartUpdated(
+                    OpenCodePart(
+                        id = "reason-1",
+                        sessionId = "s1",
+                        messageId = "m-assistant",
+                        type = "reasoning",
+                        text = "",
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            val reasoning = viewModel.uiState.value.messages.last().parts.single() as ChatPart.Reasoning
+            assertEquals("Early thought", reasoning.text)
         }
 
     @Test


### PR DESCRIPTION
思考を展開しても何も表示されない問題を修正します。

空のreasoningパートが「思考」カードとして表示されていたのが原因です。対応内容:

- `ChatViewModel`: `state`からのフォールバック抽出（`text`/`content`/`reasoning`/`reasoningDetails`系）、空スナップショット到着時の既存デルタ保持、`field="reasoning"`（Claude思考デルタ）の受容
- `AssistantActivityGroup`: 空思考をタイムラインと件数カウントから除外
- `AssistantActivityRow`: シート側でも再フィルタ、展開時はプレースホルダー表示
- `reasoning_empty` を8ロケールに追加

検証: `detekt`/`spotlessCheck` 成功、該当テスト全パス（AssistantActivityGroupTest 25件、ChatViewModelTest 55件、失敗0）。承認後にレビュー提案通り `origin/main` へリベース済み（内容の変更なし）。

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- ブランチのベースが `416a3a0` で `origin/main（0381314）` より5件ほど古いままです。差分自体にコンフリクトはありませんが、PR前に `origin/main` へリベースしてCIを再実行すると安全です。
- `AssistantActivityRow.kt:158` の `visibleParts` はフィルタ後に `activityPartKey(index, part)` の index が詰まるため、開いているシートへのストリーミング追加時にキー（=index部分）がずれて再コンポーズが増えます。実害はありませんが、気になる場合は `part.id` ベースのキーへの寄せを検討してください。
- `ReasoningCard` の `reasoning_empty` フォールバックは、タイムラインとシートの二重フィルタ後は到達不能な防御コードになっています。現状のままで問題ありませんが、将来 `ReasoningCard` を他所で直呼びする際は空カードが出る点だけ留意してください。

## チェック済み項目
- 全差分（13ファイル、+232/-8）を読解: `AssistantActivityGroup.kt` の空思考スキップ、`AssistantActivityRow.kt` のシート再フィルタ＋フォールバック表示、`ChatViewModel.kt` の `extractReasoningText`／スナップショット統合／`reasoning` デルタ対応、strings 8ファイル追加、テスト2ファイル追加を確認
- 前回ブロッカーの回帰テスト追加を確認: `AssistantActivityGroupTest` 3件（空思考の除外・カウント除外・空のみでempty）、`ChatViewModelTest` 4件（stateフォールバック、top-level優先、field=reasoning蓄積、空スナップショットのデルタ保持）。既存パターンの `FakeBackend`＋`sendMessage` 流用で妥当
- i18nキー一致を確認: `git show` で `reasoning_empty` が values＋ar/es/fr/ja/pt-rBR/ru/zh-rCN の全8ロケールに存在。表示文は `stringResource` 経由でハードコードなし、プロンプト／ログは英語のまま
- 呼び出し元と隣接挙動を確認: `ChatHomeScreen:706-714` は `findActivityParts`＋`isNotEmpty` ガードで空のみグループは開かない、`summarizeActivity.isEmpty` とタイムライン除外が一致、`ClaudeStreamJsonParser:161` で `thinking_delta`→`field="reasoning"` を裏付け
- ストリーミング統合の正しさを確認: 空スナップショットが先行デルタを消さない分岐（Text→Reasoning型補正、Reasoning保持）、`text`/`reasoning` 以外のfieldは無視、非テキスト系の `else -> return` は従来通り
- Compose／並行性の pitfalls を確認: `remember(parts)` のキー正当、`streamedParts` は単一イベント収集コルーチン内の `linkedMapOf` 更新でリークなし、`ChatPart` は `copy` のある data class
- DI・セキュリティを確認: ViewModel の依存追加なしのため Koin／`ViewModelFactory` の同期不要、秘密情報・パス走査・Intent 処理の変更なし
