### PR TITLE
feat(explorer): open modified files from the changes tab

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceExplorerScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceExplorerScreen.kt
@@ -103,6 +103,7 @@ fun WorkspaceExplorerScreen(
     tabManager: WorkspaceTabManager? = null,
     workspaceDeck: List<String> = emptyList(),
     onOpenTerminal: () -> Unit = {},
+    onOpenChange: (OpenCodeFileChange) -> Unit = {},
 ) {
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
     val tabs =
@@ -172,7 +173,7 @@ fun WorkspaceExplorerScreen(
                 when (selectedTab) {
                     0 -> FilesTab(state, onOpenNode, onNavigateUp)
                     1 -> SearchTab(state, onSearch)
-                    2 -> ChangesTab(state, branches, onSwitchBranch, onCreateBranch, commits)
+                    2 -> ChangesTab(state, branches, onSwitchBranch, onCreateBranch, commits, onOpenChange)
                     else -> PrTab(prTitle, prStatus, prDescription)
                 }
             }
@@ -180,7 +181,7 @@ fun WorkspaceExplorerScreen(
             when (selectedTab) {
                 0 -> FilesTab(state, onOpenNode, onNavigateUp)
                 1 -> SearchTab(state, onSearch)
-                2 -> ChangesTab(state, branches, onSwitchBranch, onCreateBranch, commits)
+                2 -> ChangesTab(state, branches, onSwitchBranch, onCreateBranch, commits, onOpenChange)
                 else -> PrTab(prTitle, prStatus, prDescription)
             }
         }
@@ -538,6 +539,7 @@ private fun ChangesTab(
     onSwitchBranch: (String) -> Unit,
     onCreateBranch: (String) -> Unit,
     commits: List<CommitInfo>,
+    onOpenChange: (OpenCodeFileChange) -> Unit = {},
 ) {
     var showBranchSheet by remember { mutableStateOf(false) }
     var diffViewMode by remember { mutableStateOf(DiffViewMode.UNIFIED) }
@@ -603,7 +605,7 @@ private fun ChangesTab(
         } else {
             items(state.changes, key = { it.displayPath }) { change ->
                 val detailed = state.diff.firstOrNull { it.displayPath == change.displayPath } ?: change
-                ChangeCard(detailed, diffViewMode)
+                ChangeCard(detailed, diffViewMode, onOpenChange)
             }
         }
 
@@ -752,9 +754,14 @@ private fun BranchSwitcherSheet(
 private fun ChangeCard(
     change: OpenCodeFileChange,
     diffViewMode: DiffViewMode,
+    onOpen: (OpenCodeFileChange) -> Unit = {},
 ) {
     var expanded by remember(change.displayPath, change.patch) { mutableStateOf(false) }
-    SectionCard {
+    // Deleted files no longer exist on disk, so there is nothing for the viewer to open.
+    val canOpen = change.displayPath.isNotBlank() && !change.status.equals("deleted", ignoreCase = true)
+    SectionCard(
+        modifier = if (canOpen) Modifier.clickable { onOpen(change) } else Modifier,
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -774,6 +781,11 @@ private fun ChangeCard(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                }
+            }
+            if (canOpen) {
+                OutlinedButton(onClick = { onOpen(change) }) {
+                    Text(stringResource(R.string.open_file))
                 }
             }
             if (!change.patch.isNullOrBlank()) {

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceExplorerScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/workspace/WorkspaceExplorerScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -82,6 +83,9 @@ data class CommitInfo(
 )
 
 enum class DiffViewMode { UNIFIED, SPLIT }
+
+/** Whether the changed file can be opened in the viewer. Deleted files no longer exist on disk. */
+internal fun OpenCodeFileChange.isOpenable(): Boolean = displayPath.isNotBlank() && !status.equals("deleted", ignoreCase = true)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -757,10 +761,17 @@ private fun ChangeCard(
     onOpen: (OpenCodeFileChange) -> Unit = {},
 ) {
     var expanded by remember(change.displayPath, change.patch) { mutableStateOf(false) }
-    // Deleted files no longer exist on disk, so there is nothing for the viewer to open.
-    val canOpen = change.displayPath.isNotBlank() && !change.status.equals("deleted", ignoreCase = true)
+    val canOpen = change.isOpenable()
     SectionCard(
-        modifier = if (canOpen) Modifier.clickable { onOpen(change) } else Modifier,
+        modifier =
+            if (canOpen) {
+                Modifier.clickable(
+                    role = Role.Button,
+                    onClickLabel = stringResource(R.string.open_file),
+                ) { onOpen(change) }
+            } else {
+                Modifier
+            },
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
@@ -167,6 +167,12 @@ fun NavGraphBuilder.workspaceNavGraph(
                 onSearch = explorerViewModel::search,
                 onRefreshChanges = explorerViewModel::refreshChanges,
                 onOpenTerminal = { navController.navigate(ROUTE_TERMINAL) },
+                onOpenChange = { change ->
+                    val path = change.displayPath
+                    if (path.isNotBlank() && !change.status.equals("deleted", ignoreCase = true)) {
+                        navController.navigate(codeViewerRoute(runtime.id, workspace.path, path))
+                    }
+                },
             )
         }
     }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/navigation/WorkspaceNavGraph.kt
@@ -20,6 +20,7 @@ import com.yugahashimoto.andcode.feature.workspace.WorkspaceExplorerScreen
 import com.yugahashimoto.andcode.feature.workspace.WorkspaceExplorerViewModel
 import com.yugahashimoto.andcode.feature.workspace.WorkspaceViewModel
 import com.yugahashimoto.andcode.feature.workspace.WorkspacesScreen
+import com.yugahashimoto.andcode.feature.workspace.isOpenable
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
 import com.yugahashimoto.andcode.runtime.WorkspaceRef
 import com.yugahashimoto.andcode.ui.ViewModelFactory
@@ -168,9 +169,8 @@ fun NavGraphBuilder.workspaceNavGraph(
                 onRefreshChanges = explorerViewModel::refreshChanges,
                 onOpenTerminal = { navController.navigate(ROUTE_TERMINAL) },
                 onOpenChange = { change ->
-                    val path = change.displayPath
-                    if (path.isNotBlank() && !change.status.equals("deleted", ignoreCase = true)) {
-                        navController.navigate(codeViewerRoute(runtime.id, workspace.path, path))
+                    if (change.isOpenable()) {
+                        navController.navigate(codeViewerRoute(runtime.id, workspace.path, change.displayPath))
                     }
                 },
             )

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -239,6 +239,7 @@
     <string name="no_git_info">لا توجد معلومات مستودع Git</string>
     <string name="loading_changes">جارٍ تحميل التغييرات</string>
     <string name="no_uncommitted_changes">لا توجد تغييرات غير ملتزم بها</string>
+    <string name="open_file">فتح</string>
 
     <string name="local_runtime_screen_title">OpenCode المحلي</string>
     <string name="refresh_diagnostics_description">تحديث التشخيصات ومعلومات التحديث</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -236,6 +236,7 @@
     <string name="no_git_info">Sin información del repositorio Git</string>
     <string name="loading_changes">Cargando cambios</string>
     <string name="no_uncommitted_changes">No hay cambios sin confirmar</string>
+    <string name="open_file">Abrir</string>
 
     <string name="local_runtime_screen_title">OpenCode local</string>
     <string name="refresh_diagnostics_description">Actualizar diagnósticos e información de actualización</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -236,6 +236,7 @@
     <string name="no_git_info">Aucune information de dépôt Git</string>
     <string name="loading_changes">Chargement des modifications</string>
     <string name="no_uncommitted_changes">Aucune modification non validée</string>
+    <string name="open_file">Ouvrir</string>
 
     <string name="local_runtime_screen_title">OpenCode local</string>
     <string name="refresh_diagnostics_description">Actualiser les diagnostics et les informations de mise à jour</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -234,6 +234,7 @@
     <string name="no_git_info">Gitリポジトリ情報なし</string>
     <string name="loading_changes">変更を取得しています</string>
     <string name="no_uncommitted_changes">未コミットの変更はありません</string>
+    <string name="open_file">開く</string>
 
     <string name="local_runtime_screen_title">ローカルランタイム</string>
     <string name="refresh_diagnostics_description">診断と更新情報を再取得</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -236,6 +236,7 @@
     <string name="no_git_info">Nenhuma informação de repositório Git</string>
     <string name="loading_changes">Carregando alterações</string>
     <string name="no_uncommitted_changes">Nenhuma alteração não confirmada</string>
+    <string name="open_file">Abrir</string>
 
     <string name="local_runtime_screen_title">OpenCode local</string>
     <string name="refresh_diagnostics_description">Atualizar diagnósticos e informações de atualização</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -237,6 +237,7 @@
     <string name="no_git_info">Нет информации о репозитории Git</string>
     <string name="loading_changes">Загрузка изменений</string>
     <string name="no_uncommitted_changes">Нет незафиксированных изменений</string>
+    <string name="open_file">Открыть</string>
 
     <string name="local_runtime_screen_title">Локальный OpenCode</string>
     <string name="refresh_diagnostics_description">Обновить диагностику и информацию об обновлении</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -234,6 +234,7 @@
     <string name="no_git_info">没有 Git 仓库信息</string>
     <string name="loading_changes">正在加载更改</string>
     <string name="no_uncommitted_changes">没有未提交的更改</string>
+    <string name="open_file">打开</string>
 
     <string name="local_runtime_screen_title">本地 OpenCode</string>
     <string name="refresh_diagnostics_description">刷新诊断和更新信息</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="no_git_info">No Git repository info</string>
     <string name="loading_changes">Loading changes</string>
     <string name="no_uncommitted_changes">No uncommitted changes</string>
+    <string name="open_file">Open</string>
 
     <string name="local_runtime_screen_title">Local runtime</string>
     <string name="refresh_diagnostics_description">Refresh diagnostics and update info</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/ChangeOpenableTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/workspace/ChangeOpenableTest.kt
@@ -1,0 +1,38 @@
+package com.yugahashimoto.andcode.feature.workspace
+
+import com.yugahashimoto.andcode.core.api.OpenCodeFileChange
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChangeOpenableTest {
+    @Test
+    fun `modified file is openable`() {
+        assertTrue(OpenCodeFileChange(file = "src/Main.kt", status = "modified").isOpenable())
+    }
+
+    @Test
+    fun `added file is openable`() {
+        assertTrue(OpenCodeFileChange(file = "src/New.kt", status = "added").isOpenable())
+    }
+
+    @Test
+    fun `deleted file is not openable`() {
+        assertFalse(OpenCodeFileChange(file = "src/Old.kt", status = "deleted").isOpenable())
+    }
+
+    @Test
+    fun `deleted status check is case-insensitive`() {
+        assertFalse(OpenCodeFileChange(file = "src/Old.kt", status = "Deleted").isOpenable())
+    }
+
+    @Test
+    fun `blank path is not openable`() {
+        assertFalse(OpenCodeFileChange(file = "", status = "modified").isOpenable())
+    }
+
+    @Test
+    fun `null status falls back to openable`() {
+        assertTrue(OpenCodeFileChange(file = "src/Main.kt", status = null).isOpenable())
+    }
+}


### PR DESCRIPTION
ファイルエクスプローラーの「変更」タブで、修正ファイルの全文をコードビューアーで開けるようにしました。変更カードに「開く」ボタンを追加し、カード自体のタップでも開きます（削除ファイルは除外）。TalkBack向けに role と onClickLabel を付与し、新規文字列 `open_file` を全8ロケールに追加、`isOpenable` の分岐テストも追加しています。

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
なし

## 提案（非ブロッキング）
なし

## チェック済み項目
- `git diff origin/main...HEAD` 全体（11ファイル、WorkspaceExplorerScreen.kt / WorkspaceNavGraph.kt / strings 8ロケール / ChangeOpenableTest.kt）を読解
- 今回追加分 `ChangeOpenableTest.kt` 6件が `isOpenable()` の全分岐（modified→true、added→true、deleted→false、大文字Deleted→false、空パス→false、null status→true）を網羅していることを確認。実装 `displayPath.isNotBlank() && !status.equals("deleted", ignoreCase=true)` と一致、`OpenCodeApiModels.kt` の `displayPath = file ?: path.orEmpty()` とテストの `file=` 引数の対応を確認
- `null.equals("deleted", ignoreCase=true)` が false になるKotlinの挙動により null status が openable になることを確認（テスト通り）
- 全8ロケール（values + ar/es/fr/ja/pt-rBR/ru/zh-rCN）に `open_file` キーが各1件存在することをgrepで確認、ハードコード文言なし・`stringResource(R.string.open_file)` 使用を確認
- `SectionCard(modifier)` が `AndCodeComponents.kt:62` で modifier を受け付けること、`Role.Button` + `onClickLabel` のアクセシビリティ対応を確認
- 二重ガード（UI側 `canOpen` で表示制御 + `WorkspaceNavGraph.kt:171-175` で `isOpenable()` 再チェック後に `codeViewerRoute` 遷移）を確認。`codeViewerRoute` はBase64エンコード済みで既存 `onOpenNode` と同一パターンのため新規の経路 traversal リスクなし
- DI影響なし（ViewModel変更なし、`onOpenChange` はデフォルト `{}` 付きラムダで既存プレビュー/呼び出し元を壊さない）を確認、他呼び出し元は `WorkspaceNavGraph` の1件のみ
- Compose状態面：`remember(change.displayPath, change.patch)` は既存維持、`canOpen` は純粋計算でremember不要、ネストされた clickable（カード全体 + 内側OutlinedButton）は内側が消費するため誤動作なし
