### PR TITLE
feat(fdroid): disclose that the Vosk model download bypasses F-Droid checks

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/settings/VoiceSettingsScreen.kt
@@ -993,6 +993,14 @@ private fun WakeWordModelRow(
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             }
         }
+        if (state == VoskModelState.Missing) {
+            Text(
+                text = stringResource(R.string.wake_word_model_disclosure),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
     }
 }
 

--- a/app/src/main/res/values-ja/ui_cleanup_strings.xml
+++ b/app/src/main/res/values-ja/ui_cleanup_strings.xml
@@ -77,6 +77,7 @@
     <string name="wake_word_model_language_japanese">日本語</string>
     <string name="wake_word_model_label">音声モデル</string>
     <string name="wake_word_model_not_downloaded">未ダウンロード（約%1$d MB）</string>
+    <string name="wake_word_model_disclosure">下の「ダウンロード」をタップした場合のみ、alphacephei.comから直接取得されます。これはF-Droidのビルド・ソース検査の対象外です。</string>
     <string name="wake_word_model_downloading">ダウンロード中…</string>
     <string name="wake_word_model_downloading_percent">ダウンロード中… %1$d%%</string>
     <string name="wake_word_model_extracting">展開中…</string>

--- a/app/src/main/res/values/ui_cleanup_strings.xml
+++ b/app/src/main/res/values/ui_cleanup_strings.xml
@@ -77,6 +77,7 @@
     <string name="wake_word_model_language_japanese">Japanese</string>
     <string name="wake_word_model_label">Speech model</string>
     <string name="wake_word_model_not_downloaded">Not downloaded (about %1$d MB)</string>
+    <string name="wake_word_model_disclosure">Downloaded directly from alphacephei.com only if you tap Download below — this happens outside F-Droid\'s build and source checks.</string>
     <string name="wake_word_model_downloading">Downloading…</string>
     <string name="wake_word_model_downloading_percent">Downloading… %1$d%%</string>
     <string name="wake_word_model_extracting">Unpacking…</string>

--- a/app/src/test/java/com/yugahashimoto/andcode/compliance/LegalDisclosureComplianceTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/compliance/LegalDisclosureComplianceTest.kt
@@ -172,6 +172,24 @@ class LegalDisclosureComplianceTest {
     }
 
     @Test
+    fun `Vosk model download discloses that it bypasses F-Droid's build and source checks`() {
+        listOf(
+            "app/src/main/res/values/ui_cleanup_strings.xml" to listOf("F-Droid", "alphacephei.com"),
+            "app/src/main/res/values-ja/ui_cleanup_strings.xml" to listOf("F-Droid", "alphacephei.com"),
+        ).forEach { (path, mustContain) ->
+            val text = readRepoFile(path)
+            assertTrue(
+                "$path should define wake_word_model_disclosure",
+                text.contains("name=\"wake_word_model_disclosure\""),
+            )
+            val disclosure = text.substringAfter("name=\"wake_word_model_disclosure\">").substringBefore("</string>")
+            mustContain.forEach { term ->
+                assertTrue("$path's wake_word_model_disclosure should mention $term", disclosure.contains(term))
+            }
+        }
+    }
+
+    @Test
     fun `no wake-word model files are bundled in the APK`() {
         // The previous openWakeWord models were CC BY-NC-SA 4.0 - a NonCommercial license this
         // project could not clear for downstream distribution. Nothing may quietly reappear under

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -119,57 +119,72 @@ of flavor, so leaving them applied would still embed inert Google project
 identifiers in the fdroid build).
 
 Submitting to the official catalog means opening a merge request against
