### PR TITLE
fix(chat): 動画添付をフレーム画像に変換して送信エラーを防ぐ

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/di/ViewModelModule.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/di/ViewModelModule.kt
@@ -24,6 +24,7 @@ val viewModelModule =
                 // backgrounded, or whichever one the screen happens to use decides whether those
                 // 30-second loops keep polling out of sight.
                 awaitForeground = { app.appForeground.foreground.first { visible -> visible } },
+                videoNotSupportedMessage = androidContext().getString(com.yugahashimoto.andcode.R.string.error_video_not_supported),
             )
         }
 

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -1114,6 +1114,19 @@ class ChatViewModel(
                     pendingPreviews.getOrNull(index)?.let { attachment.filename to it }
                 }.toMap()
         if (normalized.isEmpty() && pendingAttachments.isEmpty()) return
+        // Video file parts are rejected by most providers
+        // ("'file part media type video/mp4' functionality not supported"), failing the
+        // whole turn. Videos are converted to image frames at attach time, so reaching
+        // here means a stale/queued attachment slipped through: block the send with a
+        // clear error instead of breaking the session.
+        if (pendingAttachments.any { it.mime.startsWith("video/", ignoreCase = true) }) {
+            _uiState.update {
+                it.copy(
+                    error = "Video files cannot be sent directly. Remove the video and attach images instead.",
+                )
+            }
+            return
+        }
         val currentBackend = backend
         if (currentBackend == null) {
             _uiState.update { it.copy(error = "OpenCode connection is not configured") }

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/ChatViewModel.kt
@@ -33,6 +33,7 @@ import com.yugahashimoto.andcode.data.settings.DraftRepository
 import com.yugahashimoto.andcode.runtime.OpenCodeBackend
 import com.yugahashimoto.andcode.runtime.PermissionResponse
 import com.yugahashimoto.andcode.runtime.RuntimeTarget
+import com.yugahashimoto.andcode.runtime.local.VideoAttachmentHelper
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -533,6 +534,14 @@ class ChatViewModel(
      * would otherwise never return from a real wait - running unattended.
      */
     private val awaitForeground: suspend () -> Unit = {},
+    /**
+     * Shown when a video attachment reaches the send path. Videos are converted to image
+     * frames at attach time, so this only fires for stale or queued attachments that slipped
+     * through. Injected the same way as WorkspaceViewModel.incompleteConnectionMessage so
+     * the real app shows a localized string while tests keep the English default.
+     */
+    private val videoNotSupportedMessage: String =
+        "Video files cannot be sent directly. Remove the video and attach images instead.",
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow(
@@ -1119,12 +1128,8 @@ class ChatViewModel(
         // whole turn. Videos are converted to image frames at attach time, so reaching
         // here means a stale/queued attachment slipped through: block the send with a
         // clear error instead of breaking the session.
-        if (pendingAttachments.any { it.mime.startsWith("video/", ignoreCase = true) }) {
-            _uiState.update {
-                it.copy(
-                    error = "Video files cannot be sent directly. Remove the video and attach images instead.",
-                )
-            }
+        if (pendingAttachments.any { VideoAttachmentHelper.isVideoMime(it.mime) }) {
+            _uiState.update { it.copy(error = videoNotSupportedMessage) }
             return
         }
         val currentBackend = backend

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AttachmentImporter.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AttachmentImporter.kt
@@ -13,6 +13,10 @@ import java.io.ByteArrayOutputStream
 class AttachmentImporter(
     private val context: Context,
 ) {
+    /**
+     * Imports [uri] as a single attachment. For video this keeps only the first
+     * extracted frame; use [importAll] to receive every frame.
+     */
     fun import(uri: Uri): PromptAttachment = importAll(uri).first()
 
     /**

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AttachmentImporter.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AttachmentImporter.kt
@@ -2,28 +2,44 @@ package com.yugahashimoto.andcode.runtime.local
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Base64
+import android.util.Log
 import com.yugahashimoto.andcode.core.api.PromptAttachment
 import java.io.ByteArrayOutputStream
 
 class AttachmentImporter(
     private val context: Context,
 ) {
-    fun import(uri: Uri): PromptAttachment {
+    fun import(uri: Uri): PromptAttachment = importAll(uri).first()
+
+    /**
+     * Imports [uri] as one or more model-sendable attachments.
+     *
+     * Video files are not sent raw: most providers reject video file parts, so
+     * representative JPEG frames are extracted instead. Everything else keeps the
+     * previous single-attachment behaviour.
+     */
+    fun importAll(uri: Uri): List<PromptAttachment> {
         val filename = sanitize(queryDisplayName(uri) ?: "attachment-${System.currentTimeMillis()}")
         val mime = context.contentResolver.getType(uri) ?: "application/octet-stream"
+        if (VideoAttachmentHelper.isVideoMime(mime)) {
+            return importVideoFrames(uri, filename)
+        }
         val bytes =
             context.contentResolver.openInputStream(uri).use { input ->
                 requireNotNull(input) { "Cannot open attachment input stream" }
                 input.readBytes()
             }
         val encoded = Base64.encodeToString(bytes, Base64.NO_WRAP)
-        return PromptAttachment(
-            filename = filename,
-            mime = mime,
-            url = "data:$mime;base64,$encoded",
+        return listOf(
+            PromptAttachment(
+                filename = filename,
+                mime = mime,
+                url = "data:$mime;base64,$encoded",
+            ),
         )
     }
 
@@ -35,6 +51,69 @@ class AttachmentImporter(
         check(bitmap.compress(Bitmap.CompressFormat.JPEG, 90, baos)) { "Cannot encode attachment" }
         val encoded = Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
         return PromptAttachment(sanitize(filename), "image/jpeg", "data:image/jpeg;base64,$encoded")
+    }
+
+    private fun importVideoFrames(
+        uri: Uri,
+        filename: String,
+    ): List<PromptAttachment> {
+        val retriever = MediaMetadataRetriever()
+        try {
+            retriever.setDataSource(context, uri)
+            val durationMs =
+                runCatching {
+                    retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                        ?.toLongOrNull() ?: 0L
+                }.getOrDefault(0L)
+            val timestampsUs = VideoAttachmentHelper.frameTimestampsUs(durationMs * 1_000L)
+            val frames =
+                timestampsUs.mapIndexedNotNull { index, timestampUs ->
+                    val frame =
+                        runCatching {
+                            retriever.getFrameAtTime(
+                                timestampUs,
+                                MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+                            )
+                        }.getOrNull() ?: return@mapIndexedNotNull null
+                    try {
+                        val (scaledWidth, scaledHeight) =
+                            VideoAttachmentHelper.scaledDimensions(frame.width, frame.height)
+                        if (scaledWidth <= 0 || scaledHeight <= 0) return@mapIndexedNotNull null
+                        val scaled =
+                            if (scaledWidth == frame.width && scaledHeight == frame.height) {
+                                frame
+                            } else {
+                                Bitmap.createScaledBitmap(frame, scaledWidth, scaledHeight, true)
+                            }
+                        try {
+                            val baos = ByteArrayOutputStream()
+                            check(
+                                scaled.compress(Bitmap.CompressFormat.JPEG, 80, baos),
+                            ) { "Cannot encode video frame" }
+                            val encoded = Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
+                            PromptAttachment(
+                                filename = VideoAttachmentHelper.frameFilename(filename, index),
+                                mime = "image/jpeg",
+                                url = "data:image/jpeg;base64,$encoded",
+                            )
+                        } finally {
+                            if (scaled !== frame) scaled.recycle()
+                        }
+                    } finally {
+                        frame.recycle()
+                    }
+                }
+            require(frames.isNotEmpty()) { "Could not extract images from video" }
+            return frames
+        } catch (e: IllegalArgumentException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w("AttachmentImporter", "Failed to extract video frames", e)
+            throw IllegalArgumentException("Could not extract images from video", e)
+        } finally {
+            runCatching { retriever.release() }
+        }
     }
 
     private fun queryDisplayName(uri: Uri): String? =

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelper.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelper.kt
@@ -14,10 +14,14 @@ object VideoAttachmentHelper {
 
     fun isVideoMime(mime: String): Boolean = mime.startsWith("video/", ignoreCase = true)
 
+    fun isImageMime(mime: String): Boolean = mime.startsWith("image/", ignoreCase = true)
+
     /**
      * Representative timestamps (microseconds) for [durationUs].
      * Returns 0-us, middle and near-end so a short screen recording still yields
      * beginning/middle/end context. Unknown or zero durations yield a single 0-us frame.
+     * Only up to three representative points are produced; larger [maxFrames] values
+     * are clamped to the same three points.
      */
     fun frameTimestampsUs(
         durationUs: Long,

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelper.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelper.kt
@@ -1,0 +1,67 @@
+package com.yugahashimoto.andcode.runtime.local
+
+/**
+ * Pure helpers for turning video attachments into model-sendable image frames.
+ *
+ * Most LLM providers behind OpenCode reject video file parts
+ * ("'file part media type video/mp4' functionality not supported"), which used to
+ * fail the whole turn. Instead of sending the raw video bytes, the app extracts
+ * a few representative JPEG frames and sends those as image attachments.
+ */
+object VideoAttachmentHelper {
+    const val MAX_FRAMES = 3
+    const val MAX_SIDE_PX = 1280
+
+    fun isVideoMime(mime: String): Boolean = mime.startsWith("video/", ignoreCase = true)
+
+    /**
+     * Representative timestamps (microseconds) for [durationUs].
+     * Returns 0-us, middle and near-end so a short screen recording still yields
+     * beginning/middle/end context. Unknown or zero durations yield a single 0-us frame.
+     */
+    fun frameTimestampsUs(
+        durationUs: Long,
+        maxFrames: Int = MAX_FRAMES,
+    ): List<Long> {
+        if (durationUs <= 0L || maxFrames <= 1) return listOf(0L)
+        val fractions =
+            when {
+                maxFrames >= 3 -> listOf(0.0, 0.5, 0.9)
+                else -> listOf(0.0, 0.5).take(maxFrames)
+            }
+        return fractions
+            .take(maxFrames)
+            .map { (durationUs * it).toLong().coerceAtLeast(0L) }
+            .distinct()
+    }
+
+    /**
+     * Scales [width]x[height] down so the longest side is at most [maxSide],
+     * preserving aspect ratio. Never upscales.
+     */
+    fun scaledDimensions(
+        width: Int,
+        height: Int,
+        maxSide: Int = MAX_SIDE_PX,
+    ): Pair<Int, Int> {
+        if (width <= 0 || height <= 0) return 0 to 0
+        val longest = maxOf(width, height)
+        if (longest <= maxSide) return width to height
+        val scale = maxSide.toDouble() / longest.toDouble()
+        val scaledWidth = (width * scale).toInt().coerceAtLeast(1)
+        val scaledHeight = (height * scale).toInt().coerceAtLeast(1)
+        return scaledWidth to scaledHeight
+    }
+
+    fun frameFilename(
+        baseFilename: String,
+        index: Int,
+    ): String {
+        val base = baseFilename.substringBeforeLast('.', missingDelimiterValue = baseFilename)
+        val sanitized =
+            base
+                .replace(Regex("[^a-zA-Z0-9._-]"), "_")
+                .ifBlank { "video" }
+        return "$sanitized.frame-$index.jpg"
+    }
+}

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -318,6 +318,7 @@ fun AndCodeApp(
                         // backgrounded - neither loop's result is visible to anyone until it is
                         // foreground again.
                         awaitForeground = { app.appForeground.foreground.first { visible -> visible } },
+                        videoNotSupportedMessage = context.getString(R.string.error_video_not_supported),
                     )
                 },
         )
@@ -483,23 +484,30 @@ fun AndCodeApp(
             voiceScope.launch {
                 runCatching {
                     withContext(Dispatchers.IO) {
-                        com.yugahashimoto.andcode.runtime.local.AttachmentImporter(context).importAll(uri)
+                        val importer = com.yugahashimoto.andcode.runtime.local.AttachmentImporter(context)
+                        importer.importAll(uri).map { attachment ->
+                            val preview =
+                                if (com.yugahashimoto.andcode.runtime.local.VideoAttachmentHelper.isImageMime(
+                                        attachment.mime,
+                                    )
+                                ) {
+                                    runCatching {
+                                        val base64 =
+                                            attachment.url.substringAfter("base64,", missingDelimiterValue = "")
+                                        if (base64.isEmpty()) return@runCatching null
+                                        val bytes = android.util.Base64.decode(base64, android.util.Base64.DEFAULT)
+                                        android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                                    }.getOrNull()
+                                } else {
+                                    null
+                                }
+                            attachment to preview
+                        }
                     }
                 }.onSuccess { attachments ->
-                    attachments.forEach { attachment ->
-                        if (attachment.mime.startsWith("image/")) {
-                            val preview =
-                                runCatching {
-                                    val base64 = attachment.url.substringAfter("base64,", missingDelimiterValue = "")
-                                    if (base64.isEmpty()) return@runCatching null
-                                    val bytes = android.util.Base64.decode(base64, android.util.Base64.DEFAULT)
-                                    android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                                }.getOrNull()
-                            if (preview != null) {
-                                chatViewModel.addImageAttachment(attachment, preview)
-                            } else {
-                                chatViewModel.addAttachment(attachment)
-                            }
+                    attachments.forEach { (attachment, preview) ->
+                        if (preview != null) {
+                            chatViewModel.addImageAttachment(attachment, preview)
                         } else {
                             chatViewModel.addAttachment(attachment)
                         }
@@ -508,7 +516,7 @@ fun AndCodeApp(
                     android.util.Log.w("AndCodeApp", "Failed to attach file", error)
                     android.widget.Toast.makeText(
                         context,
-                        error.message ?: context.getString(R.string.attachment_load_failed),
+                        context.getString(R.string.attachment_load_failed),
                         android.widget.Toast.LENGTH_SHORT,
                     ).show()
                 }

--- a/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/ui/AndCodeApp.kt
@@ -483,10 +483,34 @@ fun AndCodeApp(
             voiceScope.launch {
                 runCatching {
                     withContext(Dispatchers.IO) {
-                        com.yugahashimoto.andcode.runtime.local.AttachmentImporter(context).import(uri)
+                        com.yugahashimoto.andcode.runtime.local.AttachmentImporter(context).importAll(uri)
                     }
-                }.onSuccess { attachment ->
-                    chatViewModel.addAttachment(attachment)
+                }.onSuccess { attachments ->
+                    attachments.forEach { attachment ->
+                        if (attachment.mime.startsWith("image/")) {
+                            val preview =
+                                runCatching {
+                                    val base64 = attachment.url.substringAfter("base64,", missingDelimiterValue = "")
+                                    if (base64.isEmpty()) return@runCatching null
+                                    val bytes = android.util.Base64.decode(base64, android.util.Base64.DEFAULT)
+                                    android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                                }.getOrNull()
+                            if (preview != null) {
+                                chatViewModel.addImageAttachment(attachment, preview)
+                            } else {
+                                chatViewModel.addAttachment(attachment)
+                            }
+                        } else {
+                            chatViewModel.addAttachment(attachment)
+                        }
+                    }
+                }.onFailure { error ->
+                    android.util.Log.w("AndCodeApp", "Failed to attach file", error)
+                    android.widget.Toast.makeText(
+                        context,
+                        error.message ?: context.getString(R.string.attachment_load_failed),
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
                 }
             }
         }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -818,6 +818,7 @@
     <string name="attach_file">File</string>
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
+    <string name="attachment_load_failed">Could not attach file</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -819,6 +819,7 @@
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
     <string name="attachment_load_failed">Could not attach file</string>
+    <string name="error_video_not_supported">Video files cannot be sent directly. Remove the video and attach images instead.</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -812,6 +812,7 @@
     <string name="attach_file">File</string>
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
+    <string name="attachment_load_failed">Could not attach file</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -813,6 +813,7 @@
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
     <string name="attachment_load_failed">Could not attach file</string>
+    <string name="error_video_not_supported">Video files cannot be sent directly. Remove the video and attach images instead.</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -812,6 +812,7 @@
     <string name="attach_file">File</string>
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
+    <string name="attachment_load_failed">Could not attach file</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -813,6 +813,7 @@
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
     <string name="attachment_load_failed">Could not attach file</string>
+    <string name="error_video_not_supported">Video files cannot be sent directly. Remove the video and attach images instead.</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -821,6 +821,7 @@
     <string name="attach_camera">カメラ</string>
     <string name="attach_gallery">ギャラリー</string>
     <string name="attachment_load_failed">ファイルを添付できませんでした</string>
+    <string name="error_video_not_supported">動画ファイルはそのまま送信できません。動画を外して画像を添付してください。</string>
     <string name="status_queued">キュー済み</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -820,6 +820,7 @@
     <string name="attach_file">ファイル</string>
     <string name="attach_camera">カメラ</string>
     <string name="attach_gallery">ギャラリー</string>
+    <string name="attachment_load_failed">ファイルを添付できませんでした</string>
     <string name="status_queued">キュー済み</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -812,6 +812,7 @@
     <string name="attach_file">File</string>
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
+    <string name="attachment_load_failed">Could not attach file</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -813,6 +813,7 @@
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
     <string name="attachment_load_failed">Could not attach file</string>
+    <string name="error_video_not_supported">Video files cannot be sent directly. Remove the video and attach images instead.</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -815,6 +815,7 @@
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
     <string name="attachment_load_failed">Could not attach file</string>
+    <string name="error_video_not_supported">Video files cannot be sent directly. Remove the video and attach images instead.</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -814,6 +814,7 @@
     <string name="attach_file">File</string>
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
+    <string name="attachment_load_failed">Could not attach file</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -809,6 +809,7 @@
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
     <string name="attachment_load_failed">Could not attach file</string>
+    <string name="error_video_not_supported">Video files cannot be sent directly. Remove the video and attach images instead.</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -808,6 +808,7 @@
     <string name="attach_file">File</string>
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
+    <string name="attachment_load_failed">Could not attach file</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -810,6 +810,7 @@
     <string name="attach_file">File</string>
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
+    <string name="attachment_load_failed">Could not attach file</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -811,6 +811,7 @@
     <string name="attach_camera">Camera</string>
     <string name="attach_gallery">Gallery</string>
     <string name="attachment_load_failed">Could not attach file</string>
+    <string name="error_video_not_supported">Video files cannot be sent directly. Remove the video and attach images instead.</string>
     <string name="status_queued">Queued</string>
 
     <!-- Resume command -->

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -185,6 +185,21 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun `video block uses the injected message`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend, videoNotSupportedMessage = "custom-video-message")
+            advanceUntilIdle()
+            viewModel.addAttachment(PromptAttachment("clip.mp4", "video/mp4", "data:video/mp4;base64,AAAA"))
+
+            viewModel.sendMessage("fix this")
+            advanceUntilIdle()
+
+            assertEquals(0, backend.sentPrompts.size)
+            assertEquals("custom-video-message", viewModel.uiState.value.error)
+        }
+
+    @Test
     fun `creating a session refreshes the shell catalog`() =
         runTest(dispatcher) {
             val backend = FakeBackend()

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/ChatViewModelTest.kt
@@ -168,6 +168,23 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun `video attachment is blocked instead of failing the session`() =
+        runTest(dispatcher) {
+            val backend = FakeBackend()
+            val viewModel = ChatViewModel(backend)
+            advanceUntilIdle()
+            viewModel.addAttachment(PromptAttachment("clip.mp4", "video/mp4", "data:video/mp4;base64,AAAA"))
+
+            viewModel.sendMessage("fix this")
+            advanceUntilIdle()
+
+            assertEquals(0, backend.sentPrompts.size)
+            assertEquals(0, backend.createSessionCalls)
+            assertNotNull(viewModel.uiState.value.error)
+            assertTrue(viewModel.uiState.value.error!!.contains("Video", ignoreCase = true))
+        }
+
+    @Test
     fun `creating a session refreshes the shell catalog`() =
         runTest(dispatcher) {
             val backend = FakeBackend()

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelperTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelperTest.kt
@@ -17,6 +17,14 @@ class VideoAttachmentHelperTest {
     }
 
     @Test
+    fun `detects image mime types`() {
+        assertTrue(VideoAttachmentHelper.isImageMime("image/jpeg"))
+        assertTrue(VideoAttachmentHelper.isImageMime("IMAGE/PNG"))
+        assertFalse(VideoAttachmentHelper.isImageMime("video/mp4"))
+        assertFalse(VideoAttachmentHelper.isImageMime("application/pdf"))
+    }
+
+    @Test
     fun `frame timestamps cover beginning middle and end`() {
         val timestamps = VideoAttachmentHelper.frameTimestampsUs(9_000_000L)
         assertEquals(listOf(0L, 4_500_000L, 8_100_000L), timestamps)

--- a/app/src/test/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelperTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/runtime/local/VideoAttachmentHelperTest.kt
@@ -1,0 +1,48 @@
+package com.yugahashimoto.andcode.runtime.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoAttachmentHelperTest {
+    @Test
+    fun `detects video mime types`() {
+        assertTrue(VideoAttachmentHelper.isVideoMime("video/mp4"))
+        assertTrue(VideoAttachmentHelper.isVideoMime("video/quicktime"))
+        assertTrue(VideoAttachmentHelper.isVideoMime("VIDEO/MP4"))
+        assertFalse(VideoAttachmentHelper.isVideoMime("image/jpeg"))
+        assertFalse(VideoAttachmentHelper.isVideoMime("application/pdf"))
+        assertFalse(VideoAttachmentHelper.isVideoMime("application/octet-stream"))
+    }
+
+    @Test
+    fun `frame timestamps cover beginning middle and end`() {
+        val timestamps = VideoAttachmentHelper.frameTimestampsUs(9_000_000L)
+        assertEquals(listOf(0L, 4_500_000L, 8_100_000L), timestamps)
+    }
+
+    @Test
+    fun `unknown duration yields single zero timestamp`() {
+        assertEquals(listOf(0L), VideoAttachmentHelper.frameTimestampsUs(0L))
+        assertEquals(listOf(0L), VideoAttachmentHelper.frameTimestampsUs(-1L))
+    }
+
+    @Test
+    fun `scaled dimensions preserve aspect ratio and never upscale`() {
+        assertEquals(640 to 480, VideoAttachmentHelper.scaledDimensions(640, 480))
+        assertEquals(1280 to 720, VideoAttachmentHelper.scaledDimensions(1920, 1080))
+        assertEquals(720 to 1280, VideoAttachmentHelper.scaledDimensions(1080, 1920))
+        assertEquals(0 to 0, VideoAttachmentHelper.scaledDimensions(0, 100))
+    }
+
+    @Test
+    fun `frame filename is sanitized`() {
+        assertEquals(
+            "Screenrecorder-2026-09-09-04-26-11-78.frame-1.jpg",
+            VideoAttachmentHelper.frameFilename("Screenrecorder-2026-09-09-04-26-11-78.mp4", 1),
+        )
+        assertEquals("___.frame-0.jpg", VideoAttachmentHelper.frameFilename("!!!", 0))
+        assertEquals("video.frame-0.jpg", VideoAttachmentHelper.frameFilename("", 0))
+    }
+}


### PR DESCRIPTION
## 概要

チャットで動画ファイル（`video/mp4` 等）を添付すると、プロバイダーが `'file part media type video/mp4' functionality not supported` エラーを返し、セッション全体が失敗する問題を修正しました。

## 変更内容

- `AttachmentImporter` が動画を raw 送信していたのをやめ、`MediaMetadataRetriever` で代表3フレームを JPEG 画像として抽出して送信（`importAll()` を追加）
- 取りこぼし対策として `ChatViewModel.sendMessage` で video 添付の送信をブロック（文言は `videoNotSupportedMessage` として注入）
- 添付失敗時は沈黙せず、ローカライズ済み Toast（`attachment_load_failed`）で通知
- `error_video_not_supported` / `attachment_load_failed` を全8ロケールに追加（ja は和訳、他は英語フォールバック）
- `VideoAttachmentHelper` の単体テストと送信ガードのテストを追加

## 検証

- `:app:testGithubDebugUnitTest`（`VideoAttachmentHelperTest`、`ChatViewModelTest`）成功
- `detekt` / `spotlessCheck` 成功
- i18n キー一致を全ロケールで確認

<!-- pre-pr-review: approved -->
## Pre-PR review

判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- `AndCodeApp.kt`: `com.yugahashimoto.andcode.runtime.local.AttachmentImporter` や `VideoAttachmentHelper`、`android.util.*` を完全修飾で呼ばず `import` にまとめると可読性が上がります（動作には影響なし）。
- `values-ar/es/fr/pt-rBR/ru/zh-rCN`: `attachment_load_failed` と `error_video_not_supported` が英語のままです。i18n-check のキー存在要件は満たしますが、余力があれば他言語も翻訳すると一貫します（現状は `ja` のみ翻訳済み）。
- `AttachmentImporter.import(uri)`: 動画時は先頭1フレームのみ返す互換シムになっており、現ブランチの `uri` 経路の呼び出しは `importAll` に移行済みです。残すならそれでよいですが、不要になれば削除も検討してください。
- `AndCodeApp.kt` のプレビュー生成: JPEG デコード失敗時に `addAttachment`（プレビューなし）へフォールバックすると `attachments` と `imagePreviews` の並びがずれて別画像のプレビューが紐づく可能性があります。直前に自前でエンコードした JPEG のデコード失敗は稀なため実害はほぼありませんが、気になる場合は失敗フレームをスキップするかプレースホルダで添付順序を保つと安全です。

## チェック済み項目
- 全差分を読了（`git diff origin/main...fix-video-attachment`、15ファイル・約317行、コミット3件）。スコープは `ChatViewModel` ガード、`AttachmentImporter` の動画フレーム化、`VideoAttachmentHelper` 新設、`AndCodeApp` の複数添付・Toast対応、8ロケールの文字列2件追加、単体テスト2件。
- DI 2経路の同期を確認（`di/ViewModelModule.kt` と `ui/AndCodeApp.kt` の手書き Factory の双方で `videoNotSupportedMessage = getString(R.string.error_video_not_supported)` を渡し、`ChatViewModel` 側は英語デフォルト付き注入で `WorkspaceViewModel.incompleteConnectionMessage` の前例と一致）。
- 送信ガードの配置を確認（空送信チェック直後・backend 未設定/オフラインキュー/`forcesQueue` キューより前）。`sendQueued` は添付を復元して `sendMessage` を再呼出しするため、キュー滞留の動画も再びガードに掛かりセッション破壊に抜けないことを確認。
- リソース/リーク観点を確認（`MediaMetadataRetriever.release` を `finally`＋`runCatching`、`Bitmap` は `scaled !== frame` 時のみ個別 recycle・`frame` は外側 `finally` で必ず recycle、`openInputStream.use`）。スケール失敗・compress 失敗時も recycle 経路が残ることを確認。
- `AndCodeApp` の添付経路を確認（`withContext(Dispatchers.IO)` 内で `importAll`＋`BitmapFactory.decodeByteArray` を実行し、`onSuccess` でメインに戻って `addImageAttachment`/`addAttachment`、`onFailure` で `Log.w`（英語のまま）＋`attachment_load_failed` のローカライズ Toast を表示。旧コードの沈黙失敗を解消）。
- i18n を確認（`values`＋`ar/es/fr/ja/pt-rBR/ru/zh-rCN` の全8ファイルに `attachment_load_failed` と `error_video_not_supported` が存在。`ja` は日本語訳、それ以外は英語フォールバックでキー一致。ViewModel の既定文言は注入用英語デフォルトでハードコード規則に適合、ログは英語のまま）。
- テストを確認（`VideoAttachmentHelperTest` が mime 判定・タイムスタンプ・縦横比・ファイル名サニタイズを検証、`ChatViewModelTest` が動画ブロックと注入文言の使用を検証。振る舞い変更に対するテスト追加あり）。
