### PR TITLE
fix(chat): keep LazyColumn keys unique when a transcript repeats a user message id

### DIFF
--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -4,26 +4,34 @@ package com.yugahashimoto.andcode.feature.chat
  * A single row of the chat timeline: a user bubble, assistant body text, or a collapsed run of
  * reasoning/tool/patch parts that the user can expand to inspect.
  *
- * Ids are namespaced by kind so they stay unique as `LazyColumn` keys across the whole transcript.
+ * Ids are namespaced by kind so they stay unique as `LazyColumn` keys across the whole transcript;
+ * [groupConversationTimeline] additionally suffixes any id the transcript repeats, so a stored
+ * transcript that contains the same id twice can never crash the list.
  */
 sealed interface TimelineEntry {
     val id: String
 
-    data class UserMessage(val message: ChatMessage) : TimelineEntry {
-        override val id: String get() = "user:${message.id}"
-    }
+    data class UserMessage(
+        override val id: String,
+        val message: ChatMessage,
+    ) : TimelineEntry
 
-    data class Body(val messageId: String, val part: ChatPart.Text) : TimelineEntry {
-        override val id: String get() = "body:${part.id}"
-    }
+    data class Body(
+        override val id: String,
+        val messageId: String,
+        val part: ChatPart.Text,
+    ) : TimelineEntry
 
-    data class Image(val messageId: String, val part: ChatPart.Image) : TimelineEntry {
-        override val id: String get() = "image:${part.id}"
-    }
+    data class Image(
+        override val id: String,
+        val messageId: String,
+        val part: ChatPart.Image,
+    ) : TimelineEntry
 
-    data class Error(val part: ChatPart.Error) : TimelineEntry {
-        override val id: String get() = "error:${part.id}"
-    }
+    data class Error(
+        override val id: String,
+        val part: ChatPart.Error,
+    ) : TimelineEntry
 
     data class Activity(override val id: String, val parts: List<ChatPart>) : TimelineEntry
 
@@ -126,7 +134,7 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
             flush()
             flushTurnFooter()
             lastUserAt = message.timestamp
-            entries += TimelineEntry.UserMessage(message)
+            entries += TimelineEntry.UserMessage("user:${message.id}", message)
             return@forEach
         }
         if (turnStartAt == null) turnStartAt = message.timestamp
@@ -150,18 +158,18 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
                 }
                 part is ChatPart.Image -> {
                     flush()
-                    entries += TimelineEntry.Image(message.id, part)
+                    entries += TimelineEntry.Image("image:${part.id}", message.id, part)
                 }
                 part is ChatPart.Error -> {
                     flush()
                     // Footer must trail the error card the way it trails a body text entry.
-                    entries += TimelineEntry.Error(part)
+                    entries += TimelineEntry.Error("error:${part.id}", part)
                     flushTurnFooter()
                 }
                 part !is ChatPart.Text -> pending += part
                 part.text.isNotBlank() -> {
                     flush()
-                    entries += TimelineEntry.Body(message.id, part)
+                    entries += TimelineEntry.Body("body:${part.id}", message.id, part)
                 }
                 else -> Unit
             }
@@ -169,8 +177,37 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
     }
     flush()
     flushTurnFooter()
-    return entries
+    return entries.withUniqueIds()
 }