-[fdroiddata](https://gitlab.com/fdroid/fdroiddata) with metadata resembling:
+[fdroiddata](https://gitlab.com/fdroid/fdroiddata). This has been done:
+[!48005](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/48005). Current
+metadata, after review feedback from F-Droid maintainers:
 
 ```yaml
 Categories:
   - AI Chat
 License: MIT
+AuthorName: Yu-ga
 RepoType: git
 Repo: https://github.com/yuga-hashimoto/and-code
 SourceCode: https://github.com/yuga-hashimoto/and-code
 IssueTracker: https://github.com/yuga-hashimoto/and-code/issues
 Changelog: https://github.com/yuga-hashimoto/and-code/releases
 
+AntiFeatures:
+  NonFreeNet: optional GitHub OAuth sign-in, not required for core functionality
+  TetheredNet: the on-demand Vosk wake-word speech model is only ever fetched from alphacephei.com
+
 Builds:
-  - versionName: "1.2.16"
-    versionCode: 55
-    commit: v1.2.16
+  - versionName: "1.2.17"
+    versionCode: 56
+    commit: 6551a03a6c37772d3610b0fd4caad4b8d51365ae
     subdir: app
     gradle:
       - fdroid
     gradleprops:
       - andcode.fdroidBuild=true
-    # google-services/firebase-crashlytics still appear (apply false) in both
-    # build.gradle.kts files; allowlist those known-safe lines rather than
-    # have the scanner flag them.
-    scanignore:
-      - build.gradle.kts
-      - app/build.gradle.kts
+    # The google-services/firebase-crashlytics Gradle plugins are declared with
+    # `apply false` in both build.gradle.kts files (needed by the "github" flavor;
+    # never applied for this fdroid build, see `andcode.fdroidBuild` above), but the
+    # source scanner still flags the bare "apply false" declaration lines. Strip
+    # just those lines instead of scanignoring the whole files.
+    prebuild:
+      - sed -i '/id("com.google.gms.google-services").*apply false/d' ../build.gradle.kts
+      - sed -i '/id("com.google.firebase.crashlytics").*apply false/d' ../build.gradle.kts
+      - sed -i '/id("com.google.gms.google-services").*apply false/d' build.gradle.kts
+      - sed -i '/id("com.google.firebase.crashlytics").*apply false/d' build.gradle.kts
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: "1.2.16"
-CurrentVersionCode: 55
+CurrentVersion: "1.2.17"
+CurrentVersionCode: 56
 ```
 
-This recipe was dry-run locally with `fdroid build --test` (pip-installed
-`fdroidserver`, no Docker/buildserver VM available) against this repo's actual
-`fdroid` flavor and confirmed to work end-to-end: clone at a pinned commit,
-`clean`, source scan, and `assembleFdroidRelease` all succeeded, producing an
-APK whose embedded versionName/versionCode matched the metadata. Both
-`Repo`/`RepoType` and the two-line `scanignore` above were only discovered as
-necessary through that dry run (without them, the build never even reaches the
-Gradle step). It has not been submitted as a merge request yet — remaining
-before that:
+This recipe was dry-run locally: after a fresh checkout at the pinned commit
+with the two `prebuild` sed lines applied to each file by hand,
+`./gradlew -Pandcode.fdroidBuild=true :app:assembleFdroidRelease` still built
+successfully end-to-end. `AntiFeatures` is a map with a reason per entry
+(the initial submission used a plain list), and `commit:` is the resolved
+full SHA rather than the tag name — both per review feedback.
 
-- decide whether any remaining dependency (e.g. the Vosk speech model,
-  downloaded on first use from alphacephei.com rather than bundled — the
-  models themselves are Apache-2.0, so this is likely not an `AntiFeature`,
-  but F-Droid reviewers may still ask about it) needs an `AntiFeature` tag
-- decide how to describe the GitHub OAuth sign-in dependency, since GitHub
-  itself is a non-free network service (used for optional sign-in, not core
-  functionality, so likely not `NonFreeNet`, but again a reviewer question)
-- a real dry run against F-Droid's actual buildserver (`fdroid build --test
-  --server`), which needs the Debian/Docker buildserver image this sandbox
-  does not have
+Review also asked whether the Vosk model download is opt-in and discloses
+that it bypasses F-Droid's build/source checks. Checked the app source: the
+download was already gated behind an explicit "Download" button in Settings
+(never auto-triggered by the wake-word toggle), so declining was already no
+harder than accepting. The missing piece — an in-app disclosure of the
+bypass — has been written (visible text next to the Download button, plus a
+regression test in `LegalDisclosureComplianceTest`), but **is not yet in a
+tagged release**, so the merge request's `Builds:` entry above still points
+at v1.2.17, which predates the fix. The MR's `Builds:` entry needs updating
+to a new release once this lands and is tagged.
+
+The fork's own CI (`soccer.hy620/fdroiddata`) is separately blocked: GitLab's
+GraphQL API reports every pipeline run failing with
+`"The pipeline failed due to the user not being verified."` — an
+account-level verification gate on shared-runner minutes, unrelated to the
+recipe itself. That needs clearing on the GitLab account before the fork's
+own pipeline can go green (does not block F-Droid's own review process).


### PR DESCRIPTION
## Summary
- F-Droid reviewers on the official-catalog submission ([fdroiddata!48005](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/48005)) asked for an in-app disclosure that the on-demand Vosk wake-word model download happens outside F-Droid's build/source checks.
- The download was already gated behind an explicit "Download" button (never auto-triggered by the wake-word toggle), so declining was already no harder than accepting — this PR adds the missing disclosure text (EN + JA) next to the Download button, plus a regression test.
- Updates `docs/RELEASE.md` to reflect the submitted MR and its updated recipe (AntiFeatures as a map with reasons, AuthorName, full commit hash, prebuild sed instead of a blanket scanignore).

## Test plan
- [x] `./gradlew :app:testGithubDebugUnitTest --tests com.yugahashimoto.andcode.compliance.LegalDisclosureComplianceTest` passes
- [x] `./gradlew -Pandcode.fdroidBuild=true :app:assembleFdroidRelease` builds successfully
- [ ] Manual check: Settings → Voice → speech model row shows the new disclosure text when not yet downloaded (EN + JA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)