+
+/**
+ * Suffixes any id the transcript repeats so `LazyColumn` keys stay unique.
+ *
+ * The first occurrence keeps its bare id; each later one gains `:<occurrence>`, matching the
+ * scheme the activity and todo groups already use. This repairs transcripts that already store
+ * duplicate ids: a turn killed between persisting the user message and advancing the runtime's
+ * step counter replays the same user-message id on the next send (see [TimelineEntry.UserMessage]),
+ * and two rows sharing one key crashed the chat the moment it was opened.
+ */
+private fun List<TimelineEntry>.withUniqueIds(): List<TimelineEntry> {
+    val seen = mutableMapOf<String, Int>()
+    return map { entry ->
+        val occurrence = seen[entry.id] ?: 0
+        seen[entry.id] = occurrence + 1
+        if (occurrence == 0) entry else entry.repeated(occurrence)
+    }
+}
+
+private fun TimelineEntry.repeated(occurrence: Int): TimelineEntry =
+    when (this) {
+        is TimelineEntry.UserMessage -> copy(id = "$id:$occurrence")
+        is TimelineEntry.Body -> copy(id = "$id:$occurrence")
+        is TimelineEntry.Image -> copy(id = "$id:$occurrence")
+        is TimelineEntry.Error -> copy(id = "$id:$occurrence")
+        is TimelineEntry.Activity -> copy(id = "$id:$occurrence")
+        is TimelineEntry.Todo -> copy(id = "$id:$occurrence")
+        is TimelineEntry.Footer -> copy(id = "$id:$occurrence")
+    }
 
 /**
  * Re-resolves an activity group by id against the current messages.

--- a/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroup.kt
@@ -187,7 +187,8 @@ fun groupConversationTimeline(messages: List<ChatMessage>): List<TimelineEntry> 
  * scheme the activity and todo groups already use. This repairs transcripts that already store
  * duplicate ids: a turn killed between persisting the user message and advancing the runtime's
  * step counter replays the same user-message id on the next send (see [TimelineEntry.UserMessage]),
- * and two rows sharing one key crashed the chat the moment it was opened.
+ * and two rows sharing one key crashed the chat the moment it was opened. (Only an original id
+ * that itself ends in `:<n>` and repeats could still collide — no runtime produces that shape.)
  */
 private fun List<TimelineEntry>.withUniqueIds(): List<TimelineEntry> {
     val seen = mutableMapOf<String, Int>()

--- a/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
+++ b/app/src/main/java/com/yugahashimoto/andcode/runtime/local/AntigravityRuntime.kt
@@ -233,7 +233,12 @@ class AntigravityRuntime(
                     val parser = AntigravityStreamJsonParser(sessionId, json)
                     val record0 = records[sessionId] ?: AntigravitySessionRecord(sessionId, null, workspace)
                     val turnNow = System.currentTimeMillis()
-                    val userId = "$sessionId-user-${record0.lastStep}"
+                    // The turn's wall clock keeps the id unique per send: lastStep only advances
+                    // once the turn finishes (below), so a death in between - the app being killed
+                    // mid-turn, a read error on the stream - would replay the same id on the next
+                    // send. Two user rows sharing one id then crashed the chat's LazyColumn the
+                    // moment that conversation was opened (issue #311).
+                    val userId = "$sessionId-user-${record0.lastStep}-$turnNow"
                     // Persist the user turn before the stream starts. The chat redraws from
                     // listMessages the moment it sees SessionIdle, and the composer's optimistic
                     // bubble is replaced by that snapshot - so a user turn that only lands at the

--- a/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
+++ b/app/src/test/java/com/yugahashimoto/andcode/feature/chat/AssistantActivityGroupTest.kt
@@ -392,6 +392,24 @@ class AssistantActivityGroupTest {
     }
 
     @Test
+    fun `duplicate user message ids still get unique entry ids`() {
+        // Antigravity persists the user turn before its step counter advances; a send killed in
+        // between (app killed mid-turn, stream read error) replays the same message id on the next
+        // send. Two rows sharing one LazyColumn key crashed the chat the moment it was opened.
+        val duplicated =
+            listOf(
+                ChatMessage(id = "s-user-2", isUser = true, parts = listOf(ChatPart.Text("u1", "first try"))),
+                ChatMessage(id = "s-user-2", isUser = true, parts = listOf(ChatPart.Text("u2", "second try"))),
+            )
+
+        val entries = groupConversationTimeline(duplicated)
+
+        assertEquals(listOf("user:s-user-2", "user:s-user-2:1"), entries.map { it.id })
+        assertEquals("first try", (entries[0] as TimelineEntry.UserMessage).message.text)
+        assertEquals("second try", (entries[1] as TimelineEntry.UserMessage).message.text)
+    }
+
+    @Test
     fun `blank reasoning parts are excluded from activity`() {
         // Blank reasoning carries nothing to expand; it must not produce a "Thinking" card.
         val entries =


### PR DESCRIPTION
Closes #311

## Problem

Entering one specific chat crashed the app (`IllegalArgumentException: Key "user:..." was already used`). Root cause: `AntigravityRuntime.send` persisted the user turn with id `<sessionId>-user-<lastStep>` *before* the turn ran, but only advanced `lastStep` after the turn finished. A send killed in between (app killed mid-turn, stream read error) left the counter stale, so the next send in that chat persisted a second user message with the same id — and `items(timelineEntries, key = { it.id })` threw on the duplicate key, bricking exactly that conversation.

## Fix (two layers)

1. **Root cause** — `AntigravityRuntime.send` now appends the turn's wall clock to the user message id (`$sessionId-user-$lastStep-$turnNow`), making it unique per send even when the counter is stale.
2. **Repair for already-corrupted transcripts** — `groupConversationTimeline` suffixes any repeated entry id (first occurrence keeps the bare id, matching the existing activity/todo occurrence scheme), so a stored transcript that already contains duplicates opens normally again. `TimelineEntry` rows now carry an explicit id so the repair pass can rewrite it.

## Testing

- New unit test: `duplicate user message ids still get unique entry ids`
- `./gradlew :app:testGithubDebugUnitTest` — BUILD SUCCESSFUL
- `./gradlew detekt spotlessCheck` — BUILD SUCCESSFUL

Note for reviewers: the second commit (`docs(chat)`) applies the reviewer's own non-blocking KDoc suggestion after the approved review; content is unchanged apart from that comment sentence.

<!-- pre-pr-review: approved -->
## Pre-PR review

```
判定: APPROVE

## ブロッカー
- なし

## 提案（非ブロッキング）
- AssistantActivityGroup.kt:192-210 — `withUniqueIds` の接尾辞は「生id + `:1`」を生成するため、元のメッセージid自体が `xxx:1` という文字列で、かつ同一idが重複している場合のみ理論上キー衝突が残る。実idsは `$sessionId-user-…` / `$sessionId…` 形式で現実に到達不能なので対応不要だが、KDocに一句添えるなら保守性が上がる。
- AntigravityRuntime.kt:241 — ランタイム側のid一意化にはユニットテストが無い（既存テストも `send` のid形式を直接検証していないため壊れないことは確認済み）。プロセス起動をモックするコストが高いため現行の表示層テストでの担保は妥当だが、将来 `AntigravityStreamJsonParserTest` と同じ粒度でid生成だけを抽出できると検証可能になる。

## チェック済み項目
- `git diff origin/main...HEAD` の全3ファイル（+79/−19）を全ハンク読了。コミットは1件で、`scripts/new-worktree.sh` 由来のワークツリー／ブランチ規約に合致。
- `TimelineEntry` の全 construction サイトを grep で列挙（`AssistantActivityGroup.kt` の4箇所のみ）。位置引数で構築する呼び出し側は存在せず、コンストラクタシグネチャ変更（id を明示化）の破壊なし。消費側（`ChatHomeScreen.kt:419-437`、`ChatMessageComponents.kt:170-180`、`ChatViewModel`）はプロパティ読み取りのみで互換。
- id 形式の後方互換性を確認: 重複しない限り `user:` / `body:` / `image:` / `error:` 接頭辞付きの生idを維持するため、既存トランスクリプトのキーは不変。Activity/Todo は既存の `firstIdOccurrences` / `todoIdOccurrences` で一意化済みのため `withUniqueIds` は再接尾辞しない → `dismissedTodoBarId` の一致（ChatHomeScreen.kt:531、ChatViewModel.kt:476）と `findActivityParts` のグループid照合（AssistantActivityGroup.kt:219-227）は影響なし。
- `repeated()` が sealed interface の全7サブタイプを網羅（将来のサブタイプ追加はコンパイルエラーで検知可能）。
- ランタイム変更の影響範囲を確認: `lastStep` は `AntigravityRuntime` 内でのみ使用され、idをパースする箇所は皆無。`mergeReloadedMessages`（ChatViewModel.kt:123-176）の楽観バブル合流は id→テキスト の順で照合するためid形式変更の影響なし。`turnNow` 自体は既存の変数で、タイムスタンプ挙動は不変。
- クラッシュ箇所の特定: `ChatHomeScreen.kt:419` の `items(timelineEntries, key = { it.id })` が唯一のキー付きタイムライン LazyColumn で、修正により重複トランスクリプトでもキーが一意になることを新規テスト（`duplicate user message ids still get unique entry ids`）が検証。既存テストが旧id形式 `"$sessionId-user-<n>"` を直接アサートしていないことを確認（テスト更新不要と判断）。
- i18n: UI文字列・strings.xml への変更なし（8ロケールへの影響なし）。コメントは英語で repo 規約どおり。シークレット・ビルド設定へのタッチなし。
- 注記: 実行制限により `./gradlew detekt spotlessCheck test` は未実行。差分は周辺コードと同一のスタイル（ktlint 1.2.1 準拠の見た目）だが、PR前にローカルCIゲートの実走を推奨。
```

(Reviewer's non-blocking KDoc suggestion was applied in commit `docs(chat): note the theoretical colon-suffix key collision in withUniqueIds`; the recommended local gates `detekt`/`spotlessCheck` and the full `testGithubDebugUnitTest` were run locally and passed after the review.)